### PR TITLE
feat: support rbgs scaling

### DIFF
--- a/api/workloads/v1alpha1/constant.go
+++ b/api/workloads/v1alpha1/constant.go
@@ -2,26 +2,32 @@ package v1alpha1
 
 const (
 	ControllerName = "rolebasedgroup-controller"
-	// Domain prefix for all labels/annotations to avoid conflicts
-	RBGDomainPrefix = "rolebasedgroup.workloads.x-k8s.io/"
+
+	// RBGPrefix Domain prefix for all labels/annotations to avoid conflicts
+	RBGPrefix = "rolebasedgroup.workloads.x-k8s.io/"
 
 	// SetNameLabelKey identifies resources belonging to a specific RoleBasedGroup
 	// Value: RoleBasedGroup.metadata.name
-	SetNameLabelKey = RBGDomainPrefix + "name"
+	SetNameLabelKey = RBGPrefix + "name"
 
 	// SetRoleLabelKey identifies resources belonging to a specific role
 	// Value: RoleSpec.name from RoleBasedGroup.spec.roles[]
-	SetRoleLabelKey = RBGDomainPrefix + "role"
+	SetRoleLabelKey = RBGPrefix + "role"
 
 	// PodGroupLabelKey identifies pods belonging to a specific pod group
 	// Value: RoleBasedName
 	PodGroupLabelKey = "pod-group.scheduling.sigs.k8s.io/name"
 
-	// RevisionAnnotationKey tracks the controller revision hash for template changes
-	// Value: SHA256 hash of RoleSpec template
-	RevisionAnnotationKey = RBGDomainPrefix + "revision"
+	RoleSizeAnnotationKey string = RBGPrefix + "role-size"
 
-	RoleSizeAnnotationKey string = RBGDomainPrefix + "role-size"
+	// RBGSetPrefix rbgs prefix for all rbgs
+	RBGSetPrefix = "rolebasedgroupset.workloads.x-k8s.io/"
+
+	// SetRBGSetNameLabelKey identifies resources belonging to a specific RoleBasedGroupSet
+	SetRBGSetNameLabelKey = RBGSetPrefix + "name"
+
+	// SetRBGIndexLabelKey SetRBGIndex identifies the index of the rbg within the rbgset
+	SetRBGIndexLabelKey = RBGSetPrefix + "rbg-index"
 )
 
 type RolloutStrategyType string

