### PR TITLE
feat: The ControllerRevision not store the replicas for RBG Roles

### DIFF
--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -456,6 +456,7 @@ func TestGetPatchAndRestore(t *testing.T) {
 
 	v2 := v1.DeepCopy()
 	v2.Spec.Roles[0].Replicas = ptr.To(int32(2))
+	v2.Spec.Roles[0].Template.Spec.Containers[0].Image = "nginx:1.19.0"
 
 	patchV1ControllerRevision := &appsv1.ControllerRevision{
 		ObjectMeta: metav1.ObjectMeta{
@@ -466,9 +467,9 @@ func TestGetPatchAndRestore(t *testing.T) {
 		},
 	}
 	restoreV1, _ := ApplyRevision(v2, patchV1ControllerRevision)
-	fmt.Println(string(patchV1))
-	assert.Equal(t, v1.Spec.Roles[0].Replicas, restoreV1.Spec.Roles[0].Replicas)
-	assert.True(t, reflect.DeepEqual(v1.Spec.PodGroupPolicy, restoreV1.Spec.PodGroupPolicy))
+	assert.Equal(t, v2.Spec.Roles[0].Replicas, restoreV1.Spec.Roles[0].Replicas)
+	assert.True(t, reflect.DeepEqual(v2.Spec.PodGroupPolicy, restoreV1.Spec.PodGroupPolicy))
+	v1.Spec.Roles[0].Replicas = ptr.To(int32(2))
 	assert.True(t, reflect.DeepEqual(v1.Spec.Roles, restoreV1.Spec.Roles))
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->
In an RBG, individual Roles may be associated with an HPA for dynamic scaling.
Storing the Role replica counts in a ControllerRevision can cause some important changes in the spec to be overwritten by outdated replica values (especially since ControllerRevision has a history size limit).

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->
Serialization:
When serializing an RBG into a ControllerRevision, the RBG is first deep-copied. The replicas field for all Roles in the copy is then set to the default value of 1 before running the serialization process.

Deserialization:
The ControllerRevision does not store the actual Role replica counts. After deserialization, the replica counts from the current RBG Roles are used. If a Role from the historical ControllerRevision does not exist in the current RBG, its replica count will default to 1.

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅴ. Describe how to verify it
Ran 28 of 28 Specs in 142.256 seconds
SUCCESS! -- 28 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (142.26s)
PASS
ok      sigs.k8s.io/rbgs/test/e2e       142.742s

### VI. Special notes for reviews


## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.