### PR TITLE
chore(rbg): migrate RollingUpdate field type

### DIFF
--- a/api/workloads/v1alpha1/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha1/rolebasedgroup_types.go
@@ -163,7 +163,7 @@ type RollingUpdate struct {
 	//
 	// +optional
 	// +kubebuilder:default=0
-	Partition *int32 `json:"partition,omitempty"`
+	Partition *intstr.IntOrString `json:"partition,omitempty"`
 
 	// The maximum number of replicas that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
@@ -178,7 +178,7 @@ type RollingUpdate struct {
 	//
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:default=1
-	MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty"`
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
 	// The maximum number of replicas that can be scheduled above the original number of
 	// replicas.
@@ -194,7 +194,7 @@ type RollingUpdate struct {
 	//
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:default=0
-	MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
+	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 
 	// Paused indicates that the InstanceSet is paused.
 	// Default value is false

--- a/api/workloads/v1alpha1/zz_generated.deepcopy.go
+++ b/api/workloads/v1alpha1/zz_generated.deepcopy.go
@@ -1244,11 +1244,19 @@ func (in *RollingUpdate) DeepCopyInto(out *RollingUpdate) {
 	*out = *in
 	if in.Partition != nil {
 		in, out := &in.Partition, &out.Partition
-		*out = new(int32)
+		*out = new(intstr.IntOrString)
 		**out = **in
 	}
-	out.MaxUnavailable = in.MaxUnavailable
-	out.MaxSurge = in.MaxSurge
+	if in.MaxUnavailable != nil {
+		in, out := &in.MaxUnavailable, &out.MaxUnavailable
+		*out = new(intstr.IntOrString)
+		**out = **in
+	}
+	if in.MaxSurge != nil {
+		in, out := &in.MaxSurge, &out.MaxSurge
+		*out = new(intstr.IntOrString)
+		**out = **in
+	}
 	if in.InPlaceUpdateStrategy != nil {
 		in, out := &in.InPlaceUpdateStrategy, &out.InPlaceUpdateStrategy
 		*out = new(InPlaceUpdateStrategy)

--- a/client-go/applyconfiguration/workloads/v1alpha1/rollingupdate.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/rollingupdate.go
@@ -26,7 +26,7 @@ import (
 // with apply.
 type RollingUpdateApplyConfiguration struct {
 	Type                  *workloadsv1alpha1.UpdateStrategyType    `json:"type,omitempty"`
-	Partition             *int32                                   `json:"partition,omitempty"`
+	Partition             *intstr.IntOrString                      `json:"partition,omitempty"`
 	MaxUnavailable        *intstr.IntOrString                      `json:"maxUnavailable,omitempty"`
 	MaxSurge              *intstr.IntOrString                      `json:"maxSurge,omitempty"`
 	Paused                *bool                                    `json:"paused,omitempty"`
@@ -50,7 +50,7 @@ func (b *RollingUpdateApplyConfiguration) WithType(value workloadsv1alpha1.Updat
 // WithPartition sets the Partition field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Partition field is set to the value of the last call.
-func (b *RollingUpdateApplyConfiguration) WithPartition(value int32) *RollingUpdateApplyConfiguration {
+func (b *RollingUpdateApplyConfiguration) WithPartition(value intstr.IntOrString) *RollingUpdateApplyConfiguration {
 	b.Partition = &value
 	return b
 }

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -1644,12 +1644,14 @@ spec:
                                 Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
                               x-kubernetes-int-or-string: true
                             partition:
+                              anyOf:
+                              - type: integer
+                              - type: string
                               default: 0
                               description: |-
                                 Partition indicates the ordinal at which the role should be partitioned for updates.
                                 During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
-                              format: int32
-                              type: integer
+                              x-kubernetes-int-or-string: true
                             paused:
                               description: |-
                                 Paused indicates that the InstanceSet is paused.

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -1682,12 +1682,14 @@ spec:
                                     Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
                                   x-kubernetes-int-or-string: true
                                 partition:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
                                   default: 0
                                   description: |-
                                     Partition indicates the ordinal at which the role should be partitioned for updates.
                                     During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
-                                  format: int32
-                                  type: integer
+                                  x-kubernetes-int-or-string: true
                                 paused:
                                   description: |-
                                     Paused indicates that the InstanceSet is paused.

--- a/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -1644,12 +1644,14 @@ spec:
                                 Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
                               x-kubernetes-int-or-string: true
                             partition:
+                              anyOf:
+                              - type: integer
+                              - type: string
                               default: 0
                               description: |-
                                 Partition indicates the ordinal at which the role should be partitioned for updates.
                                 During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
-                              format: int32
-                              type: integer
+                              x-kubernetes-int-or-string: true
                             paused:
                               description: |-
                                 Paused indicates that the InstanceSet is paused.

--- a/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/deploy/helm/rbgs/crds/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -1682,12 +1682,14 @@ spec:
                                     Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
                                   x-kubernetes-int-or-string: true
                                 partition:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
                                   default: 0
                                   description: |-
                                     Partition indicates the ordinal at which the role should be partitioned for updates.
                                     During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
-                                  format: int32
-                                  type: integer
+                                  x-kubernetes-int-or-string: true
                                 paused:
                                   description: |-
                                     Paused indicates that the InstanceSet is paused.

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -1074,24 +1074,24 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge with no overlap",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role2": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 				"role2": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 			},
 		},
@@ -1099,20 +1099,20 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge with overlap, B has smaller maxUnavailable",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(10),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(10)),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(3)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(3)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5), // Smaller value
-					Partition:      ptr.To(int32(5)),  // Larger partition
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)), // Smaller value
+					Partition:      ptr.To(intstr.FromInt32(5)), // Larger partition
 				},
 			},
 		},
@@ -1120,20 +1120,20 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge with overlap, B has larger partition",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(3)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(3)),
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(10)), // Larger partition
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(10)), // Larger partition
 				},
 			},
 		},