--- a/api/workloads/v1alpha1/rolebasedgroupset_types.go
+++ b/api/workloads/v1alpha1/rolebasedgroupset_types.go
@@ -20,9 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TODO 参考deployment优化rbgs
-// ref: https://github.com/kubernetes/kubernetes/blob/83bb5d570580a3f477737fec5c24ba8fc3554264/staging/src/k8s.io/api/apps/v1/types.go
-
 // RoleBasedGroupSetSpec defines the desired state of RoleBasedGroupSet.
 type RoleBasedGroupSetSpec struct {
 	// Replicas is the number of RoleBasedGroup that will be created.
@@ -33,6 +30,12 @@ type RoleBasedGroupSetSpec struct {
 	Template RoleBasedGroupSpec `json:"template"`
 }
 
+type RoleBasedGroupSetConditionType string
+
+const (
+	RoleBasedGroupSetReady RoleBasedGroupSetConditionType = "Ready"
+)
+
 // RoleBasedGroupSetStatus defines the observed state of RoleBasedGroupSet.
 type RoleBasedGroupSetStatus struct {
 	// The generation observed by the deployment controller.
@@ -42,6 +45,9 @@ type RoleBasedGroupSetStatus struct {
 	// +optional
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,2,opt,name=replicas"`
 
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas" protobuf:"varint,3,opt,name=readyReplicas"`
+
 	// Conditions track the condition of the rbgs
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -50,7 +56,9 @@ type RoleBasedGroupSetStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:printcolumn:name="DESIRED",type="string",JSONPath=".status.replicas",description="desired replicas"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.readyReplicas",description="ready replicas"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName={rbgs}
 

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -17,7 +17,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+    - description: desired replicas
+      jsonPath: .status.replicas
+      name: DESIRED
+      type: string
+    - description: ready replicas
+      jsonPath: .status.readyReplicas
       name: READY
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -8768,6 +8773,9 @@ spec:
                 description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
+              readyReplicas:
+                format: int32
+                type: integer
               replicas:
                 format: int32
                 type: integer
@@ -8776,4 +8784,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -17,7 +17,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+    - description: desired replicas
+      jsonPath: .status.replicas
+      name: DESIRED
+      type: string
+    - description: ready replicas
+      jsonPath: .status.readyReplicas
       name: READY
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -8768,6 +8773,9 @@ spec:
                 description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
+              readyReplicas:
+                format: int32
+                type: integer
               replicas:
                 format: int32
                 type: integer
@@ -8776,4 +8784,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/deploy/helm/rbgs/templates/clusterrole.yaml
+++ b/deploy/helm/rbgs/templates/clusterrole.yaml
@@ -15,7 +15,6 @@ rules:
       - workloads.x-k8s.io
     resources:
       - rolebasedgroupsets
-      - rolebasedgroups
       - clusterengineruntimeprofiles
     verbs:
       - get
@@ -27,6 +26,7 @@ rules:
       - workloads.x-k8s.io
     resources:
       - rolebasedgroupscalingadapters
+      - rolebasedgroups
     verbs:
       - get
       - list

--- a/examples/rbgs/rbgs-base.yaml
+++ b/examples/rbgs/rbgs-base.yaml
@@ -1,0 +1,31 @@
+apiVersion: workloads.x-k8s.io/v1alpha1
+kind: RoleBasedGroupSet
+metadata:
+  name: rbgs-test
+spec:
+  replicas: 2
+  template:
+    roles:
+      - name: role-1
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - name: nginx-leader
+                image: anolis-registry.cn-zhangjiakou.cr.aliyuncs.com/openanolis/nginx:1.14.1-8.6
+                ports:
+                  - containerPort: 80
+      - name: role-2
+        replicas: 2
+        workload:
+          apiVersion: apps/v1
+          kind: Deployment
+        template:
+          spec:
+            containers:
+              - name: nginx-worker
+                image: anolis-registry.cn-zhangjiakou.cr.aliyuncs.com/openanolis/nginx:1.14.1-8.6
+                ports:
+                  - containerPort: 8080
+
+

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.38.0
 	k8s.io/api v0.33.1
@@ -56,6 +57,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/internal/controller/workloads/rolebasedgroupset_controller.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller.go
@@ -19,12 +19,16 @@ package workloads
 import (
 	"context"
 	"fmt"
-	"sync"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
+	"k8s.io/client-go/util/retry"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -32,10 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
 	"sigs.k8s.io/rbgs/pkg/utils"
-)
-
-const (
-	RoleBasedGroupSetKey = "workload-rbgs-name"
+	"strconv"
+	"sync"
 )
 
 // RoleBasedGroupSetReconciler reconciles a RoleBasedGroupSet object
@@ -59,73 +61,257 @@ func NewRoleBasedGroupSetReconciler(mgr ctrl.Manager) *RoleBasedGroupSetReconcil
 // +kubebuilder:rbac:groups=workloads.x-k8s.io,resources=rolebasedgroupsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=workloads.x-k8s.io,resources=rolebasedgroupsets/finalizers,verbs=update
 
+// Reconcile is the main reconciliation logic for RoleBasedGroupSet
 func (r *RoleBasedGroupSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Fetch the RoleBasedGroup instance
+	logger := log.FromContext(ctx).WithValues("rbgset", req.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, logger)
+	logger.Info("Start to reconcile rbgset")
+
+	// 1. Fetch the RoleBasedGroupSet instance.
 	rbgset := &workloadsv1alpha1.RoleBasedGroupSet{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, rbgset); err != nil {
+	if err := r.client.Get(ctx, req.NamespacedName, rbgset); err != nil {
+		// Ignore not-found errors, which can happen after an object has been deleted.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger := log.FromContext(ctx).WithValues("rbgset", klog.KObj(rbgset))
-	ctx = ctrl.LoggerInto(ctx, logger)
-	logger.Info("Start reconciling")
-
-	var rbglist workloadsv1alpha1.RoleBasedGroupList
-	opts := []client.ListOption{
-		client.InNamespace(rbgset.Namespace),
-		client.MatchingLabels{RoleBasedGroupSetKey: rbgset.Name},
-	}
-	err := r.client.List(ctx, &rbglist, opts...)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if len(rbglist.Items) >= int(*rbgset.Spec.Replicas) {
-		// TODO update
+	if !rbgset.ObjectMeta.DeletionTimestamp.IsZero() {
+		logger.Info("rbgset is deleting, skip reconcile")
 		return ctrl.Result{}, nil
 	}
 
-	createNum := int(*rbgset.Spec.Replicas) - len(rbglist.Items)
-	// create rbg
-	var wg sync.WaitGroup
-
-	for i := 1; i <= createNum; i++ {
-		wg.Add(1)
-		go func() {
-			err := r.createRBG(ctx, rbgset, &wg)
-			if err != nil {
-				logger.Error(err, "create rbg failed.")
-			}
-		}()
+	// 2. List all child RoleBasedGroup instances currently associated with this RoleBasedGroupSet.
+	var rbglist workloadsv1alpha1.RoleBasedGroupList
+	selector, _ := labels.Parse(fmt.Sprintf("%s=%s", workloadsv1alpha1.SetRBGSetNameLabelKey, rbgset.Name))
+	if err := r.client.List(ctx, &rbglist, client.InNamespace(rbgset.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		logger.Error(err, "Failed to list child RoleBasedGroups")
+		return ctrl.Result{}, err
 	}
-	wg.Wait()
 
+	// 3. Calculate the difference between the desired state and the current state to determine which RBGs to create or delete.
+	// Map existing RBGs by their index label for efficient lookup.
+	existingRBGs := make(map[int]*workloadsv1alpha1.RoleBasedGroup)
+	var rbgsToDelete []*workloadsv1alpha1.RoleBasedGroup
+	for i := range rbglist.Items {
+		rbg := &rbglist.Items[i]
+		indexStr, ok := rbg.Labels[workloadsv1alpha1.SetRBGIndexLabelKey]
+		if !ok {
+			logger.Info("Found RoleBasedGroup with missing index label, marking for deletion", "rbgName", rbg.Name)
+			rbgsToDelete = append(rbgsToDelete, rbg)
+			continue
+		}
+		index, err := strconv.Atoi(indexStr)
+		if err != nil {
+			logger.Error(err, "Failed to parse index label for RoleBasedGroup, marking for deletion", "rbgName", rbg.Name)
+			rbgsToDelete = append(rbgsToDelete, rbg)
+			continue
+		}
+		existingRBGs[index] = rbg
+	}
+
+	desiredReplicas := int(*rbgset.Spec.Replicas)
+	var rbgsToCreate []*workloadsv1alpha1.RoleBasedGroup
+
+	// Determine which RBGs need to be created.
+	for i := 0; i < desiredReplicas; i++ {
+		if _, exists := existingRBGs[i]; !exists {
+			rbg := newRBGForSet(rbgset, i)
+			rbgsToCreate = append(rbgsToCreate, rbg)
+		}
+	}
+
+	// Determine which RBGs need to be deleted (e.g., index is out of bounds of desired replicas).
+	for index, rbg := range existingRBGs {
+		if index >= desiredReplicas {
+			rbgsToDelete = append(rbgsToDelete, rbg)
+		}
+	}
+
+	// 4. Perform scaling operations.
+	if len(rbgsToCreate) > 0 {
+		logger.Info(fmt.Sprintf("Scaling up RoleBasedGroups, %d -> %d", len(existingRBGs), desiredReplicas), "count", len(rbgsToCreate))
+		if err := r.scaleUp(ctx, rbgset, rbgsToCreate); err != nil {
+			logger.Error(err, "Failed to scale up")
+			// Returning an error will trigger a requeue.
+			return ctrl.Result{}, err
+		}
+	}
+
+	if len(rbgsToDelete) > 0 {
+		logger.Info(fmt.Sprintf("Scaling down RoleBasedGroups, %d -> %d", len(existingRBGs), desiredReplicas), "count", len(rbgsToDelete))
+		if err := r.scaleDown(ctx, rbgsToDelete); err != nil {
+			logger.Error(err, "Failed to scale down")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// 5. Update the status after all operations are complete.
+	// After scaling, re-list the children to ensure the status is accurate.
+	if err := r.client.List(ctx, &rbglist, client.InNamespace(rbgset.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		logger.Error(err, "Failed to re-list child RoleBasedGroups for status update")
+		return ctrl.Result{}, err
+	}
+	if err := r.updateStatus(ctx, rbgset, &rbglist); err != nil {
+		logger.Error(err, "Failed to update RoleBasedGroupSet status")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Successfully reconciled rbgset")
 	return ctrl.Result{}, nil
 }
 
-func (r *RoleBasedGroupSetReconciler) createRBG(
-	ctx context.Context,
-	rbgset *workloadsv1alpha1.RoleBasedGroupSet,
-	wg *sync.WaitGroup) error {
-	defer wg.Done()
-	rbg := workloadsv1alpha1.RoleBasedGroup{}
-	rbg.Namespace = rbgset.Namespace
-	rbg.GenerateName = fmt.Sprintf("%s-", rbgset.Name)
-	rbg.Labels = map[string]string{
-		RoleBasedGroupSetKey: rbgset.Name,
+// scaleUp concurrently creates a given set of RoleBasedGroup instances.
+func (r *RoleBasedGroupSetReconciler) scaleUp(ctx context.Context, rbgset *workloadsv1alpha1.RoleBasedGroupSet, rbgsToCreate []*workloadsv1alpha1.RoleBasedGroup) error {
+	logger := log.FromContext(ctx)
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(rbgsToCreate))
+
+	for _, rbg := range rbgsToCreate {
+		wg.Add(1)
+		go func(rbgToCreate *workloadsv1alpha1.RoleBasedGroup) {
+			defer wg.Done()
+
+			// Set the owner reference.
+			if err := controllerutil.SetControllerReference(rbgset, rbgToCreate, r.scheme); err != nil {
+				errChan <- fmt.Errorf("failed to set controller reference for rbg %s: %w", rbgToCreate.Name, err)
+				return
+			}
+
+			if err := r.client.Create(ctx, rbgToCreate); err != nil {
+				// If it already exists, ignore the error. This ensures idempotency,
+				// e.g., if the previous reconcile was interrupted after a successful creation.
+				if !apierrors.IsAlreadyExists(err) {
+					errChan <- fmt.Errorf("failed to create RoleBasedGroup %s: %w", rbgToCreate.Name, err)
+				}
+			} else {
+				logger.Info("Successfully created RoleBasedGroup", "name", rbgToCreate.Name)
+			}
+		}(rbg)
 	}
 
-	if err := controllerutil.SetControllerReference(rbgset, &rbg, r.scheme); err != nil {
+	wg.Wait()
+	close(errChan)
+
+	// Aggregate all concurrent errors.
+	var allErrs []error
+	for err := range errChan {
+		allErrs = append(allErrs, err)
+	}
+	return utilerrors.NewAggregate(allErrs)
+}
+
+// scaleDown concurrently deletes a given set of RoleBasedGroup instances.
+func (r *RoleBasedGroupSetReconciler) scaleDown(ctx context.Context, rbgsToDelete []*workloadsv1alpha1.RoleBasedGroup) error {
+	logger := log.FromContext(ctx)
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(rbgsToDelete))
+
+	for _, rbg := range rbgsToDelete {
+		wg.Add(1)
+		go func(rbgToDelete *workloadsv1alpha1.RoleBasedGroup) {
+			defer wg.Done()
+
+			if err := r.client.Delete(ctx, rbgToDelete); err != nil {
+				// If the resource is not found, it's considered a success, ensuring idempotency.
+				if !apierrors.IsNotFound(err) {
+					errChan <- fmt.Errorf("failed to delete RoleBasedGroup %s: %w", rbgToDelete.Name, err)
+				}
+			} else {
+				logger.Info("Successfully deleted RoleBasedGroup", "name", rbgToDelete.Name)
+			}
+		}(rbg)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	var allErrs []error
+	for err := range errChan {
+		allErrs = append(allErrs, err)
+	}
+	return utilerrors.NewAggregate(allErrs)
+}
+
+// updateStatus updates the status of the RoleBasedGroupSet.
+func (r *RoleBasedGroupSetReconciler) updateStatus(ctx context.Context, rbgset *workloadsv1alpha1.RoleBasedGroupSet, rbglist *workloadsv1alpha1.RoleBasedGroupList) error {
+	logger := log.FromContext(ctx)
+
+	// Create a deep copy of the status to modify.
+	newStatus := *rbgset.Status.DeepCopy()
+	newStatus.Replicas = int32(len(rbglist.Items))
+
+	// Calculate the number of ready replicas.
+	readyReplicas := 0
+	for _, rbg := range rbglist.Items {
+		if meta.IsStatusConditionTrue(rbg.Status.Conditions, string(workloadsv1alpha1.RoleBasedGroupReady)) {
+			readyReplicas++
+		}
+	}
+	newStatus.ReadyReplicas = int32(readyReplicas)
+
+	// Update the Condition.
+	desiredReplicas := *rbgset.Spec.Replicas
+	var condition metav1.Condition
+	if newStatus.ReadyReplicas >= desiredReplicas {
+		condition = metav1.Condition{
+			Type:               string(workloadsv1alpha1.RoleBasedGroupSetReady),
+			Status:             metav1.ConditionTrue,
+			Reason:             "AllReplicasReady",
+			Message:            "All RoleBasedGroup replicas are ready.",
+			LastTransitionTime: metav1.Now(),
+		}
+	} else {
+		condition = metav1.Condition{
+			Type:               string(workloadsv1alpha1.RoleBasedGroupSetReady),
+			Status:             metav1.ConditionFalse,
+			Reason:             "ReplicasNotReady",
+			Message:            fmt.Sprintf("Waiting for replicas to be ready (%d/%d)", newStatus.ReadyReplicas, desiredReplicas),
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+	// Use apimeta.SetStatusCondition to safely set or update the condition. It correctly handles the LastTransitionTime.
+	meta.SetStatusCondition(&newStatus.Conditions, condition)
+
+	// Only update the status if it has changed to avoid unnecessary API calls.
+	if reflect.DeepEqual(rbgset.Status, newStatus) {
+		return nil
+	}
+
+	// Use RetryOnConflict to handle potential conflicts during status updates.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// On each retry, get the latest version of the rbgset object.
+		latestRBGSet := &workloadsv1alpha1.RoleBasedGroupSet{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: rbgset.Name, Namespace: rbgset.Namespace}, latestRBGSet); err != nil {
+			return err
+		}
+
+		// Apply the status changes to the latest object.
+		latestRBGSet.Status = newStatus
+
+		err := r.client.Status().Update(ctx, latestRBGSet)
+		if err == nil {
+			logger.Info("Successfully updated RoleBasedGroupSet status",
+				"replicas", newStatus.Replicas, "readyReplicas", newStatus.ReadyReplicas)
+		}
 		return err
-	}
+	})
+}
 
-	rbg.Spec.Roles = rbgset.Spec.Template.Roles
-
-	err := r.client.Create(ctx, &rbg)
-	if err != nil {
-		return fmt.Errorf("create rbg error: %v", err)
+// newRBGForSet creates a new RoleBasedGroup object based on the set's template.
+func newRBGForSet(rbgset *workloadsv1alpha1.RoleBasedGroupSet, index int) *workloadsv1alpha1.RoleBasedGroup {
+	return &workloadsv1alpha1.RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: rbgset.Namespace,
+			Name:      fmt.Sprintf("%s-%d", rbgset.Name, index),
+			Labels: map[string]string{
+				workloadsv1alpha1.SetRBGSetNameLabelKey: rbgset.Name,
+				workloadsv1alpha1.SetRBGIndexLabelKey:   fmt.Sprintf("%d", index),
+			},
+			// The OwnerReference will be set in the scaleUp function.
+		},
+		Spec: workloadsv1alpha1.RoleBasedGroupSpec{
+			Roles: rbgset.Spec.Template.Roles,
+		},
 	}
-	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -134,7 +320,7 @@ func (r *RoleBasedGroupSetReconciler) SetupWithManager(mgr ctrl.Manager, options
 		WithOptions(options).
 		For(&workloadsv1alpha1.RoleBasedGroupSet{}).
 		Owns(&workloadsv1alpha1.RoleBasedGroup{}).
-		Named("workloads-rolebasedgroupset").
+		Named("rbgset-controller").
 		Complete(r)
 }
 

--- a/internal/controller/workloads/rolebasedgroupset_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller_test.go
@@ -17,16 +17,21 @@ limitations under the License.
 package workloads
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/rbgs/api/workloads/v1alpha1"
 	"testing"
 
-	// . "github.com/onsi/ginkgo/v2"
-	// . "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -145,6 +150,404 @@ func TestRoleBasedGroupSetReconciler_CheckCrdExists(t *testing.T) {
 						t.Error("Expected NotFound error not received")
 					}
 				}
+			}
+		})
+	}
+}
+
+// TestRoleBasedGroupSetReconciler_scaleUp tests the scaleUp function.
+func TestRoleBasedGroupSetReconciler_scaleUp(t *testing.T) {
+	// Setup test scheme
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	// Create a RoleBasedGroupSet for testing
+	rbgset := &v1alpha1.RoleBasedGroupSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rbgset",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: v1alpha1.RoleBasedGroupSetSpec{
+			Template: v1alpha1.RoleBasedGroupSpec{
+				Roles: []v1alpha1.RoleSpec{
+					{Name: "role-1"},
+					{Name: "role-2"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		count       int
+		expectError bool
+	}{
+		{
+			name:        "Create 3 RBGs",
+			count:       3,
+			expectError: false,
+		},
+		{
+			name:        "Create 0 RBGs",
+			count:       0,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test reconciler with a fake client
+			r := &RoleBasedGroupSetReconciler{
+				client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+				scheme: scheme,
+			}
+
+			// The new scaleUp function expects a list of objects to create.
+			// We generate this list based on the test case count.
+			var rbgsToCreate []*v1alpha1.RoleBasedGroup
+			for i := 0; i < tt.count; i++ {
+				rbgsToCreate = append(rbgsToCreate, newRBGForSet(rbgset, i))
+			}
+
+			err := r.scaleUp(context.Background(), rbgset, rbgsToCreate)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify the result by listing the created objects.
+			var rbglist v1alpha1.RoleBasedGroupList
+			opts := []client.ListOption{
+				client.InNamespace(rbgset.Namespace),
+				client.MatchingLabels{v1alpha1.SetRBGSetNameLabelKey: rbgset.Name},
+			}
+			err = r.client.List(context.Background(), &rbglist, opts...)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.count, len(rbglist.Items))
+		})
+	}
+}
+
+// TestRoleBasedGroupSetReconciler_scaleDown tests the scaleDown function.
+func TestRoleBasedGroupSetReconciler_scaleDown(t *testing.T) {
+	// Setup test scheme
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	rbgBase := []v1alpha1.RoleBasedGroup{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rbg-0",
+				Namespace: "default",
+				Labels: map[string]string{
+					v1alpha1.SetRBGSetNameLabelKey: "rbgs-test",
+					v1alpha1.SetRBGIndexLabelKey:   "0",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rbg-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					v1alpha1.SetRBGSetNameLabelKey: "rbgs-test",
+					v1alpha1.SetRBGIndexLabelKey:   "1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rbg-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					v1alpha1.SetRBGSetNameLabelKey: "rbgs-test",
+					v1alpha1.SetRBGIndexLabelKey:   "2",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		initialRBGs         []v1alpha1.RoleBasedGroup
+		rbgsToDeleteIndices []int // Indices from initialRBGs to delete
+		expectedNamesLeft   []string
+	}{
+		{
+			name:                "Delete 2 out of 3 RBGs",
+			initialRBGs:         rbgBase,
+			rbgsToDeleteIndices: []int{0, 2}, // Delete rbg-1 and rbg-3
+			expectedNamesLeft:   []string{"rbg-1"},
+		},
+		{
+			name:                "Delete all RBGs",
+			initialRBGs:         rbgBase,
+			rbgsToDeleteIndices: []int{0, 1, 2},
+			expectedNamesLeft:   []string{},
+		},
+		{
+			name:                "Delete 0 items",
+			initialRBGs:         rbgBase,
+			rbgsToDeleteIndices: []int{},
+			expectedNamesLeft:   []string{"rbg-0", "rbg-1", "rbg-2"},
+		},
+		{
+			name:                "Delete from an empty list",
+			initialRBGs:         []v1alpha1.RoleBasedGroup{},
+			rbgsToDeleteIndices: []int{},
+			expectedNamesLeft:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Prepare initial objects for the fake client
+			objs := make([]runtime.Object, len(tt.initialRBGs))
+			for i := range tt.initialRBGs {
+				objs[i] = &tt.initialRBGs[i]
+			}
+			r := &RoleBasedGroupSetReconciler{
+				client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build(),
+			}
+
+			// The new scaleDown function expects an explicit list of objects to delete.
+			var rbgsToDelete []*v1alpha1.RoleBasedGroup
+			for _, index := range tt.rbgsToDeleteIndices {
+				// We need to pass pointers to copies to avoid issues with loop variables.
+				rbgCopy := tt.initialRBGs[index].DeepCopy()
+				rbgsToDelete = append(rbgsToDelete, rbgCopy)
+			}
+
+			err := r.scaleDown(context.Background(), rbgsToDelete)
+			assert.NoError(t, err)
+
+			// Verify the result by listing the remaining objects.
+			var leftRbgList v1alpha1.RoleBasedGroupList
+			opts := []client.ListOption{
+				client.InNamespace("default"),
+				client.MatchingLabels{v1alpha1.SetRBGSetNameLabelKey: "rbgs-test"},
+			}
+			err = r.client.List(context.Background(), &leftRbgList, opts...)
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expectedNamesLeft), len(leftRbgList.Items))
+
+			// Check if the correct items are left.
+			remainingNames := make(map[string]bool)
+			for _, rbg := range leftRbgList.Items {
+				remainingNames[rbg.Name] = true
+			}
+			for _, expectedName := range tt.expectedNamesLeft {
+				assert.True(t, remainingNames[expectedName], fmt.Sprintf("Expected RBG %s to remain, but it was deleted", expectedName))
+			}
+		})
+	}
+}
+
+// TestRoleBasedGroupSetReconciler_Reconcile_StatusUpdate tests the status update logic within the Reconcile loop.
+func TestRoleBasedGroupSetReconciler_Reconcile_StatusUpdate(t *testing.T) {
+	// Setup test scheme
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                string
+		initialRBGSet       *v1alpha1.RoleBasedGroupSet
+		rbgList             []v1alpha1.RoleBasedGroup
+		expectReady         bool
+		expectReplicas      int32
+		expectReadyReplicas int32
+		expectedReason      string
+		expectedMessagePart string
+	}{
+		{
+			name: "All RBGs ready, replicas match spec",
+			initialRBGSet: &v1alpha1.RoleBasedGroupSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rbgset", Namespace: "default"},
+				Spec:       v1alpha1.RoleBasedGroupSetSpec{Replicas: pointer.Int32(2)},
+			},
+			rbgList: []v1alpha1.RoleBasedGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbg-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							v1alpha1.SetRBGSetNameLabelKey: "test-rbgset",
+							v1alpha1.SetRBGIndexLabelKey:   "0",
+						},
+					},
+					Status: v1alpha1.RoleBasedGroupStatus{Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.RoleBasedGroupReady),
+							Status: metav1.ConditionTrue,
+						},
+					}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbg-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							v1alpha1.SetRBGSetNameLabelKey: "test-rbgset",
+							v1alpha1.SetRBGIndexLabelKey:   "1",
+						},
+					},
+					Status: v1alpha1.RoleBasedGroupStatus{Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.RoleBasedGroupReady),
+							Status: metav1.ConditionTrue,
+						},
+					}},
+				},
+			},
+			expectReady:         true,
+			expectReplicas:      2,
+			expectReadyReplicas: 2,
+			expectedReason:      "AllReplicasReady",
+			expectedMessagePart: "All RoleBasedGroup replicas are ready.",
+		},
+		{
+			name: "Partial RBGs ready",
+			initialRBGSet: &v1alpha1.RoleBasedGroupSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rbgset", Namespace: "default"},
+				Spec:       v1alpha1.RoleBasedGroupSetSpec{Replicas: pointer.Int32(2)},
+			},
+			rbgList: []v1alpha1.RoleBasedGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbg-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							v1alpha1.SetRBGSetNameLabelKey: "test-rbgset",
+							v1alpha1.SetRBGIndexLabelKey:   "0",
+						},
+					},
+					Status: v1alpha1.RoleBasedGroupStatus{Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.RoleBasedGroupReady),
+							Status: metav1.ConditionTrue,
+						},
+					}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbg-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							v1alpha1.SetRBGSetNameLabelKey: "test-rbgset",
+							v1alpha1.SetRBGIndexLabelKey:   "1",
+						},
+					},
+					Status: v1alpha1.RoleBasedGroupStatus{Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.RoleBasedGroupReady),
+							Status: metav1.ConditionFalse,
+						},
+					}},
+				},
+			},
+			expectReady:         false,
+			expectReplicas:      2,
+			expectReadyReplicas: 1,
+			expectedReason:      "ReplicasNotReady",
+			expectedMessagePart: "Waiting for replicas to be ready (1/2)",
+		},
+		{
+			name: "No RBGs ready",
+			initialRBGSet: &v1alpha1.RoleBasedGroupSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rbgset", Namespace: "default"},
+				Spec:       v1alpha1.RoleBasedGroupSetSpec{Replicas: pointer.Int32(1)},
+			},
+			rbgList: []v1alpha1.RoleBasedGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbg-0",
+						Namespace: "default",
+						Labels: map[string]string{
+							v1alpha1.SetRBGSetNameLabelKey: "test-rbgset",
+							v1alpha1.SetRBGIndexLabelKey:   "0",
+						},
+					},
+					Status: v1alpha1.RoleBasedGroupStatus{Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.RoleBasedGroupReady),
+							Status: metav1.ConditionFalse,
+						},
+					}},
+				},
+			},
+			expectReady:         false,
+			expectReplicas:      1,
+			expectReadyReplicas: 0,
+			expectedReason:      "ReplicasNotReady",
+			expectedMessagePart: "Waiting for replicas to be ready (0/1)",
+		},
+		{
+			name: "Empty RBG list with zero replicas spec",
+			initialRBGSet: &v1alpha1.RoleBasedGroupSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rbgset", Namespace: "default"},
+				Spec:       v1alpha1.RoleBasedGroupSetSpec{Replicas: pointer.Int32(0)},
+			},
+			rbgList:             []v1alpha1.RoleBasedGroup{},
+			expectReady:         true, // 0 ready >= 0 desired, so it's considered ready.
+			expectReplicas:      0,
+			expectReadyReplicas: 0,
+			expectedReason:      "AllReplicasReady",
+			expectedMessagePart: "All RoleBasedGroup replicas are ready.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Prepare all objects for the fake client.
+			objs := []runtime.Object{tt.initialRBGSet}
+			for i := range tt.rbgList {
+				objs = append(objs, &tt.rbgList[i])
+			}
+
+			// Configure the fake client to provide a status subresource for the CRD.
+			r := &RoleBasedGroupSetReconciler{
+				client: fake.NewClientBuilder().WithScheme(scheme).
+					WithRuntimeObjects(objs...).
+					WithStatusSubresource(&v1alpha1.RoleBasedGroupSet{}).Build(),
+				scheme: scheme,
+			}
+
+			// Run the full reconcile loop. Since replicas in spec match the number of existing
+			// objects, no scaling will occur, and it will proceed to status update.
+			_, err := r.Reconcile(context.TODO(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: tt.initialRBGSet.Namespace,
+					Name:      tt.initialRBGSet.Name,
+				},
+			})
+			// We expect a RequeueAfter, so we don't assert a nil error, just no *real* error.
+			assert.True(t, err == nil || err.Error() == "", "Reconcile returned an unexpected error: %v", err)
+
+			// Fetch the updated RBGSet to check its status.
+			updatedRBGSet := &v1alpha1.RoleBasedGroupSet{}
+			err = r.client.Get(context.Background(), types.NamespacedName{
+				Name:      tt.initialRBGSet.Name,
+				Namespace: tt.initialRBGSet.Namespace,
+			}, updatedRBGSet)
+			assert.NoError(t, err)
+
+			// Verify status fields
+			assert.Equal(t, tt.expectReplicas, updatedRBGSet.Status.Replicas)
+			assert.Equal(t, tt.expectReadyReplicas, updatedRBGSet.Status.ReadyReplicas)
+
+			// Verify condition
+			assert.NotEmpty(t, updatedRBGSet.Status.Conditions, "Status conditions should not be empty")
+			condition := updatedRBGSet.Status.Conditions[0]
+			assert.Equal(t, string(v1alpha1.RoleBasedGroupSetReady), condition.Type)
+			assert.Equal(t, tt.expectedReason, condition.Reason)
+			assert.Contains(t, condition.Message, tt.expectedMessagePart)
+
+			if tt.expectReady {
+				assert.Equal(t, metav1.ConditionTrue, condition.Status)
+			} else {
+				assert.Equal(t, metav1.ConditionFalse, condition.Status)
 			}
 		})
 	}

