### PR TITLE
fix: sts_reconciler failure to retrieve historical StatefulSet revisions

### DIFF
--- a/pkg/reconciler/sts_reconciler_test.go
+++ b/pkg/reconciler/sts_reconciler_test.go
@@ -912,7 +912,7 @@ func TestStatefulSetReconciler_rollingUpdateParameters(t *testing.T) {
 
 				ctx := log.IntoContext(context.TODO(), zap.New().WithValues("env", "test"))
 				retPartition, retReplicas, retErr := r.rollingUpdateParameters(
-					ctx, &rbg.Spec.Roles[0], tt.sts, tt.stsUpdated, rbg.GetCommonLabelsFromRole(&rbg.Spec.Roles[0]))
+					ctx, &rbg.Spec.Roles[0], tt.sts, tt.stsUpdated)
 
 				if tt.wantErr != (retErr != nil) {
 					t.Errorf("rollingUpdateParameters() error = %v, wantErr %v", retErr, tt.wantErr)

--- a/test/e2e/framework/workloads/statefulset_expect.go
+++ b/test/e2e/framework/workloads/statefulset_expect.go
@@ -44,7 +44,7 @@ func (s *StatefulSetEqualChecker) ExpectWorkloadEqual(rbg *v1alpha1.RoleBasedGro
 	svc := &v1.Service{}
 	err = s.client.Get(
 		s.ctx, client.ObjectKey{
-			Name:      rbg.GetWorkloadName(&role),
+			Name:      rbg.GetServiceName(&role),
 			Namespace: rbg.Namespace,
 		}, svc,
 	)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->
fix: sts_reconciler failure to retrieve historical StatefulSet revisions

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->
Align sts_reconciler StatefulSet revision listing label selector with available Pod retrieval logic, following StatefulSet controller’s revision creation behavior
https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/statefulset/stateful_set_utils.go#L576-L581
RBG StatefulSet PodTemplate Label
https://github.com/sgl-project/rbg/blob/main/pkg/reconciler/sts_reconciler.go#L473-L474

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #76 

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
[AfterSuite] PASSED [0.031 seconds]
------------------------------

Ran 28 of 28 Specs in 133.556 seconds
SUCCESS! -- 28 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (133.56s)
PASS
ok      sigs.k8s.io/rbgs/test/e2e       134.100s

### Ⅴ. Describe how to verify it

https://github.com/sgl-project/rbg/issues/76
```
~ k get controllerrevision
NAME                            CONTROLLER                                      REVISION   AGE
rbg-example-55476cbfcf-2        rolebasedgroup.workloads.x-k8s.io/rbg-example   2          5m1s
rbg-example-5f6557855f-1        rolebasedgroup.workloads.x-k8s.io/rbg-example   1          7m38s
rbg-example-role-0-5b5ccc8994   statefulset.apps/rbg-example-role-0             1          8m43s
rbg-example-role-1-6b65c68658   statefulset.apps/rbg-example-role-1             2          5m
rbg-example-role-1-74c5b8f8db   statefulset.apps/rbg-example-role-1             1          8m47s
rbg-example-role-2-7c4b8b8796   statefulset.apps/rbg-example-role-2             1          8m46s

~ k get po
NAME                   READY   STATUS    RESTARTS   AGE
rbg-example-role-0-0   1/1     Running   0          8m45s
rbg-example-role-1-0   1/1     Running   0          3m58s
rbg-example-role-1-1   1/1     Running   0          4m31s
rbg-example-role-1-2   1/1     Running   0          3m20s
rbg-example-role-2-0   1/1     Running   0          8m48s
```

### VI. Special notes for reviews


## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.