@@ -1141,20 +1141,20 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge with percentage maxUnavailable",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromString("20%"),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromString("20%")),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromString("10%"),
-					Partition:      ptr.To(int32(3)),
+					MaxUnavailable: ptr.To(intstr.FromString("10%")),
+					Partition:      ptr.To(intstr.FromInt32(3)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromString("10%"), // Smaller value
-					Partition:      ptr.To(int32(5)),         // Larger partition
+					MaxUnavailable: ptr.To(intstr.FromString("10%")), // Smaller value
+					Partition:      ptr.To(intstr.FromInt32(5)),      // Larger partition
 				},
 			},
 		},
@@ -1162,20 +1162,20 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge with nil partition",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(5),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
 					Partition:      nil,
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(10)), // B's partition
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(10)), // B's partition
 				},
 			},
 		},
@@ -1183,36 +1183,36 @@ func Test_mergeStrategyRollingUpdate(t *testing.T) {
 			name: "merge multiple roles",
 			strategiesA: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(10),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(10)),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 				"role2": {
-					MaxUnavailable: intstr.FromInt(5),
-					Partition:      ptr.To(int32(3)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(5)),
+					Partition:      ptr.To(intstr.FromInt32(3)),
 				},
 			},
 			strategiesB: map[string]workloadsv1alpha1.RollingUpdate{
 				"role2": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 				"role3": {
-					MaxUnavailable: intstr.FromInt(7),
-					Partition:      ptr.To(int32(8)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(7)),
+					Partition:      ptr.To(intstr.FromInt32(8)),
 				},
 			},
 			expected: map[string]workloadsv1alpha1.RollingUpdate{
 				"role1": {
-					MaxUnavailable: intstr.FromInt(10),
-					Partition:      ptr.To(int32(5)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(10)),
+					Partition:      ptr.To(intstr.FromInt32(5)),
 				},
 				"role2": {
-					MaxUnavailable: intstr.FromInt(3),
-					Partition:      ptr.To(int32(10)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(3)),
+					Partition:      ptr.To(intstr.FromInt32(10)),
 				},
 				"role3": {
-					MaxUnavailable: intstr.FromInt(7),
-					Partition:      ptr.To(int32(8)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(7)),
+					Partition:      ptr.To(intstr.FromInt32(8)),
 				},
 			},
 		},

