### PR TITLE
bugfix: Fix the permission issue that rbgs controller cannot create rbg

### DIFF
--- a/config/rbac/rbgs_controller_role.yaml
+++ b/config/rbac/rbgs_controller_role.yaml
@@ -18,7 +18,6 @@ rules:
       - workloads.x-k8s.io
     resources:
       - rolebasedgroupsets
-      - rolebasedgroups
       - clusterengineruntimeprofiles
     verbs:
       - get
@@ -29,6 +28,7 @@ rules:
   - apiGroups:
       - workloads.x-k8s.io
     resources:
+      - rolebasedgroups
       - rolebasedgroupscalingadapters
     verbs:
       - get


### PR DESCRIPTION
The rgbs controller needs to create/delete rbg objects according to the rgbs declaration. Currently, the controller lacks the create/delete permission for rgb. The specific error is as follows
`{"level":"ERROR","time":"2025-09-02T01:12:47.892Z","caller":"workloads/rolebasedgroupset_controller.go:97","message":"create rbg failed.","controller":"workloads-rolebasedgroupset","controllerGroup":"workloads.x-k8s.io","controllerKind":"RoleBasedGroupSet","RoleBasedGroupSet":{"name":"rbgs-test","namespace":"default"},"namespace":"default","name":"rbgs-test","reconcileID":"7fbf093e-4a74-494e-a182-0f1efef5ffb7","rbgset":{"name":"rbgs-test","namespace":"default"},"error":"create rbg error: rolebasedgroups.workloads.x-k8s.io is forbidden: User \"system:serviceaccount:rbgs-system:rbgs-rbgs-controller-sa\" cannot create resource \"rolebasedgroups\" in API group \"workloads.x-k8s.io\" in the namespace \"default\"","stacktrace":"sigs.k8s.io/rbgs/internal/controller/workloads.(*RoleBasedGroupSetReconciler).Reconcile.func1\n\t/workspace/internal/controller/workloads/rolebasedgroupset_controller.go:97"}`

Reproduction method: 
1. In the project root directory, execute `make deploy` to deploy rbg. 
2. Execute `kubectl apply -f examples/rbgs/rbgs-base.yaml` to deploy the test case. 
3. Use `kubectl logs -n rbgs-system <controller-pod>` to view the error log. 
4. Run `make undeploy` to clean up the test resources.