### PR TITLE
fix: use GetWorkloadName for instance address generation

### DIFF
--- a/pkg/discovery/config_builder.go
+++ b/pkg/discovery/config_builder.go
@@ -95,7 +95,7 @@ func (b *ConfigBuilder) buildInstances(role *workloadsv1alpha1.RoleSpec) ([]Inst
 
 	for i := 0; i < int(*role.Replicas); i++ {
 		instance := Instance{
-			Address: fmt.Sprintf("%s-%d.%s", role.Name, i, serviceName),
+			Address: fmt.Sprintf("%s-%d.%s", b.rbg.GetWorkloadName(role), i, serviceName),
 			Ports:   make(map[string]int32),
 		}
 

--- a/pkg/discovery/config_builder_test.go
+++ b/pkg/discovery/config_builder_test.go
@@ -72,19 +72,19 @@ func TestConfigBuilder_Build(t *testing.T) {
 roles:
   leader:
     instances:
-    - address: leader-0.s-test-cluster-leader
+    - address: test-cluster-leader-0.s-test-cluster-leader
       ports:
         api: 6443
     size: 1
   worker:
     instances:
-    - address: worker-0.s-test-cluster-worker
+    - address: test-cluster-worker-0.s-test-cluster-worker
       ports:
         http: 8080
-    - address: worker-1.s-test-cluster-worker
+    - address: test-cluster-worker-1.s-test-cluster-worker
       ports:
         http: 8080
-    - address: worker-2.s-test-cluster-worker
+    - address: test-cluster-worker-2.s-test-cluster-worker
       ports:
         http: 8080
     size: 3
@@ -149,19 +149,19 @@ roles:
 roles:
   leader:
     instances:
-    - address: leader-0.test-cluster-leader
+    - address: test-cluster-leader-0.test-cluster-leader
       ports:
         api: 6443
     size: 1
   worker:
     instances:
-    - address: worker-0.test-cluster-worker
+    - address: test-cluster-worker-0.test-cluster-worker
       ports:
         http: 8080
-    - address: worker-1.test-cluster-worker
+    - address: test-cluster-worker-1.test-cluster-worker
       ports:
         http: 8080
-    - address: worker-2.test-cluster-worker
+    - address: test-cluster-worker-2.test-cluster-worker
       ports:
         http: 8080
     size: 3
@@ -205,7 +205,7 @@ roles:
 roles:
   web:
     instances:
-    - address: web-0.s-test-cluster-web
+    - address: test-cluster-web-0.s-test-cluster-web
       ports:
         port80: 80
         port443: 443
@@ -258,19 +258,19 @@ roles:
 roles:
   leader:
     instances:
-    - address: leader-0.s-1-test-cluster-leader
+    - address: 1-test-cluster-leader-0.s-1-test-cluster-leader
       ports:
         api: 6443
     size: 1
   worker:
     instances:
-    - address: worker-0.s-1-test-cluster-worker
+    - address: 1-test-cluster-worker-0.s-1-test-cluster-worker
       ports:
         http: 8080
-    - address: worker-1.s-1-test-cluster-worker
+    - address: 1-test-cluster-worker-1.s-1-test-cluster-worker
       ports:
         http: 8080
-    - address: worker-2.s-1-test-cluster-worker
+    - address: 1-test-cluster-worker-2.s-1-test-cluster-worker
       ports:
         http: 8080
     size: 3
@@ -590,8 +590,8 @@ func TestConfigBuilder_buildInstances(t *testing.T) {
 	}
 
 	// Verify first instance
-	if instances[0].Address != "server-0.s-test-cluster-server" {
-		t.Errorf("Expected address 's-server-0.test-cluster-server', got '%s'", instances[0].Address)
+	if instances[0].Address != "test-cluster-server-0.s-test-cluster-server" {
+		t.Errorf("Expected address 'test-cluster-server-0.test-cluster-server', got '%s'", instances[0].Address)
 	}
 
 	if len(instances[0].Ports) != 2 {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->
before
```yaml
    roles:
      lws:
        instances:
        - address: lws-0.s-rbg-with-lws-workload-lws
        size: 1
      sts:
        instances:
        - address: sts-0.s-rbg-with-lws-workload-sts
        size: 1
```
after
```yaml
    roles:
      lws:
        instances:
        - address: rbg-with-lws-workload-lws-0.s-rbg-with-lws-workload-lws
        size: 1
      sts:
        instances:
        - address: rbg-with-lws-workload-sts-0.s-rbg-with-lws-workload-sts
        size: 1
```
actual pod template
``` yaml
hostname: rbg-with-lws-workload-lws-0
```

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
