### PR TITLE
fix(sts-reconciler): use compatible headless service name for statefu…

### DIFF
--- a/pkg/reconciler/sts_reconciler.go
+++ b/pkg/reconciler/sts_reconciler.go
@@ -479,11 +479,16 @@ func (r *StatefulSetReconciler) constructStatefulSetApplyConfiguration(
 	stsLabel := maps.Clone(matchLabels)
 	stsLabel[fmt.Sprintf(workloadsv1alpha1.RoleRevisionLabelKeyFmt, role.Name)] = revisionKey
 
+	svcName, err := utils.GetCompatibleHeadlessServiceName(ctx, r.client, rbg, role)
+	if err != nil {
+		return nil, err
+	}
 	// construct statefulset apply configuration
 	statefulSetConfig := appsapplyv1.StatefulSet(rbg.GetWorkloadName(role), rbg.Namespace).
 		WithSpec(
 			appsapplyv1.StatefulSetSpec().
-				WithServiceName(rbg.GetWorkloadName(role)).
+				// WithServiceName(rbg.GetWorkloadName(role)).
+				WithServiceName(svcName).
 				WithReplicas(*role.Replicas).
 				WithTemplate(podTemplateApplyConfiguration).
 				WithPodManagementPolicy(appsv1.ParallelPodManagement).


### PR DESCRIPTION



<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->
- Update StatefulSet reconciliation to use a compatible headless service name
- Add error handling for cases where a compatible service name cannot be found
- This change ensures compatibility with headless services in various environments

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #80 

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅴ. Describe how to verify it


### VI. Special notes for reviews


## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.