### PR TITLE
fix: delete corresponding podgroup created by rbg when gang-schedulin…

### DIFF
--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -141,14 +141,11 @@ func (r *RoleBasedGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	podGroupExist := scheduler.GetPodGroupAndLoadCrdName(rbg, runtimeController, &watchedWorkload, r.apiReader)
 	// Process PodGroup
-	if podGroupExist {
-		podGroupManager := scheduler.NewPodGroupScheduler(r.client)
-		if err := podGroupManager.Reconcile(ctx, rbg); err != nil {
-			r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCreatePodGroup, err.Error())
-			return ctrl.Result{}, err
-		}
+	podGroupManager := scheduler.NewPodGroupScheduler(r.client)
+	if err := podGroupManager.Reconcile(ctx, rbg, runtimeController, &watchedWorkload, r.apiReader); err != nil {
+		r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCreatePodGroup, err.Error())
+		return ctrl.Result{}, err
 	}
 
 	// Reconcile role, add & update

--- a/pkg/scheduler/podgroup_manager_test.go
+++ b/pkg/scheduler/podgroup_manager_test.go
@@ -2,18 +2,23 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	workloadsv1alpha "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/pkg/utils"
 	"sigs.k8s.io/rbgs/test/wrappers"
 	schedv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	volcanoschedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -25,11 +30,25 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 	_ = workloadsv1alpha.AddToScheme(scheme)
 	_ = schedv1alpha1.AddToScheme(scheme)
 	_ = volcanoschedulingv1beta1.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
 
+	gvk := utils.GetRbgGVK()
+	rbgName := "test-rbg"
+	rbgNamespace := "default"
 	podGroup := &schedv1alpha1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-rbg",
-			Namespace: "default",
+			Name:      rbgName,
+			Namespace: rbgNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         gvk.GroupVersion().String(),
+					Kind:               gvk.Kind,
+					Name:               rbgName,
+					UID:                "rbg-test-uid",
+					Controller:         ptr.To[bool](true),
+					BlockOwnerDeletion: ptr.To[bool](true),
+				},
+			},
 		},
 		Spec: schedv1alpha1.PodGroupSpec{
 			MinMember:              3,
@@ -37,18 +56,57 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 		},
 	}
 
+	runtimeController := builder.TypedBuilder[reconcile.Request]{}
+	watchedWorkload := sync.Map{}
+
 	tests := []struct {
 		name        string
 		client      client.Client
 		rbg         *workloadsv1alpha.RoleBasedGroup
+		apiReader   client.Reader
+		preFunc     func()
 		expectPG    bool
 		expectError bool
 	}{
 		{
 			name:   "create pod group when gang scheduling enabled and pod group not exists",
 			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-			rbg: wrappers.BuildBasicRoleBasedGroup("test-rbg", "default").
+			rbg: wrappers.BuildBasicRoleBasedGroup(rbgName, rbgNamespace).
 				WithKubeGangScheduling(true).Obj(),
+			apiReader: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: KubePodGroupCrdName},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+							{
+								Type:   apiextensionsv1.Established,
+								Status: apiextensionsv1.ConditionTrue,
+							},
+						},
+					},
+				},
+			).Build(),
+			expectPG:    true,
+			expectError: false,
+		},
+		{
+			name:   "create pod group when volcano gang scheduling enabled and pod group not exists",
+			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			rbg: wrappers.BuildBasicRoleBasedGroup(rbgName, rbgNamespace).
+				WithVolcanoGangScheduling("high-priority", "gpu-queue").Obj(),
+			apiReader: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: VolcanoPodGroupCrdName},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+							{
+								Type:   apiextensionsv1.Established,
+								Status: apiextensionsv1.ConditionTrue,
+							},
+						},
+					},
+				},
+			).Build(),
 			expectPG:    true,
 			expectError: false,
 		},
@@ -57,8 +115,8 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
 			rbg: &workloadsv1alpha.RoleBasedGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-rbg",