--- a/pkg/reconciler/lws_reconciler.go
+++ b/pkg/reconciler/lws_reconciler.go
@@ -111,7 +111,7 @@ func (r *LeaderWorkerSetReconciler) CleanupOrphanedWorkloads(ctx context.Context
 	logger := log.FromContext(ctx)
 	err := utils.CheckCrdExists(r.client, utils.LwsCrdName)
 	if err != nil {
-		logger.Info(fmt.Sprintf("LeaderWorkerSetReconciler CleanupOrphanedWorkloads check lws crd failed: %s", err.Error()))
+		logger.V(1).Info(fmt.Sprintf("LeaderWorkerSetReconciler CleanupOrphanedWorkloads check lws crd failed: %s", err.Error()))
 		return nil
 	}
 	// list lws managed by rbg

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -47,6 +47,7 @@ func TestE2E(t *testing.T) {
 		testcase.RunDeploymentWorkloadTestCases(f)
 		testcase.RunStatefulSetWorkloadTestCases(f)
 		testcase.RunLeaderWorkerSetWorkloadTestCases(f)
+		testcase.RunRbgSetControllerTestCases(f)
 	})
 
 	ginkgo.RunSpecs(t, "run rbg e2e test")

--- a/test/e2e/framework/rbgs_expect.go
+++ b/test/e2e/framework/rbgs_expect.go
@@ -1,0 +1,77 @@
+package framework
+
+import (
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/test/utils"
+)
+
+func (f *Framework) ExpectRbgSetEqual(rbgSet *v1alpha1.RoleBasedGroupSet) {
+	logger := log.FromContext(f.Ctx).WithValues("rbgSet", rbgSet.Name)
+	newRbg := &v1alpha1.RoleBasedGroup{}
+	gomega.Eventually(func() bool {
+		err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      rbgSet.Name,
+			Namespace: rbgSet.Namespace,
+		}, newRbg)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				logger.Error(err, "get rbgset error")
+			}
+			return false
+		}
+		return true
+	}, utils.Timeout, utils.Interval).Should(gomega.BeTrue())
+
+	// check rbg exists
+	rbgList := &v1alpha1.RoleBasedGroupList{}
+	err := f.Client.List(f.Ctx, rbgList, &client.ListOptions{})
+	gomega.Expect(err).To(gomega.BeNil())
+
+	// check if the rbg instance number is equal to the rbgset.replicas
+	gomega.Expect(*rbgSet.Spec.Replicas).To(gomega.Equal(len(rbgList.Items)))
+}
+
+func (f *Framework) ExpectRbgSetDeleted(rbgSet *v1alpha1.RoleBasedGroupSet) {
+	newRbg := &v1alpha1.RoleBasedGroup{}
+	gomega.Eventually(func() bool {
+		err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      rbgSet.Name,
+			Namespace: rbgSet.Namespace,
+		}, newRbg)
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+
+		return false
+	}, utils.Timeout, utils.Interval).Should(gomega.BeTrue())
+}
+
+func (f *Framework) ExpectRbgSetCondition(rbgSet *v1alpha1.RoleBasedGroupSet,
+	conditionType v1alpha1.RoleBasedGroupConditionType, conditionStatus metav1.ConditionStatus) bool {
+	logger := log.FromContext(f.Ctx)
+
+	newRbg := &v1alpha1.RoleBasedGroup{}
+	gomega.Eventually(func() bool {
+		err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      rbgSet.Name,
+			Namespace: rbgSet.Namespace,
+		}, newRbg)
+		if err != nil {
+			logger.V(1).Error(err, "get rbgset error")
+		}
+		return err == nil
+	}, utils.Timeout, utils.Interval).Should(gomega.BeTrue())
+
+	for _, condition := range newRbg.Status.Conditions {
+		if condition.Type == string(conditionType) && condition.Status == conditionStatus {
+			return true
+		}
+
+	}
+	return false
+}

