### PR TITLE
CI:add release script

### DIFF
--- a/doc/dev/how_to_release.md
+++ b/doc/dev/how_to_release.md
@@ -1,0 +1,57 @@
+### Helm Chart Version Updater  
+**Script Path:** `rbg/tools/release/version-update.sh`  
+**Purpose:** Automatically updates Helm chart versions and image tags based on Git branch names.  
+
+---
+
+###  🚀 Quick Start  
+1. **Ensure you're on a valid version branch**:  
+   ```bash
+   git checkout 0.5.0        # Valid: 0.5.0, 0.5.0-alpha.1, 2.0.0-rc.1
+   ```
+2. **Run the script**:  
+   ```bash
+   ./rbg/tools/release/version-update.sh
+   ```
+
+---
+
+### ✅ Requirements  
+| Item               | Requirement                         | Example                |
+|--------------------|-------------------------------------|------------------------|
+| **Branch name**    | Must be a semantic version          | `0.5.0`, `1.2.3-rc.1` |
+| **Makefile**       | Must contain `VERSION` variable     | `VERSION ?= v0.5.0`    |
+| **File structure** | Helm charts in `deploy/helm/rbgs/`  | -                      |
+
+---
+
+###  🔄 What It Updates  
+| File               | Field Updated       | Example Value        | Source                     |
+|--------------------|---------------------|----------------------|----------------------------|
+| `Chart.yaml`       | `version`          | `0.5.0-alpha.2`      | Branch name (without `v`)  |
+| `Chart.yaml`       | `appVersion`       | `0.5.0-abc123`       | Image tag without `v`      |
+| `values.yaml`      | `image.tag`        | `v0.5.0-abc123`      | Makefile `VERSION` + Git SHA |
+
+---
+
+###  🛠️ Troubleshooting  
+**Common Errors:**  
+```bash
+# Error 1: Invalid branch name
+Error: Branch 'feature/login' is not a valid version
+
+# Solution: Rename branch to a semantic version
+git branch -m 0.5.0
+
+# Error 2: Missing files
+Error: Chart.yaml not found at deploy/helm/rbgs/Chart.yaml!
+
+# Solution: Verify chart exists at correct location
+ls deploy/helm/rbgs/Chart.yaml
+```
+
+**Debug Mode:**  
+```bash
+# Run with detailed output
+bash -x rbg/tools/release/version-update.sh
+```

--- a/tools/release/version-update.sh
+++ b/tools/release/version-update.sh
@@ -59,13 +59,13 @@ if [[ -f "$CHART_FILE" ]]; then
     # Update version field
     sed -i.bak -E "s/^(version:[[:space:]]+).*/\1${CLEAN_VERSION}/" "$CHART_FILE"
     
-    # Update appVersion field (remove any existing quotes)
-    sed -i.bak -E "s/^(appVersion:[[:space:]]+).*/\1\"${APP_VERSION}\"/" "$CHART_FILE"
+    # Update appVersion field without quotes
+    sed -i.bak -E "s/^(appVersion:[[:space:]]+).*/\1${APP_VERSION}/" "$CHART_FILE"
     
     rm -f "${CHART_FILE}.bak"
     echo "Updated $CHART_FILE:"
     echo "  version: $CLEAN_VERSION"
-    echo "  appVersion: \"$APP_VERSION\""
+    echo "  appVersion: $APP_VERSION"
 else
     echo "Error: $CHART_FILE not found at ${CHART_FILE}!"
     exit 1
@@ -74,10 +74,10 @@ fi
 # Update values.yaml
 VALUES_FILE="${CHARTS_DIR}/rbgs/values.yaml"
 if [[ -f "$VALUES_FILE" ]]; then
-    # Update tag field
-    sed -i.bak -E "s/^(  tag:[[:space:]]+).*/\1\"$TAG\"/" "$VALUES_FILE"
+    # Update tag field without quotes
+    sed -i.bak -E "s/^(  tag:[[:space:]]+).*/\1$TAG/" "$VALUES_FILE"
     rm -f "${VALUES_FILE}.bak"
-    echo "Updated $VALUES_FILE tag to \"$TAG\""
+    echo "Updated $VALUES_FILE tag to $TAG"
 else
     echo "Error: $VALUES_FILE not found at ${VALUES_FILE}!"
     exit 1


### PR DESCRIPTION
### Ⅰ. Motivation  
This pull request introduces an automated Helm chart version update script to streamline release processes. The key motivations are:  
1. **Eliminate manual errors** in Helm chart versioning and image tagging  
2. **Enforce branch naming conventions** for semantic versioning  
3. **Automate synchronization** between Git branches, Helm charts, and container images  
4. **Reduce release overhead** by replacing error-prone manual updates with a single command  

### Ⅱ. Modifications  
1. **Added new script**: `rbg/tools/release/version-update.sh`  
2. **Core functionality**:  
   - Auto-detects semantic versions from Git branch names (`0.5.0`, `v1.2.3-rc.1`)  
   - Updates Helm chart fields:  
     ```diff
     Chart.yaml:
     - version: 0.5.0        # From branch name
     - appVersion: 0.5.0-abc123  # From image tag (without 'v')
     
     values.yaml:
     - image.tag: v0.5.0-abc123  # From Makefile VERSION + Git SHA
     ```  
   - Validates:  
     - Branch naming conventions  
     - Makefile variable presence  
     - File existence  
3. **Path handling**:  
   - Works from any directory in repository  
   - Correctly resolves paths:  
     ```bash
     CHARTS_DIR="deploy/helm"  # Relative to repo root
     ```  

### Ⅲ. Does this pull request fix one issue?  
NONE  

### Ⅳ. List the added test cases  
**No tests added** because:  
1. This is a release utility script run manually  
2. Contains built-in validations and error checks:  
   - Branch format validation  
   - Makefile variable checks  
   - File existence verification  
3. Outputs clear error messages for all failure cases  
4. Will be validated during actual release processes  

---

> **Note**: Manual testing has been performed with:  
> - Valid branches (`0.5.0`, `v1.2.3-rc1`)  