-					Namespace: "default",
+					Name:      rbgName,
+					Namespace: rbgNamespace,
 				},
 				Spec: workloadsv1alpha.RoleBasedGroupSpec{
 					PodGroupPolicy: nil,
@@ -70,6 +128,10 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 					},
 				},
 			},
+			preFunc: func() {
+				watchedWorkload.LoadOrStore(KubePodGroupCrdName, struct{}{})
+				runtimeController.Owns(&schedv1alpha1.PodGroup{})
+			},
 			expectPG:    false,
 			expectError: false,
 		},
@@ -78,8 +140,8 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
 			rbg: &workloadsv1alpha.RoleBasedGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-rbg",
-					Namespace: "default",
+					Name:      rbgName,
+					Namespace: rbgNamespace,
 				},
 				Spec: workloadsv1alpha.RoleBasedGroupSpec{
 					PodGroupPolicy: &workloadsv1alpha.PodGroupPolicy{
@@ -103,8 +165,8 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 			client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(podGroup).Build(),
 			rbg: &workloadsv1alpha.RoleBasedGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-rbg",
-					Namespace: "default",
+					Name:      rbgName,
+					Namespace: rbgNamespace,
 				},
 				Spec: workloadsv1alpha.RoleBasedGroupSpec{
 					PodGroupPolicy: &workloadsv1alpha.PodGroupPolicy{
@@ -122,22 +184,43 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 					},
 				},
 			},
+			apiReader: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: KubePodGroupCrdName},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+							{
+								Type:   apiextensionsv1.Established,
+								Status: apiextensionsv1.ConditionTrue,
+							},
+						},
+					},
+				},
+			).Build(),
 			expectPG:    true,
 			expectError: false,
 		},
 		{
 			name:   "delete pod group when gang scheduling disabled and pod group exists",
 			client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(podGroup).Build(),
-			rbg: wrappers.BuildBasicRoleBasedGroup("test-rbg", "default").
+			rbg: wrappers.BuildBasicRoleBasedGroup(rbgName, rbgNamespace).
 				WithKubeGangScheduling(false).Obj(),
+			preFunc: func() {
+				watchedWorkload.LoadOrStore(KubePodGroupCrdName, struct{}{})
+				runtimeController.Owns(&schedv1alpha1.PodGroup{})
+			},
 			expectPG:    false,
 			expectError: false,
 		},
 		{
 			name:   "do nothing when gang scheduling disabled and pod group not exists",
 			client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-			rbg: wrappers.BuildBasicRoleBasedGroup("test-rbg", "default").
+			rbg: wrappers.BuildBasicRoleBasedGroup(rbgName, rbgNamespace).
 				WithKubeGangScheduling(false).Obj(),
+			preFunc: func() {
+				watchedWorkload.LoadOrStore(KubePodGroupCrdName, struct{}{})
+				runtimeController.Owns(&schedv1alpha1.PodGroup{})
+			},
 			expectPG:    false,
 			expectError: false,
 		},
@@ -149,7 +232,10 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 
 				scheduler := NewPodGroupScheduler(tt.client)
 				ctx := log.IntoContext(context.TODO(), zap.New().WithValues("env", "test"))
