### PR TITLE
refactor: migrate Template field from value to pointer type

### DIFF
--- a/api/workloads/v1alpha1/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha1/rolebasedgroup_types.go
@@ -176,8 +176,8 @@ type RoleSpec struct {
 	Workload WorkloadSpec `json:"workload,omitempty"`
 
 	// Pod template specification
-	// +kubebuilder:validation:Required
-	Template corev1.PodTemplateSpec `json:"template"`
+	// +optional
+	Template *corev1.PodTemplateSpec `json:"template,omitempty"`
 
 	// LeaderWorkerSet template
 	// +optional

--- a/api/workloads/v1alpha1/zz_generated.deepcopy.go
+++ b/api/workloads/v1alpha1/zz_generated.deepcopy.go
@@ -1072,7 +1072,11 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 		copy(*out, *in)
 	}
 	out.Workload = in.Workload
-	in.Template.DeepCopyInto(&out.Template)
+	if in.Template != nil {
+		in, out := &in.Template, &out.Template
+		*out = new(v1.PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	in.LeaderWorkerSet.DeepCopyInto(&out.LeaderWorkerSet)
 	if in.ServicePorts != nil {
 		in, out := &in.ServicePorts, &out.ServicePorts

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -8924,7 +8924,6 @@ spec:
                   required:
                   - name
                   - replicas
-                  - template
                   type: object
                 minItems: 1
                 type: array

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -9076,7 +9076,6 @@ spec:
                       required:
                       - name
                       - replicas
-                      - template
                       type: object
                     minItems: 1
                     type: array

--- a/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -8924,7 +8924,6 @@ spec:
                   required:
                   - name
                   - replicas
-                  - template
                   type: object
                 minItems: 1
                 type: array

--- a/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -9076,7 +9076,6 @@ spec:
                       required:
                       - name
                       - replicas
-                      - template
                       type: object
                     minItems: 1
                     type: array

--- a/pkg/reconciler/lws_reconciler.go
+++ b/pkg/reconciler/lws_reconciler.go
@@ -189,7 +189,7 @@ func (r *LeaderWorkerSetReconciler) constructLWSApplyConfiguration(
 		return nil, err
 	}
 	leaderTemplateApplyCfg, err := podReconciler.ConstructPodTemplateSpecApplyConfiguration(
-		ctx, rbg, role, rbg.GetCommonLabelsFromRole(role), leaderTemp,
+		ctx, rbg, role, rbg.GetCommonLabelsFromRole(role), *leaderTemp,
 	)
 	if err != nil {
 		logger.Error(err, "patch Construct PodTemplateSpecApplyConfiguration failed", "rbg", keyOfRbg(rbg))
@@ -206,7 +206,7 @@ func (r *LeaderWorkerSetReconciler) constructLWSApplyConfiguration(
 	// workerTemplate do not need to inject sidecar
 	workerPodReconciler.SetInjectors([]string{"config", "env"})
 	workerTemplateApplyCfg, err := workerPodReconciler.ConstructPodTemplateSpecApplyConfiguration(
-		ctx, rbg, role, rbg.GetCommonLabelsFromRole(role), workerTemp,
+		ctx, rbg, role, rbg.GetCommonLabelsFromRole(role), *workerTemp,
 	)
 	if err != nil {
 		logger.Error(err, "patch Construct PodTemplateSpecApplyConfiguration failed", "rbg", keyOfRbg(rbg))
@@ -426,7 +426,10 @@ func leaderWorkerTemplateEqual(oldLwt, newLwt lwsv1.LeaderWorkerTemplate) (bool,
 	return true, nil
 }
 
-func patchPodTemplate(template corev1.PodTemplateSpec, patch runtime.RawExtension) (corev1.PodTemplateSpec, error) {
+func patchPodTemplate(template *corev1.PodTemplateSpec, patch runtime.RawExtension) (*corev1.PodTemplateSpec, error) {
+	if template == nil {
+		template = &corev1.PodTemplateSpec{}
+	}
 	if patch.Raw == nil {
 		return template, nil
 	}
@@ -439,7 +442,7 @@ func patchPodTemplate(template corev1.PodTemplateSpec, patch runtime.RawExtensio
 	if err = json.Unmarshal(modified, newTemp); err != nil {
 		return template, err
 	}
-	return *newTemp, nil
+	return newTemp, nil
 }
 
 func keyOfRbg(rbg *workloadsv1alpha1.RoleBasedGroup) string {

--- a/pkg/reconciler/lws_reconciler_test.go
+++ b/pkg/reconciler/lws_reconciler_test.go
@@ -221,7 +221,7 @@ func TestLeaderWorkerSetReconciler_CleanupOrphanedWorkloads(t *testing.T) {
 						APIVersion: "leaderworkerset.x-k8s.io/v1",
 						Kind:       "LeaderWorkerSet",
 					},
-					Template: corev1.PodTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{

--- a/pkg/reconciler/pod_reconciler.go
+++ b/pkg/reconciler/pod_reconciler.go
@@ -45,9 +45,10 @@ func (r *PodReconciler) ConstructPodTemplateSpecApplyConfiguration(
 	var podTemplateSpec corev1.PodTemplateSpec
 	if len(podTmpls) > 0 {
 		podTemplateSpec = podTmpls[0]
-	} else {
+	} else if role.Template != nil {
 		podTemplateSpec = *role.Template.DeepCopy()
 	}
+	// else: podTemplateSpec stays as zero value, same behavior as before when Template was a value type
 	podAnnotations := podTemplateSpec.Annotations
 	if podAnnotations == nil {
 		podAnnotations = make(map[string]string)

--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -418,7 +418,7 @@ func TestGetPatchAndRestore(t *testing.T) {
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
-					Template: v1.PodTemplateSpec{
+					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"app": "nginx",
@@ -659,7 +659,7 @@ func getRBG() *workloadsv1alpha1.RoleBasedGroup {
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},
-					Template: v1.PodTemplateSpec{
+					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"app": "router",
@@ -739,7 +739,7 @@ func getRBG() *workloadsv1alpha1.RoleBasedGroup {
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
-					Template: v1.PodTemplateSpec{
+					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"app":  "decode",
@@ -781,7 +781,7 @@ func getRBG() *workloadsv1alpha1.RoleBasedGroup {
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},
-					Template: v1.PodTemplateSpec{
+					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"app":  "prefill",

--- a/test/e2e/testcase/rbg.go
+++ b/test/e2e/testcase/rbg.go
@@ -118,7 +118,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "StatefulSet",
 									},
-									Template: wrappers.BuildBasicPodTemplateSpec().Obj(),
+									Template: ptr.To(wrappers.BuildBasicPodTemplateSpec().Obj()),
 								},
 								{
 
@@ -131,7 +131,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "StatefulSet",
 									},
-									Template: wrappers.BuildBasicPodTemplateSpec().Obj(),
+									Template: ptr.To(wrappers.BuildBasicPodTemplateSpec().Obj()),
 								},
 							},
 						).Obj()
@@ -163,7 +163,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "StatefulSet",
 									},
-									Template: template,
+									Template: &template,
 								},
 								{
 
@@ -176,7 +176,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "StatefulSet",
 									},
-									Template: template,
+									Template: &template,
 								},
 							},
 						).Obj()
@@ -209,7 +209,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "Deployment",
 									},
-									Template: wrappers.BuildBasicPodTemplateSpec().Obj(),
+									Template: ptr.To(wrappers.BuildBasicPodTemplateSpec().Obj()),
 								},
 								{
 									Name:     "prefill",
@@ -221,7 +221,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "apps/v1",
 										Kind:       "StatefulSet",
 									},
-									Template: wrappers.BuildBasicPodTemplateSpec().Obj(),
+									Template: ptr.To(wrappers.BuildBasicPodTemplateSpec().Obj()),
 								},
 								{
 									Name:     "decode",
@@ -233,7 +233,7 @@ func RunRbgControllerTestCases(f *framework.Framework) {
 										APIVersion: "leaderworkerset.x-k8s.io/v1",
 										Kind:       "LeaderWorkerSet",
 									},
-									Template: wrappers.BuildBasicPodTemplateSpec().Obj(),
+									Template: ptr.To(wrappers.BuildBasicPodTemplateSpec().Obj()),
 								},
 							},
 						).Obj()

--- a/test/wrappers/role_wrapper.go
+++ b/test/wrappers/role_wrapper.go
@@ -46,7 +46,7 @@ func (roleWrapper *RoleWrapper) WithMaxSurge(value int32) *RoleWrapper {
 }
 
 func (roleWrapper *RoleWrapper) WithTemplate(template corev1.PodTemplateSpec) *RoleWrapper {
-	roleWrapper.Template = template
+	roleWrapper.Template = &template
 	return roleWrapper
 }
 
@@ -112,6 +112,7 @@ func (roleWrapper *RoleWrapper) WithScalingAdapter(enable bool) *RoleWrapper {
 }
 
 func BuildBasicRole(name string) *RoleWrapper {
+	template := BuildBasicPodTemplateSpec().Obj()
 	return &RoleWrapper{
 		workloadsv1alpha.RoleSpec{
 			Name:     name,
@@ -123,7 +124,7 @@ func BuildBasicRole(name string) *RoleWrapper {
 				APIVersion: "apps/v1",
 				Kind:       "StatefulSet",
 			},
-			Template: BuildBasicPodTemplateSpec().Obj(),
+			Template: &template,
 		},
 	}
 }
@@ -131,6 +132,7 @@ func BuildBasicRole(name string) *RoleWrapper {
 func BuildLwsRole(name string) *RoleWrapper {
 	leaderPatch := BuildLWSTemplatePatch(map[string]string{"role": "leader"})
 	workerPatch := BuildLWSTemplatePatch(map[string]string{"role": "worker"})
+	template := BuildBasicPodTemplateSpec().Obj()
 
 	return &RoleWrapper{
 		workloadsv1alpha.RoleSpec{
@@ -143,7 +145,7 @@ func BuildLwsRole(name string) *RoleWrapper {
 				APIVersion: "leaderworkerset.x-k8s.io/v1",
 				Kind:       "LeaderWorkerSet",
 			},
-			Template: BuildBasicPodTemplateSpec().Obj(),
+			Template: &template,
 			LeaderWorkerSet: workloadsv1alpha.LeaderWorkerTemplate{
 				Size:                ptr.To(int32(2)),
 				PatchLeaderTemplate: leaderPatch,


### PR DESCRIPTION
# Motivation

  This PR addresses the `template` field design issue discussed in KEP-8 (#70).

  ### Problem
  KEP-8 introduces `templateRef` and `template` as logically mutually exclusive options. However, with the current value-type design:
  - Zero value `PodTemplateSpec{}` serializes to invalid JSON that violates CRD schema
  - Users would need placeholder templates even when using `templateRef` (bad UX)
  - No clear way to express "template not set" vs "empty template"

  ### Solution
  Migrate `Template` from value type to pointer type (Solution 2 from the discussion).

  **Why pointer over placeholder approach:**
  - Cleaner semantics: `nil` = not set, avoiding placeholder code smell
  - Aligns with Kubernetes conventions (large optional structs use pointers)
  - Enables strict mutual exclusion validation
  - Better foundation for future horizontal expansion (as noted by maintainers)

  **Timing:**
  - User base is still small, best time for breaking changes
  - This PR need merge before KEP-8 implementation (as suggested by maintainers)
  - Splitting API change from KEP-8 feature for easier review

  ## Changes

  ### API Layer
  - `RoleSpec.Template`: `corev1.PodTemplateSpec` → `*corev1.PodTemplateSpec`
  - Mark as `+optional` (was `+kubebuilder:validation:Required`)
  - CRD schema updated: `template` no longer in required fields

  ### Controller Logic
  - Handle `nil` Template gracefully with zero-value fallback
  - Maintains backward compatibility: existing behavior unchanged
  - Internal functions updated to use pointer throughout

  ### Test Updates
  - All test code updated to use pointer initialization (`&template` or `ptr.To()`)
  - Approximately 10 files modified across unit tests and E2E tests

  ### Auto-generated
  - DeepCopy code regenerated
  - CRD manifests updated

  ## Breaking Change

  ### For Go SDK Users
  **Before:**
  ```go
  role.Template = corev1.PodTemplateSpec{
      Spec: corev1.PodSpec{
          Containers: []corev1.Container{...},
      },
  }

  After:
  role.Template = &corev1.PodTemplateSpec{
      Spec: corev1.PodSpec{
          Containers: []corev1.Container{...},
      },
  }
```
  ### For YAML Users

  **No change required.** YAML manifests remain compatible:
  ```yaml
  roles:
  - name: role1
    template:  # Still works, now optional
      spec:
        containers:
        - name: app
          image: nginx
 ```

  For KEP-8 templateRef mode (future PR):
 ```yaml
  roles:
  - name: role1
    templateRef:
      name: base-template
    # template field can be omitted entirely
 ```
  Testing

  - Unit tests and E2E tests verified
  - No regression in test coverage or behavior

  Related

  Relates to #70 

  This is the prerequisite API change. KEP-8 feature implementation (templateRef/templatePatch) will follow in a separate PR after community review.