### PR TITLE
fix: prevent updates of  RestartInProgress condition be covered by updating role status

### DIFF
--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -312,6 +312,9 @@ func (r *RoleBasedGroupReconciler) updateRBGStatus(
 		}
 	}
 
+	if err := r.client.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, rbg); err != nil {
+		return err
+	}
 	setCondition(rbg, readyCondition)
 
 	// update role status


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation

### Ⅱ. Modifications

### Ⅲ. Does this pull request fix one issue?
fixes #87 

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅴ. Describe how to verify it
1. Deploy the corresponding YAML
```
apiVersion: workloads.x-k8s.io/v1alpha1
kind: RoleBasedGroup
metadata:
  name: restart-policy
spec:
  roles:
    - name: sts
      restartPolicy: RecreateRBGOnPodRestart
      replicas: 2
      template:
        metadata:
          labels:
            appVersion: v1
        spec:
          containers:
            - name: sts
              image: anolis-registry.cn-zhangjiakou.cr.aliyuncs.com/openanolis/nginx:1.14.1-8.6
              ports:
                - containerPort: 80
```
2. Manually delete the created Pod
3. Observe the conditions of RBGStatus
4. Loop through steps 2 and 3, and observe 'RestartInProgress' status is

### VI. Special notes for reviews
Set logLevel=1 and look at "patch content" in pkg/utils/utils.go:30 PatchObjectApplyConfiguration:
After all pod restarted, the condition of RestartInProgress was set to RBGRestartCompleted
<img width="3018" height="404" alt="image" src="https://github.com/user-attachments/assets/e894e059-05ad-42c4-8670-bb8cdcad684e" />

Then in reconcile cycle of RoleBasedGroup, when updateRoleStatus, it used an outdated condition 'RBGRestart', not 'RBGRestartCompleted'. So the condition of RestartInProgress stayed in 'RBGRestart' forever. When pod restart next time, the restart-policy will not work anymore.
<img width="1507" height="112" alt="image" src="https://github.com/user-attachments/assets/8681bc95-80d9-4860-a4da-f9c4c56cdea7" />


## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.