### PR TITLE
rbgs support pod group policy

### DIFF
--- a/internal/controller/workloads/rolebasedgroupset_controller.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller.go
@@ -479,7 +479,8 @@ func newRBGForSet(rbgset *workloadsv1alpha1.RoleBasedGroupSet, index int) *workl
 			// The OwnerReference will be set in the scaleUp function.
 		},
 		Spec: workloadsv1alpha1.RoleBasedGroupSpec{
-			Roles: rbgset.Spec.Template.Roles,
+			PodGroupPolicy: rbgset.Spec.Template.PodGroupPolicy,
+			Roles:          rbgset.Spec.Template.Roles,
 		},
 	}
 	// Copy annotations from RBGSet to child RBG


### PR DESCRIPTION
### Ⅰ. Motivation

  - Fix the bug where a RoleBasedGroupSet with podGroupPolicy creates RoleBasedGroups that do not inherit that policy, so PodGroup metadata never reaches the RoleBasedGroup and gang scheduling breaks.

  ### Ⅱ. Modifications

  - In the RoleBasedGroupSet reconciler, detect whether podGroupPolicy is set on the RBGS and, if so, propagate the field to every generated RoleBasedGroup so it can correctly handle PodGroup creation.

  ### Ⅲ. Does this pull request fix one issue?

  NONE

  ### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

  - No new tests; the change is a small wiring fix and is already covered by existing RBGS/RBG e2e flows.

  ### Ⅴ. Describe how to verify it

  - Deploy the updated controller, create an RBGS that specifies podGroupPolicy, and confirm each resulting RoleBasedGroup now contains the same podGroupPolicy.
  - Observe via kubectl get podgroup (or Volcano equivalent) that PodGroups are created/updated for each RoleBasedGroup.
  - Remove the RBGS and ensure the associated RoleBasedGroups and PodGroups are garbage collected.

  ### VI. Special notes for reviews

  - Double-check that the propagation only happens when the RBGS actually specifies podGroupPolicy, to avoid altering RoleBasedGroups that do not need it.

  ## Checklist
  - NONE