### PR TITLE
fix: avoid duplicate --platform argument in docker-buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,8 @@ docker-push: ${DOCKER_PUSH}
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross if not already present
+	awk '/^FROM[[:space:]]+/ && !/^[[:space:]]*FROM[[:space:]]+--platform/ {sub(/^FROM/, "FROM --platform=$${BUILDPLATFORM}")} {print}' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name rbgs-builder
 	$(CONTAINER_TOOL) buildx use rbgs-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${RBG_CONTROLLER_IMG}:${TAG} -f Dockerfile.cross .


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
Fix the issue where docker-buildx target adds duplicate --platform argument when Dockerfile already contains it. Add a check to detect if Dockerfile already has --platform parameter before inserting it.

This resolves the build error: "duplicate flag specified: --platform" that occurs when running make docker-buildx.


### Ⅱ. Modifications

Modify Makefile: Check if the Dockerfile already contains the --platform parameter before insertion to avoid duplicate additions.

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #136

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No unit tests are needed for this change.

### Ⅴ. Describe how to verify it
run  `make docker-buildx`

### VI. Special notes for reviews

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
