### PR TITLE
fix(rbg): fix incorrect apiVersion in auto-generated applyconfigurations

### DIFF
--- a/api/workloads/v1alpha1/doc.go
+++ b/api/workloads/v1alpha1/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +kubebuilder:object:generate=true
+// +groupName=workloads.x-k8s.io
+
+package v1alpha1

--- a/client-go/applyconfiguration/utils.go
+++ b/client-go/applyconfiguration/utils.go
@@ -30,7 +30,7 @@ import (
 // apply configuration type exists for the given GroupVersionKind.
 func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
-	// Group=workloads, Version=v1alpha1
+	// Group=workloads.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("AdapterScaleTargetRef"):
 		return &workloadsv1alpha1.AdapterScaleTargetRefApplyConfiguration{}
 	case v1alpha1.SchemeGroupVersion.WithKind("ClusterEngineRuntimeProfile"):

--- a/client-go/applyconfiguration/workloads/v1alpha1/clusterengineruntimeprofile.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/clusterengineruntimeprofile.go
@@ -40,7 +40,7 @@ func ClusterEngineRuntimeProfile(name, namespace string) *ClusterEngineRuntimePr
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("ClusterEngineRuntimeProfile")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b ClusterEngineRuntimeProfileApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/applyconfiguration/workloads/v1alpha1/instance.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/instance.go
@@ -39,7 +39,7 @@ func Instance(name, namespace string) *InstanceApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("Instance")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b InstanceApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/applyconfiguration/workloads/v1alpha1/instanceset.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/instanceset.go
@@ -39,7 +39,7 @@ func InstanceSet(name, namespace string) *InstanceSetApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("InstanceSet")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b InstanceSetApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroup.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroup.go
@@ -39,7 +39,7 @@ func RoleBasedGroup(name, namespace string) *RoleBasedGroupApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("RoleBasedGroup")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b RoleBasedGroupApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupscalingadapter.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupscalingadapter.go
@@ -39,7 +39,7 @@ func RoleBasedGroupScalingAdapter(name, namespace string) *RoleBasedGroupScaling
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("RoleBasedGroupScalingAdapter")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b RoleBasedGroupScalingAdapterApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupset.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupset.go
@@ -39,7 +39,7 @@ func RoleBasedGroupSet(name, namespace string) *RoleBasedGroupSetApplyConfigurat
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("RoleBasedGroupSet")
-	b.WithAPIVersion("workloads/v1alpha1")
+	b.WithAPIVersion("workloads.x-k8s.io/v1alpha1")
 	return b
 }
 func (b RoleBasedGroupSetApplyConfiguration) IsApplyConfiguration() {}

--- a/client-go/clientset/versioned/typed/workloads/v1alpha1/workloads_client.go
+++ b/client-go/clientset/versioned/typed/workloads/v1alpha1/workloads_client.go
@@ -35,7 +35,7 @@ type WorkloadsV1alpha1Interface interface {
 	RoleBasedGroupSetsGetter
 }
 
-// WorkloadsV1alpha1Client is used to interact with features provided by the workloads group.
+// WorkloadsV1alpha1Client is used to interact with features provided by the workloads.x-k8s.io group.
 type WorkloadsV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/client-go/informers/externalversions/generic.go
+++ b/client-go/informers/externalversions/generic.go
@@ -51,7 +51,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=workloads, Version=v1alpha1
+	// Group=workloads.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("clusterengineruntimeprofiles"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Workloads().V1alpha1().ClusterEngineRuntimeProfiles().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("instances"):


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
Ensure the generated client code has the correct apiVersion by declaring` // +groupName=workloads.x-k8s.io `in the doc.go file.





### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->


### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅴ. Describe how to verify it


### VI. Special notes for reviews


## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.