--- a/test/e2e/framework/rbgsa_expect.go
+++ b/test/e2e/framework/rbgsa_expect.go
@@ -2,10 +2,93 @@ package framework
 
 import (
 	"fmt"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/rbgs/pkg/scale"
+	"sigs.k8s.io/rbgs/test/utils"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"sigs.k8s.io/rbgs/api/workloads/v1alpha1"
 )
+
+func (f *Framework) ExpectRoleScalingAdapterEqual(rbg *v1alpha1.RoleBasedGroup, role v1alpha1.RoleSpec, expectedReplicas *int32) {
+	logger := log.FromContext(f.Ctx).WithValues("rbg", rbg.Name)
+
+	gomega.Eventually(func() bool {
+		rbgSa := &v1alpha1.RoleBasedGroupScalingAdapter{}
+		err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      scale.GenerateScalingAdapterName(rbg.Name, role.Name),
+			Namespace: rbg.Namespace,
+		}, rbgSa)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				logger.Error(err, "get rbg error")
+			}
+			return false
+		}
+
+		scale := &autoscalingv1.Scale{}
+		if err := f.Client.SubResource("scale").Get(f.Ctx, rbgSa, scale); err != nil {
+			logger.Info("get subresource-scale for rbg scaling adapter failed, wait next time", "reason", err.Error())
+			return false
+		}
+		if err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      rbg.Name,
+			Namespace: rbg.Namespace,
+		}, rbg); err != nil {
+			logger.Info("get subresource-scale for rbg scaling adapter failed, wait next time", "reason", err.Error())
+			return false
+		}
+		newRoleFound := false
+		for _, newRole := range rbg.Spec.Roles {
+			if newRole.Name == role.Name {
+				role, newRoleFound = newRole, true
+				break
+			}
+		}
+		if !newRoleFound {
+			return false
+		}
+		err = expectRbgScalingAdapterEqual(rbgSa, rbg, role, scale, expectedReplicas)
+		if err != nil {
+			logger.Info("rbgScalingAdapter not equal, wait next time", "reason", err.Error())
+		}
+		return err == nil
+	}, utils.Timeout, utils.Interval).Should(gomega.BeTrue())
+}
+
+func (f *Framework) ExpectRbgScalingAdapterEqual(rbg *v1alpha1.RoleBasedGroup) {
+	for _, role := range rbg.Spec.Roles {
+		if role.ScalingAdapter == nil || !role.ScalingAdapter.Enable {
+			f.ExpectScalingAdapterNotExist(rbg, role)
+		} else {
+			f.ExpectRoleScalingAdapterEqual(rbg, role, nil)
+		}
+	}
+}
+
+func (f *Framework) ExpectScalingAdapterNotExist(rbg *v1alpha1.RoleBasedGroup, role v1alpha1.RoleSpec) {
+	checkScalingAdapterNotExist := func() error {
+		rbgSa := &v1alpha1.RoleBasedGroupScalingAdapter{}
+		err := f.Client.Get(f.Ctx, client.ObjectKey{
+			Name:      scale.GenerateScalingAdapterName(rbg.Name, role.Name),
+			Namespace: rbg.Namespace,
+		}, rbgSa)
+		if err == nil {
+			return fmt.Errorf("rbg scalingAdapter still exists")
+		}
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	gomega.Eventually(func() bool {
+		return checkScalingAdapterNotExist() == nil
+	}, utils.Timeout, utils.Interval).Should(gomega.BeTrue())
+}
 
 func expectRbgScalingAdapterEqual(rbgScalingAdapter *v1alpha1.RoleBasedGroupScalingAdapter, rbg *v1alpha1.RoleBasedGroup, role v1alpha1.RoleSpec, scale *autoscalingv1.Scale, expectedReplicas *int32) error {
 	if rbgScalingAdapter == nil || rbgScalingAdapter.Spec.Replicas == nil {

--- a/test/e2e/testcase/rbg.go
+++ b/test/e2e/testcase/rbg.go
@@ -25,6 +25,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 					}).Obj()
 
 			gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+			f.ExpectRbgEqual(rbg)
 
 			// delete rbg
 			gomega.Expect(f.Client.Delete(f.Ctx, rbg)).Should(gomega.Succeed())

--- a/test/e2e/testcase/rbgs.go
+++ b/test/e2e/testcase/rbgs.go
@@ -1,0 +1,44 @@
+package testcase
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/test/e2e/framework"
+	"sigs.k8s.io/rbgs/test/utils"
+	"sigs.k8s.io/rbgs/test/wrappers"
+)
+
+func RunRbgSetControllerTestCases(f *framework.Framework) {
+	ginkgo.Describe("rbgset controller", func() {
+		ginkgo.It("create & delete rbgset", func() {
+			rbgset := wrappers.BuildBasicRoleBasedGroupSet("test", f.Namespace).Obj()
+			gomega.Expect(f.Client.Create(f.Ctx, rbgset)).Should(gomega.Succeed())
+			f.ExpectRbgSetEqual(rbgset)
+
+			// delete rbg
+			gomega.Expect(f.Client.Delete(f.Ctx, rbgset)).Should(gomega.Succeed())
+			f.ExpectRbgSetDeleted(rbgset)
+		})
+
+		ginkgo.It("scaling rbgset", func() {
+			rbgset := wrappers.BuildBasicRoleBasedGroupSet("test", f.Namespace).WithReplicas(1).Obj()
+			gomega.Expect(f.Client.Create(f.Ctx, rbgset)).Should(gomega.Succeed())
+			f.ExpectRbgSetEqual(rbgset)
+
+			//  replicas 1 to 2
+			utils.UpdateRbgSet(f.Ctx, f.Client, rbgset, func(rs *workloadsv1alpha1.RoleBasedGroupSet) {
+				rs.Spec.Replicas = ptr.To(int32(2))
+			})
+			f.ExpectRbgSetEqual(rbgset)
+
+			// replicas 2 to 1
+			utils.UpdateRbgSet(f.Ctx, f.Client, rbgset, func(rs *workloadsv1alpha1.RoleBasedGroupSet) {
+				rs.Spec.Replicas = ptr.To(int32(1))
+			})
+			f.ExpectRbgSetEqual(rbgset)
+		})
+	})
+
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -126,6 +126,28 @@ func UpdateRbg(ctx context.Context, rclient client.Client, rbg *workloadsv1alpha
 	}, Timeout, Interval).Should(gomega.BeTrue())
 }
 