--- a/pkg/reconciler/deploy_reconciler.go
+++ b/pkg/reconciler/deploy_reconciler.go
@@ -146,15 +146,19 @@ func (r *DeploymentReconciler) constructDeployApplyConfiguration(
 				WithController(true),
 		)
 	if role.RolloutStrategy != nil && role.RolloutStrategy.RollingUpdate != nil {
+		rollingUpdate := appsapplyv1.RollingUpdateDeployment()
+		if role.RolloutStrategy.RollingUpdate.MaxSurge != nil {
+			rollingUpdate = rollingUpdate.WithMaxSurge(*role.RolloutStrategy.RollingUpdate.MaxSurge)
+		}
+		if role.RolloutStrategy.RollingUpdate.MaxUnavailable != nil {
+			rollingUpdate = rollingUpdate.WithMaxUnavailable(*role.RolloutStrategy.RollingUpdate.MaxUnavailable)
+		}
+
 		deployConfig = deployConfig.WithSpec(
 			deployConfig.Spec.WithStrategy(
 				appsapplyv1.DeploymentStrategy().
 					WithType(appsv1.DeploymentStrategyType(role.RolloutStrategy.Type)).
-					WithRollingUpdate(
-						appsapplyv1.RollingUpdateDeployment().
-							WithMaxSurge(role.RolloutStrategy.RollingUpdate.MaxSurge).
-							WithMaxUnavailable(role.RolloutStrategy.RollingUpdate.MaxUnavailable),
-					),
+					WithRollingUpdate(rollingUpdate),
 			),
 		)
 	}
@@ -175,12 +179,15 @@ func (r *DeploymentReconciler) constructDeployApplyConfiguration(
 				),
 			)
 		}
+
+		rollingUpdate := appsapplyv1.RollingUpdateDeployment()
+		if rollingUpdateStrategy.MaxUnavailable != nil {
+			rollingUpdate = rollingUpdate.WithMaxUnavailable(*rollingUpdateStrategy.MaxUnavailable)
+		}
+
 		deployConfig = deployConfig.WithSpec(
 			deployConfig.Spec.WithStrategy(
-				deployConfig.Spec.Strategy.WithRollingUpdate(
-					deployConfig.Spec.Strategy.RollingUpdate.
-						WithMaxUnavailable(rollingUpdateStrategy.MaxUnavailable),
-				),
+				deployConfig.Spec.Strategy.WithRollingUpdate(rollingUpdate),
 			),
 		)
 	}