-				err := scheduler.Reconcile(ctx, tt.rbg)
+				if tt.preFunc != nil {
+					tt.preFunc()
+				}
+				err := scheduler.Reconcile(ctx, tt.rbg, &runtimeController, &watchedWorkload, tt.apiReader)
 
 				// Verify
 				if (err != nil) != tt.expectError {
@@ -157,24 +243,42 @@ func TestPodGroupScheduler_Reconcile(t *testing.T) {
 				}
 
 				// Check if pod group exists or not
-				pg := &schedv1alpha1.PodGroup{}
-				err = scheduler.client.Get(
-					context.Background(), types.NamespacedName{
-						Name:      tt.rbg.Name,
-						Namespace: tt.rbg.Namespace,
-					}, pg,
-				)
+				var obj client.Object
+				if tt.rbg.IsVolcanoGangScheduling() {
+					pg := &volcanoschedulingv1beta1.PodGroup{}
+					err = scheduler.client.Get(
+						context.Background(), types.NamespacedName{
+							Name:      tt.rbg.Name,
+							Namespace: tt.rbg.Namespace,
+						}, pg,
+					)
+					obj = pg
+				} else {
+					pg := &schedv1alpha1.PodGroup{}
+					err = scheduler.client.Get(
+						context.Background(), types.NamespacedName{
+							Name:      tt.rbg.Name,
+							Namespace: tt.rbg.Namespace,
+						}, pg,
+					)
+					obj = pg
+				}
 
 				if tt.expectPG {
 					assert.NoError(t, err)
-					assert.Equal(t, tt.rbg.Name, pg.Name)
-					assert.Equal(t, tt.rbg.Namespace, pg.Namespace)
-					assert.Equal(t, int32(tt.rbg.GetGroupSize()), pg.Spec.MinMember)
 
-					// Check owner reference
-					assert.Len(t, pg.OwnerReferences, 1)
-					assert.Equal(t, tt.rbg.Name, pg.OwnerReferences[0].Name)
-					assert.Equal(t, "RoleBasedGroup", pg.OwnerReferences[0].Kind)
+					switch pg := obj.(type) {
+					case *volcanoschedulingv1beta1.PodGroup:
+					case *schedv1alpha1.PodGroup:
+						assert.Equal(t, tt.rbg.Name, pg.Name)
+						assert.Equal(t, tt.rbg.Namespace, pg.Namespace)
+						assert.Equal(t, int32(tt.rbg.GetGroupSize()), pg.Spec.MinMember)
+
+						// Check owner reference
+						assert.Len(t, pg.OwnerReferences, 1)
+						assert.Equal(t, tt.rbg.Name, pg.OwnerReferences[0].Name)
+						assert.Equal(t, "RoleBasedGroup", pg.OwnerReferences[0].Kind)
+					}
 				} else {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), "not found")

--- a/test/wrappers/rbg_wrapper.go
+++ b/test/wrappers/rbg_wrapper.go
@@ -30,12 +30,6 @@ func (rbgWrapper *RoleBasedGroupWrapper) WithRoles(roles []workloadsv1alpha.Role
 	return rbgWrapper
 }
 
-func (rbgWrapper *RoleBasedGroupWrapper) WithPodGroupPolicy(
-	podGroupPolicy *workloadsv1alpha.PodGroupPolicy) *RoleBasedGroupWrapper {
-	rbgWrapper.Spec.PodGroupPolicy = podGroupPolicy
-	return rbgWrapper
-}
-
 func (rbgWrapper *RoleBasedGroupWrapper) AddRole(role workloadsv1alpha.RoleSpec) *RoleBasedGroupWrapper {
 	rbgWrapper.Spec.Roles = append(rbgWrapper.Spec.Roles, role)
 	return rbgWrapper
@@ -86,6 +80,10 @@ func (rbgWrapper *RoleBasedGroupWrapper) WithStatus(
 func BuildBasicRoleBasedGroup(name, ns string) *RoleBasedGroupWrapper {
 	return &RoleBasedGroupWrapper{
 		workloadsv1alpha.RoleBasedGroup{
+			TypeMeta: v1.TypeMeta{
+				APIVersion: "workloads.x-k8s.io/v1alpha1",
+				Kind:       "RoleBasedGroup",
+			},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,
 				Namespace: ns,


### PR DESCRIPTION
### Ⅰ. Motivation
bugfix

### Ⅱ. Modifications
podgroup_manager and rolebasedgroup_controller reconcile logic

### Ⅲ. Does this pull request fix one issue?
fixes [#56](https://github.com/sgl-project/rbg/issues/56)

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it
1. create a RoleBasedGroup with gang-scheduling enabled
2. update the RoleBasedGroup and remove spec.podGroupPolicy
3. check if the podGroup created by the RoleBasedGroup is deleted

### VI. Special notes for reviews


## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.