+func UpdateRbgSet(ctx context.Context, rclient client.Client, rbgset *workloadsv1alpha1.RoleBasedGroupSet, updateFunc func(rbgset *workloadsv1alpha1.RoleBasedGroupSet)) {
+	logger := log.FromContext(ctx)
+
+	gomega.Eventually(func() bool {
+		err := rclient.Get(ctx, client.ObjectKey{
+			Name:      rbgset.Name,
+			Namespace: rbgset.Namespace,
+		}, rbgset)
+		if err != nil {
+			logger.V(1).Error(err, "get rbg error")
+			return false
+		}
+		updateFunc(rbgset)
+
+		err = rclient.Update(ctx, rbgset)
+		if err != nil {
+			logger.V(1).Error(err, "update rbgset error")
+		}
+		return err == nil
+	}, Timeout, Interval).Should(gomega.BeTrue())
+}
+
 func MapContains(m map[string]string, key, value string) bool {
 	for k, v := range m {
 		if k == key && v == value {

--- a/test/wrappers/rbgs_wrapper.go
+++ b/test/wrappers/rbgs_wrapper.go
@@ -1,0 +1,45 @@
+package wrappers
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	workloadsv1alpha "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+)
+
+type RoleBasedGroupSetWrapper struct {
+	workloadsv1alpha.RoleBasedGroupSet
+}
+
+func (rsWrapper *RoleBasedGroupSetWrapper) Obj() *workloadsv1alpha.RoleBasedGroupSet {
+	return &rsWrapper.RoleBasedGroupSet
+}
+
+func (rsWrapper *RoleBasedGroupSetWrapper) WithName(name string) *RoleBasedGroupSetWrapper {
+	rsWrapper.ObjectMeta.Name = name
+	return rsWrapper
+}
+
+func (rsWrapper *RoleBasedGroupSetWrapper) WithNamespace(namespace string) *RoleBasedGroupSetWrapper {
+	rsWrapper.ObjectMeta.Namespace = namespace
+	return rsWrapper
+}
+
+func (rsWrapper *RoleBasedGroupSetWrapper) WithReplicas(replicas int32) *RoleBasedGroupSetWrapper {
+	rsWrapper.Spec.Replicas = &replicas
+	return rsWrapper
+}
+
+func BuildBasicRoleBasedGroupSet(name, ns string) *RoleBasedGroupSetWrapper {
+	return &RoleBasedGroupSetWrapper{
+		workloadsv1alpha.RoleBasedGroupSet{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+			Spec: workloadsv1alpha.RoleBasedGroupSetSpec{
+				Replicas: ptr.To(int32(1)),
+				Template: BuildBasicRoleBasedGroup(name, ns).Obj().Spec,
+			},
+		},
+	}
+}


### PR DESCRIPTION
#### Feature
support for scaling rbgs

#### How to use

1. create rbgs with replicas=2
```
kubectl apply -f examples/rbgs/rbgs-base.yaml
```
```
$ kubectl get rbgs
NAME        DESIRED   READY   AGE
rbgs-test   2         2       48s

$ kubectl get rbg
NAME          READY   AGE
rbgs-test-0   True    47s
rbgs-test-1   True    47s

$ kubectl get po
NAME                                  READY   STATUS    RESTARTS   AGE
rbgs-test-0-role-1-0                  1/1     Running   0          56s
rbgs-test-0-role-2-5dd697886d-dpzx6   1/1     Running   0          56s
rbgs-test-0-role-2-5dd697886d-xkcjp   1/1     Running   0          56s
rbgs-test-1-role-1-0                  1/1     Running   0          56s
rbgs-test-1-role-2-55c778bc5f-whcjx   1/1     Running   0          56s
rbgs-test-1-role-2-55c778bc5f-zsvf2   1/1     Running   0          56s

```
2. scale up rbgs with replicas=3

```
kubectl scale rbgs rbgs-test --replicas=3
```
```
$ kubectl get rbgs
NAME        DESIRED   READY   AGE
rbgs-test   3         3       93s

$ kubectl get rbg
NAME          READY   AGE
rbgs-test-0   True    92s
rbgs-test-1   True    92s
rbgs-test-2   True    20s

$ kubectl get po
NAME                                  READY   STATUS    RESTARTS   AGE
rbgs-test-0-role-1-0                  1/1     Running   0          107s
rbgs-test-0-role-2-5dd697886d-dpzx6   1/1     Running   0          107s
rbgs-test-0-role-2-5dd697886d-xkcjp   1/1     Running   0          107s
rbgs-test-1-role-1-0                  1/1     Running   0          107s
rbgs-test-1-role-2-55c778bc5f-whcjx   1/1     Running   0          107s
rbgs-test-1-role-2-55c778bc5f-zsvf2   1/1     Running   0          107s
rbgs-test-2-role-1-0                  1/1     Running   0          35s
rbgs-test-2-role-2-64b54f467d-l7g6g   1/1     Running   0          35s
rbgs-test-2-role-2-64b54f467d-zlkqt   1/1     Running   0          35s

```

3. scale down rbgs with replicas=2

**Noted**： When scaling down rbgs, the max index rbg will be deleted first.

```
kubectl scale rbgs rbgs-test --replicas=2
```
```
$ kubectl get rbgs
NAME        DESIRED   READY   AGE
rbgs-test   2         2       3m6s

$ kubectl get rbg
NAME          READY   AGE
rbgs-test-0   True    3m8s
rbgs-test-1   True    3m8s


$ kubectl get po
NAME                                  READY   STATUS    RESTARTS   AGE
rbgs-test-0-role-1-0                  1/1     Running   0          3m19s
rbgs-test-0-role-2-5dd697886d-dpzx6   1/1     Running   0          3m19s
rbgs-test-0-role-2-5dd697886d-xkcjp   1/1     Running   0          3m19s
rbgs-test-1-role-1-0                  1/1     Running   0          3m19s
rbgs-test-1-role-2-55c778bc5f-whcjx   1/1     Running   0          3m19s
rbgs-test-1-role-2-55c778bc5f-zsvf2   1/1     Running   0          3m19s

```