--- a/pkg/reconciler/instanceset_reconciler_test.go
+++ b/pkg/reconciler/instanceset_reconciler_test.go
@@ -379,8 +379,8 @@ func TestInstanceSetReconciler_constructInstanceSetApplyConfiguration(t *testing
 
 	t.Run("with rollout strategy", func(t *testing.T) {
 		rollingUpdateStrategy := &workloadsv1alpha1.RollingUpdate{
-			Partition:      ptr.To(int32(1)),
-			MaxUnavailable: intstr.FromInt32(1),
+			Partition:      ptr.To(intstr.FromInt32(1)),
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		}
 
 		role := &workloadsv1alpha1.RoleSpec{
@@ -399,8 +399,8 @@ func TestInstanceSetReconciler_constructInstanceSetApplyConfiguration(t *testing
 			RolloutStrategy: &workloadsv1alpha1.RolloutStrategy{
 				Type: workloadsv1alpha1.RollingUpdateStrategyType,
 				RollingUpdate: &workloadsv1alpha1.RollingUpdate{
-					Partition:      ptr.To(int32(2)),
-					MaxUnavailable: intstr.FromInt32(2),
+					Partition:      ptr.To(intstr.FromInt32(2)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
 				},
 			},
 		}
@@ -455,9 +455,9 @@ func TestInstanceSetReconciler_Reconciler(t *testing.T) {
 		WithWorkload(workloadsv1alpha1.InstanceSetWorkloadType).
 		WithRollingUpdate(
 			workloadsv1alpha1.RollingUpdate{
-				MaxUnavailable: intstr.FromInt32(2),
-				MaxSurge:       intstr.FromInt32(2),
-				Partition:      ptr.To(int32(1)),
+				MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+				MaxSurge:       ptr.To(intstr.FromInt32(2)),
+				Partition:      ptr.To(intstr.FromInt32(1)),
 			},
 		).Obj()
 

--- a/pkg/reconciler/sts_reconciler_test.go
+++ b/pkg/reconciler/sts_reconciler_test.go
@@ -34,9 +34,9 @@ func TestStatefulSetReconciler_Reconciler(t *testing.T) {
 	rollingRole := wrappers.BuildBasicRole("test-role").WithReplicas(4).
 		WithRollingUpdate(
 			workloadsv1alpha1.RollingUpdate{
-				MaxUnavailable: intstr.FromInt32(2),
-				MaxSurge:       intstr.FromInt32(2),
-				Partition:      ptr.To(int32(1)),
+				MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+				MaxSurge:       ptr.To(intstr.FromInt32(2)),
+				Partition:      ptr.To(intstr.FromInt32(1)),
 			},
 		).Obj()
 
@@ -445,9 +445,9 @@ func TestStatefulSetReconciler_rollingUpdateParameters(t *testing.T) {
 			rollingStrategy: &workloadsv1alpha1.RolloutStrategy{
 				Type: workloadsv1alpha1.RollingUpdateStrategyType,
 				RollingUpdate: &workloadsv1alpha1.RollingUpdate{
-					MaxUnavailable: intstr.FromInt32(2),
-					MaxSurge:       intstr.FromInt32(2),
-					Partition:      ptr.To(int32(0)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+					MaxSurge:       ptr.To(intstr.FromInt32(2)),
+					Partition:      ptr.To(intstr.FromInt32(0)),
 				},
 			},
 			sts: &appsv1.StatefulSet{
@@ -562,9 +562,9 @@ func TestStatefulSetReconciler_rollingUpdateParameters(t *testing.T) {
 			rollingStrategy: &workloadsv1alpha1.RolloutStrategy{
 				Type: workloadsv1alpha1.RollingUpdateStrategyType,
 				RollingUpdate: &workloadsv1alpha1.RollingUpdate{
-					MaxUnavailable: intstr.FromInt32(2),
-					MaxSurge:       intstr.FromInt32(2),
-					Partition:      ptr.To(int32(0)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+					MaxSurge:       ptr.To(intstr.FromInt32(2)),
+					Partition:      ptr.To(intstr.FromInt32(0)),
 				},
 			},
 			sts: &appsv1.StatefulSet{
@@ -721,9 +721,9 @@ func TestStatefulSetReconciler_rollingUpdateParameters(t *testing.T) {
 			rollingStrategy: &workloadsv1alpha1.RolloutStrategy{
 				Type: workloadsv1alpha1.RollingUpdateStrategyType,
 				RollingUpdate: &workloadsv1alpha1.RollingUpdate{
-					MaxUnavailable: intstr.FromInt32(2),
-					MaxSurge:       intstr.FromInt32(2),
-					Partition:      ptr.To(int32(0)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+					MaxSurge:       ptr.To(intstr.FromInt32(2)),
+					Partition:      ptr.To(intstr.FromInt32(0)),
 				},
 			},
 			sts: &appsv1.StatefulSet{

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -341,7 +341,7 @@ func TestCalculatePartitionReplicas(t *testing.T) {
 		},
 		{
 			name:      "absolute partition value",
-			partition: ptrToIntStr(intstr.FromInt(5)),
+			partition: ptrToIntStr(intstr.FromInt32(5)),
 			replicas:  ptrToInt32(10),
 			expected:  5,
 		},
@@ -390,19 +390,19 @@ func TestCalculatePartitionReplicas(t *testing.T) {
 		},
 		{
 			name:      "partition exceeds replicas",
-			partition: ptrToIntStr(intstr.FromInt(15)),
+			partition: ptrToIntStr(intstr.FromInt32(15)),
 			replicas:  ptrToInt32(10),
 			expected:  10, // Clamped to replicas
 		},
 		{
 			name:      "negative partition",
-			partition: ptrToIntStr(intstr.FromInt(-5)),
+			partition: ptrToIntStr(intstr.FromInt32(-5)),
 			replicas:  ptrToInt32(10),
 			expected:  0, // Clamped to 0
 		},
 		{
 			name:      "nil replicas with absolute partition",
-			partition: ptrToIntStr(intstr.FromInt(5)),
+			partition: ptrToIntStr(intstr.FromInt32(5)),
 			replicas:  nil,
 			expected:  1,
 		},
@@ -414,7 +414,7 @@ func TestCalculatePartitionReplicas(t *testing.T) {
 		},
 		{
 			name:      "zero replicas",
-			partition: ptrToIntStr(intstr.FromInt(5)),
+			partition: ptrToIntStr(intstr.FromInt32(5)),
 			replicas:  ptrToInt32(0),
 			expected:  0,
 		},
@@ -476,7 +476,7 @@ func TestParseIntStrAsNonZero(t *testing.T) {
 		// Normal cases
 		{
 			name:     "absolute value",
-			input:    ptrToIntStr(intstr.FromInt(5)),
+			input:    ptrToIntStr(intstr.FromInt32(5)),
 			replicas: 100,
 			expected: 5,
 		},
@@ -507,13 +507,13 @@ func TestParseIntStrAsNonZero(t *testing.T) {
 		// Edge cases - should return at least 1
 		{
 			name:     "zero value should become 1",
-			input:    ptrToIntStr(intstr.FromInt(0)),
+			input:    ptrToIntStr(intstr.FromInt32(0)),
 			replicas: 100,
 			expected: 1,
 		},
 		{
 			name:     "negative value should become 1",
-			input:    ptrToIntStr(intstr.FromInt(-5)),
+			input:    ptrToIntStr(intstr.FromInt32(-5)),
 			replicas: 100,
 			expected: 1,
 		},
@@ -525,7 +525,7 @@ func TestParseIntStrAsNonZero(t *testing.T) {
 		},
 		{
 			name:     "large absolute value",
-			input:    ptrToIntStr(intstr.FromInt(1000)),
+			input:    ptrToIntStr(intstr.FromInt32(1000)),
 			replicas: 100,
 			expected: 1000,
 		},

--- a/test/e2e/testcase/deploy.go
+++ b/test/e2e/testcase/deploy.go
@@ -38,8 +38,8 @@ func RunDeploymentWorkloadTestCases(f *framework.Framework) {
 					WithReplicas(2).
 					WithWorkload(workloadsv1alpha1.DeploymentWorkloadType).
 					WithRollingUpdate(workloadsv1alpha1.RollingUpdate{
-						MaxUnavailable: intstr.FromInt32(1),
-						MaxSurge:       intstr.FromInt32(1),
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
 					}).Obj(),
 			}).Obj()
 		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())

--- a/test/e2e/testcase/lws.go
+++ b/test/e2e/testcase/lws.go
@@ -69,8 +69,8 @@ func RunLeaderWorkerSetWorkloadTestCases(f *framework.Framework) {
 				wrappers.BuildLwsRole("role-1").
 					WithReplicas(2).
 					WithRollingUpdate(workloadsv1alpha1.RollingUpdate{
-						MaxUnavailable: intstr.FromInt32(1),
-						MaxSurge:       intstr.FromInt32(1),
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
 					}).Obj(),
 			}).Obj()
 		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())

--- a/test/e2e/testcase/sts.go
+++ b/test/e2e/testcase/sts.go
@@ -38,8 +38,8 @@ func RunStatefulSetWorkloadTestCases(f *framework.Framework) {
 					WithReplicas(2).
 					WithWorkload(workloadsv1alpha1.StatefulSetWorkloadType).
 					WithRollingUpdate(workloadsv1alpha1.RollingUpdate{
-						MaxUnavailable: intstr.FromInt32(1),
-						MaxSurge:       intstr.FromInt32(1),
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
 					}).Obj(),
 			}).Obj()
 		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())

--- a/test/wrappers/role_wrapper.go
+++ b/test/wrappers/role_wrapper.go
@@ -33,7 +33,7 @@ func (roleWrapper *RoleWrapper) WithMaxUnavailable(value int32) *RoleWrapper {
 	if roleWrapper.RolloutStrategy.RollingUpdate == nil {
 		roleWrapper.RolloutStrategy.RollingUpdate = &workloadsv1alpha.RollingUpdate{}
 	}
-	roleWrapper.RolloutStrategy.RollingUpdate.MaxUnavailable = intstr.FromInt32(value)
+	roleWrapper.RolloutStrategy.RollingUpdate.MaxUnavailable = ptr.To(intstr.FromInt32(value))
 	return roleWrapper
 }
 
@@ -41,7 +41,7 @@ func (roleWrapper *RoleWrapper) WithMaxSurge(value int32) *RoleWrapper {
 	if roleWrapper.RolloutStrategy.RollingUpdate == nil {
 		roleWrapper.RolloutStrategy.RollingUpdate = &workloadsv1alpha.RollingUpdate{}
 	}
-	roleWrapper.RolloutStrategy.RollingUpdate.MaxSurge = intstr.FromInt32(value)
+	roleWrapper.RolloutStrategy.RollingUpdate.MaxSurge = ptr.To(intstr.FromInt32(value))
 	return roleWrapper
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->
Migrate type of API fields in role.rolloutStrategy.
```go
// RollingUpdate defines the parameters to be used for RollingUpdateStrategyType.
type RollingUpdate struct {
  // Migrate from:
    // Partition *int32 `json:"partition,omitempty"`
  Partition *intstr.IntOrString `json:"partition,omitempty"`

  // Migrate from:
    // MaxUnavailable intstr.IntOrString `json:"maxUnavailable,omitempty"`
  MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
    
  // Migrate from:
    // MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
  MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
}
```


### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
