### PR TITLE
Introduce pipeline-based reconciliation for RoleBasedGroup

### DIFF
--- a/internal/controller/workloads/data.go
+++ b/internal/controller/workloads/data.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/pkg/dependency"
+	"sigs.k8s.io/rbgs/pkg/reconciler"
+)
+
+// ReconcileData holds the data required during the reconciliation process of a RoleBasedGroup.
+// It encapsulates both input (read-only) and intermediate (mutable) state used across reconciliation steps.
+type ReconcileData struct {
+	// readOnly
+	rbg               *workloadsv1alpha1.RoleBasedGroup
+	dependencyManager *dependency.DefaultDependencyManager
+
+	// Mutable intermediate results computed and updated during reconciliation.
+	expectedRolesRevisionHash map[string]string
+	sortedRoles               [][]*workloadsv1alpha1.RoleSpec
+	roleStatuses              []workloadsv1alpha1.RoleStatus
+	// ScalingTargets            map[string]int32
+	rollingUpdateStrategies map[string]workloadsv1alpha1.RollingUpdate
+	// needUpdateStatus          *bool
+	roleReconciler map[string]reconciler.WorkloadReconciler
+}
+
+// NewReconcileData creates and initializes a new ReconcileData instance.
+// It takes a RoleBasedGroup (rbg) and a dependency manager (dm) as required inputs.
+func NewReconcileData(rbg *workloadsv1alpha1.RoleBasedGroup, dm *dependency.DefaultDependencyManager) *ReconcileData {
+	return &ReconcileData{
+		rbg:               rbg,
+		dependencyManager: dm,
+	}
+}
+
+// GetRBG returns the RoleBasedGroup being reconciled.
+// The returned pointer should not be mutated.
+func (rd *ReconcileData) GetRBG() *workloadsv1alpha1.RoleBasedGroup {
+	return rd.rbg
+}
+
+// GetDependencyManager returns the dependency manager used for external interactions.
+func (rd *ReconcileData) GetDependencyManager() *dependency.DefaultDependencyManager {
+	return rd.dependencyManager
+}
+
+// GetSortedRoles returns the current grouping of roles into ordered batches.
+// The structure enables phased or dependency-aware reconciliation.
+func (rd *ReconcileData) GetSortedRoles() [][]*workloadsv1alpha1.RoleSpec {
+	return rd.sortedRoles
+}
+
+// SetSortedRoles sets the sortedRoles field, typically after dependency analysis or topological sorting.
+func (rd *ReconcileData) SetSortedRoles(sortedRoles [][]*workloadsv1alpha1.RoleSpec) {
+	rd.sortedRoles = sortedRoles
+}
+
+// SetRoleStatuses updates the roleStatuses slice with the latest reconciliation outcomes.
+func (rd *ReconcileData) SetRoleStatuses(roleStatuses []workloadsv1alpha1.RoleStatus) {
+	rd.roleStatuses = roleStatuses
+}
+
+// GetRoleStatuses returns the current list of role statuses, intended for status update.
+func (rd *ReconcileData) GetRoleStatuses() []workloadsv1alpha1.RoleStatus {
+	return rd.roleStatuses
+}
+
+// GetRollingUpdateStrategies returns the map of rolling update strategies keyed by role name.
+func (rd *ReconcileData) GetRollingUpdateStrategies() map[string]workloadsv1alpha1.RollingUpdate {
+	return rd.rollingUpdateStrategies
+}
+
+// SetRollingUpdateStrategies sets the rolling update strategies for each role.
+func (rd *ReconcileData) SetRollingUpdateStrategies(rollingUpdateStrategies map[string]workloadsv1alpha1.RollingUpdate) {
+	rd.rollingUpdateStrategies = rollingUpdateStrategies
+}
+
+func (rd *ReconcileData) SetExpectedRolesRevisionHash(hash map[string]string) {
+	rd.expectedRolesRevisionHash = hash
+}
+
+func (rd *ReconcileData) GetExpectedRolesRevisionHash() map[string]string {
+	return rd.expectedRolesRevisionHash
+}
+
+func (rd *ReconcileData) SetRoleReconcilers(reconcilers map[string]reconciler.WorkloadReconciler) {
+	rd.roleReconciler = reconcilers
+}
+
+func (rd *ReconcileData) GetRoleReconcilers() map[string]reconciler.WorkloadReconciler {
+	return rd.roleReconciler
+}

--- a/internal/controller/workloads/pipeline.go
+++ b/internal/controller/workloads/pipeline.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ReconcileStep 管道步骤接口
+type ReconcileStep interface {
+	Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error)
+	Name() string
+}
+
+// Pipeline 管道执行器
+type Pipeline struct {
+	steps []ReconcileStep
+}
+
+func NewPipeline(steps ...ReconcileStep) *Pipeline {
+	return &Pipeline{steps: steps}
+}
+
+func (p *Pipeline) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	for _, step := range p.steps {
+		logger.Info("Executing pipeline step", "step", step.Name())
+		result, err := step.Execute(ctx, data)
+		if err != nil {
+			logger.Error(err, "Pipeline step failed", "step", step.Name())
+			return result, err
+		}
+		if result.RequeueAfter > 0 {
+			logger.Info("Pipeline step requested requeue",
+				"step", step.Name(),
+				"requeueAfter", result.RequeueAfter)
+			return result, nil
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/pipeline.go
+++ b/internal/controller/workloads/pipeline.go
@@ -23,13 +23,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// ReconcileStep 管道步骤接口
+// ReconcileStep defines the interface for a step in the reconciliation pipeline.
 type ReconcileStep interface {
 	Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error)
 	Name() string
 }
 
-// Pipeline 管道执行器
+// Pipeline executes a series of reconciliation steps in order.
 type Pipeline struct {
 	steps []ReconcileStep
 }

--- a/internal/controller/workloads/step_cleanup.go
+++ b/internal/controller/workloads/step_cleanup.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/rbgs/pkg/utils"
+)
+
+type CleanupStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (c *CleanupStep) Name() string { return "cleanup" }
+func (c *CleanupStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	// delete orphan roles
+	rbg := data.GetRBG()
+	if err := c.deleteOrphanRoles(ctx, rbg); err != nil {
+		c.recorder.Eventf(
+			rbg, corev1.EventTypeWarning, "delete role error",
+			"Failed to delete roles for %s: %v", rbg.Name, err,
+		)
+		return ctrl.Result{}, err
+	}
+
+	// delete expired controllerRevision
+	if _, err := utils.CleanExpiredRevision(ctx, c.client, rbg); err != nil {
+		c.recorder.Eventf(
+			rbg, corev1.EventTypeWarning, "delete expired revision error",
+			"Failed to delete expired revision for %s: %v", rbg.Name, err,
+		)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_coordination.go
+++ b/internal/controller/workloads/step_coordination.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type CoordinationStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (c *CoordinationStep) Name() string { return "coordination" }
+func (c *CoordinationStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	rbg := data.GetRBG()
+	roleStatuses := data.GetRoleStatuses()
+	rollingUpdateStrategies, err := c.CalculateRollingUpdateForAllCoordination(rbg, roleStatuses)
+	if err != nil {
+		c.recorder.Eventf(
+			rbg, corev1.EventTypeWarning, FailedUpdateStatus,
+			"Failed to update status for %s: %v", rbg.Name, err,
+		)
+		return ctrl.Result{}, err
+	}
+	data.SetRollingUpdateStrategies(rollingUpdateStrategies)
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_dependency.go
+++ b/internal/controller/workloads/step_dependency.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type DependencyStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (s *DependencyStep) Name() string { return "dependency" }
+
+func (s *DependencyStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	dependencyManager := data.GetDependencyManager()
+	sortedRoles, err := dependencyManager.SortRoles(ctx, data.GetRBG())
+	if err != nil {
+		s.recorder.Event(data.GetRBG(), corev1.EventTypeWarning, InvalidRoleDependency, err.Error())
+		return ctrl.Result{}, err
+	}
+	data.SetSortedRoles(sortedRoles)
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_podgroup.go
+++ b/internal/controller/workloads/step_podgroup.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/rbgs/pkg/scheduler"
+)
+
+type PodGroupStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (p *PodGroupStep) Name() string { return "podGroup" }
+
+func (p *PodGroupStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	podGroupManager := scheduler.NewPodGroupScheduler(p.client)
+	if err := podGroupManager.Reconcile(ctx, data.GetRBG(), runtimeController, &watchedWorkload, p.apiReader); err != nil {
+		p.recorder.Event(data.GetRBG(), corev1.EventTypeWarning, FailedCreatePodGroup, err.Error())
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_reconcile_roles.go
+++ b/internal/controller/workloads/step_reconcile_roles.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+
+	"github.com/modern-go/reflect2"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+)
+
+type ReconcileRolesStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (r *ReconcileRolesStep) Name() string { return "reconcileRoles" }
+func (r *ReconcileRolesStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	// Reconcile roles, do create/update actions for roles.
+	sortedRoles := data.GetSortedRoles()
+	rbg := data.GetRBG()
+	dependencyManager := data.GetDependencyManager()
+	for _, roleList := range sortedRoles {
+		var errs error
+
+		for _, role := range roleList {
+			logger := log.FromContext(ctx)
+			roleCtx := log.IntoContext(ctx, logger.WithValues("role", role.Name))
+
+			// Check dependencies first
+			ready, err := dependencyManager.CheckDependencyReady(roleCtx, rbg, role)
+			if err != nil {
+				r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCheckRoleDependency, err.Error())
+				return ctrl.Result{}, err
+			}
+			if !ready {
+				err := fmt.Errorf("dependencies not met for role '%s'", role.Name)
+				r.recorder.Event(rbg, corev1.EventTypeWarning, DependencyNotMet, err.Error())
+				return ctrl.Result{}, err
+			}
+
+			reconciler, ok := data.roleReconciler[role.Name]
+			if !ok || reflect2.IsNil(reconciler) {
+				err = fmt.Errorf("workload reconciler not found")
+				logger.Error(err, "Failed to get workload reconciler")
+				r.recorder.Eventf(
+					rbg, corev1.EventTypeWarning, FailedReconcileWorkload,
+					"Failed to reconcile role %s: %v", role.Name, err,
+				)
+				errs = stderrors.Join(errs, err)
+				continue
+			}
+
+			var rollingUpdateStrategy *workloadsv1alpha1.RollingUpdate
+			rollingUpdateStrategies := data.GetRollingUpdateStrategies()
+			if rollout, ok := rollingUpdateStrategies[role.Name]; ok {
+				rollingUpdateStrategy = &rollout
+			}
+
+			expectedRolesRevisionHash := data.GetExpectedRolesRevisionHash()
+			if err := reconciler.Reconciler(roleCtx, rbg, role, rollingUpdateStrategy, expectedRolesRevisionHash[role.Name]); err != nil {
+				logger.Error(err, "Failed to reconcile workload")
+				r.recorder.Eventf(
+					rbg, corev1.EventTypeWarning, FailedReconcileWorkload,
+					"Failed to reconcile role %s: %v", role.Name, err,
+				)
+				errs = stderrors.Join(errs, err)
+				continue
+			}
+
+			if err := r.ReconcileScalingAdapter(roleCtx, rbg, role); err != nil {
+				logger.Error(err, "Failed to reconcile scaling adapter")
+				r.recorder.Eventf(
+					rbg, corev1.EventTypeWarning, FailedCreateScalingAdapter,
+					"Failed to reconcile scaling adapter for role %s: %v", role.Name, err,
+				)
+				errs = stderrors.Join(errs, err)
+				continue
+			}
+		}
+
+		if errs != nil {
+			return ctrl.Result{}, errs
+		}
+	}
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_reconcile_roles.go
+++ b/internal/controller/workloads/step_reconcile_roles.go
@@ -57,7 +57,7 @@ func (r *ReconcileRolesStep) Execute(ctx context.Context, data *ReconcileData) (
 				return ctrl.Result{}, err
 			}
 
-			reconciler, ok := data.roleReconciler[role.Name]
+			reconciler, ok := data.GetRoleReconcilers()[role.Name]
 			if !ok || reflect2.IsNil(reconciler) {
 				err = fmt.Errorf("workload reconciler not found")
 				logger.Error(err, "Failed to get workload reconciler")

--- a/internal/controller/workloads/step_revision.go
+++ b/internal/controller/workloads/step_revision.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/pkg/utils"
+)
+
+type RevisionStep struct {
+	// client client.Client
+	*RoleBasedGroupReconciler
+}
+
+func (s *RevisionStep) Name() string { return "revision" }
+
+func (s *RevisionStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	revisionHash, err := s.handleRevisions(ctx, data.GetRBG())
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// data.expectedRolesRevisionHash = revisionHash
+	data.SetExpectedRolesRevisionHash(revisionHash)
+	return ctrl.Result{}, nil
+}
+
+func (r *RoleBasedGroupReconciler) handleRevisions(ctx context.Context, rbg *workloadsv1alpha1.RoleBasedGroup) (map[string]string, error) {
+	logger := log.FromContext(ctx)
+
+	currentRevision, err := r.getCurrentRevision(ctx, rbg)
+	if err != nil {
+		logger.Error(err, "Failed get or create revision")
+		return nil, err
+	}
+
+	expectedRevision, err := utils.NewRevision(ctx, r.client, rbg, currentRevision)
+	if err != nil {
+		return nil, err
+	}
+
+	if !utils.EqualRevision(currentRevision, expectedRevision) {
+		logger.Info("Current revision need to be updated")
+		if err := r.client.Create(ctx, expectedRevision); err != nil {
+			logger.Error(err, fmt.Sprintf("Failed to create revision %v", expectedRevision))
+			r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCreateRevision, "Failed create revision for RoleBasedGroup")
+			return nil, err
+		} else {
+			logger.Info(fmt.Sprintf("Create revision [%s] successfully", expectedRevision.Name))
+			r.recorder.Event(rbg, corev1.EventTypeNormal, SucceedCreateRevision, "Successful create revision for RoleBasedGroup")
+		}
+	}
+
+	expectedRolesRevisionHash, err := utils.GetRolesRevisionHash(expectedRevision)
+	if err != nil {
+		logger.Error(err, "Failed to get roles revision hash")
+		return nil, err
+	}
+
+	return expectedRolesRevisionHash, nil
+}

--- a/internal/controller/workloads/step_rolestatus.go
+++ b/internal/controller/workloads/step_rolestatus.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	"sigs.k8s.io/rbgs/pkg/reconciler"
+)
+
+// role_status_step.go
+type RoleStatusStep struct {
+	*RoleBasedGroupReconciler
+}
+
+func (r *RoleStatusStep) Name() string { return "roleStatus" }
+
+func (r *RoleStatusStep) Execute(ctx context.Context, data *ReconcileData) (ctrl.Result, error) {
+	rbg := data.GetRBG()
+
+	var updateStatus bool
+	roleStatuses := make([]workloadsv1alpha1.RoleStatus, 0, len(rbg.Spec.Roles))
+	data.roleReconciler = make(map[string]reconciler.WorkloadReconciler)
+	for _, role := range rbg.Spec.Roles {
+		logger := log.FromContext(ctx)
+		roleCtx := log.IntoContext(ctx, logger.WithValues("role", role.Name))
+		// first check whether watch lws cr
+		dynamicWatchCustomCRD(roleCtx, role.Workload.Kind)
+
+		reconciler, err := reconciler.NewWorkloadReconciler(role.Workload, r.scheme, r.client)
+		if err != nil {
+			logger.Error(err, "Failed to create workload reconciler")
+			r.recorder.Eventf(
+				rbg, corev1.EventTypeWarning, FailedReconcileWorkload,
+				"Failed to reconcile role %s, err: %v", role.Name, err,
+			)
+			return ctrl.Result{}, err
+		}
+
+		if err := reconciler.Validate(ctx, &role); err != nil {
+			logger.Error(err, "Failed to validate role declaration")
+			r.recorder.Eventf(
+				rbg, corev1.EventTypeWarning, FailedReconcileWorkload,
+				"Failed to validate role %s declaration, err: %v", role.Name, err,
+			)
+			return ctrl.Result{}, err
+		}
+
+		data.roleReconciler[role.Name] = reconciler
+
+		roleStatus, updateRoleStatus, err := reconciler.ConstructRoleStatus(roleCtx, rbg, &role)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.recorder.Eventf(
+					rbg, corev1.EventTypeWarning, FailedReconcileWorkload,
+					"Failed to construct role %s status: %v", role.Name, err,
+				)
+				return ctrl.Result{}, err
+			}
+		}
+		updateStatus = updateStatus || updateRoleStatus
+		roleStatuses = append(roleStatuses, roleStatus)
+	}
+
+	data.SetRoleStatuses(roleStatuses)
+	// data.needUpdateStatus = &updateStatus
+
+	// Update the status based on the observed role statuses.
+	if updateStatus {
+		if err := r.updateRBGStatus(ctx, rbg, data.GetRoleStatuses()); err != nil {
+			r.recorder.Eventf(
+				rbg, corev1.EventTypeWarning, FailedUpdateStatus,
+				"Failed to update status for %s: %v", rbg.Name, err,
+			)
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/workloads/step_rolestatus.go
+++ b/internal/controller/workloads/step_rolestatus.go
@@ -39,7 +39,7 @@ func (r *RoleStatusStep) Execute(ctx context.Context, data *ReconcileData) (ctrl
 
 	var updateStatus bool
 	roleStatuses := make([]workloadsv1alpha1.RoleStatus, 0, len(rbg.Spec.Roles))
-	data.roleReconciler = make(map[string]reconciler.WorkloadReconciler)
+	data.SetRoleReconcilers(make(map[string]reconciler.WorkloadReconciler))
 	for _, role := range rbg.Spec.Roles {
 		logger := log.FromContext(ctx)
 		roleCtx := log.IntoContext(ctx, logger.WithValues("role", role.Name))

--- a/pkg/utils/rbg_utils.go
+++ b/pkg/utils/rbg_utils.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+)
+
+func GetRBG(ctx context.Context, client client.Client, key types.NamespacedName) (rbg *workloadsv1alpha1.RoleBasedGroup, err error) {
+	rbg = &workloadsv1alpha1.RoleBasedGroup{}
+	err = client.Get(ctx, key, rbg)
+	return rbg, err
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
The `RoleBasedGroupReconciler.Reconcile` function had become a large, monolithic block of logic that mixed multiple concerns—revision handling, dependency resolution, status construction, role reconciliation, and cleanup—making it hard to read, test, and maintain. This PR refactors the reconciler into a clean, extensible pipeline architecture where each step has a single responsibility. This improves code clarity, enables easier testing of individual components, and provides a structured way to add new reconciliation logic in the future.

### Ⅱ. Modifications
- Introduced `ReconcileData` (`internal/controller/workloads/data.go`) to encapsulate shared state across reconciliation steps.
- Implemented a generic `Pipeline` executor (`pipeline.go`) that runs `ReconcileStep` implementations in sequence and supports early termination on error or requeue.
- Extracted the original reconciler logic into seven focused steps:
  - `RevisionStep`: manages controller revisions and computes role revision hashes.
  - `DependencyStep`: sorts roles based on dependency order.
  - `PodGroupStep`: handles PodGroup scheduling.
  - `RoleStatusStep`: validates workloads, constructs role statuses, and updates RBG status if needed.
  - `CoordinationStep`: calculates rolling update strategies for all roles.
  - `ReconcileRolesStep`: reconciles each role (create/update) respecting dependencies and applying rolling updates.
  - `CleanupStep`: deletes orphaned roles and expired controller revisions.
- Updated `RoleBasedGroupReconciler.Reconcile` to:
  - Use a new utility `utils.GetRBG` to fetch the RBG resource with consistent error handling.
  - Initialize `ReconcileData` and execute the pipeline.
  - Record a single success/failure event at the end based on pipeline outcome.
- Added `GetRBG` utility in `pkg/utils/rbg_utils.go` to centralize RBG fetching logic.
- Removed unused imports (`stderrors`, `reflect2`) from the main controller file.

### Ⅲ. Does this pull request fix one issue?
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new test cases are added in this PR. The changes are purely structural (refactoring) and do not alter existing behavior. Existing unit and integration tests should continue to pass, ensuring correctness. However, future PRs should add unit tests for individual pipeline steps to improve test coverage.

### Ⅴ. Describe how to verify it
- Run `make test` to ensure all existing unit and integration tests pass.
- Deploy the controller and create/update/delete `RoleBasedGroup` resources to verify end-to-end reconciliation behaves as before (e.g., roles are created in dependency order, status is updated correctly, cleanup occurs as expected).
- Check controller logs and events to confirm successful reconciliation or proper error reporting.

### VI. Special notes for reviews
- This is a pure refactoring PR; no functional changes are intended.
- Pay attention to data flow in `ReconcileData`—ensure all necessary fields are properly set by earlier steps and consumed by later ones.
- Note that `roleReconciler` and `expectedRolesRevisionHash` in `ReconcileData` are currently unexported but accessed directly in `ReconcileRolesStep`. Consider whether to add getters/setters if this pattern becomes common, though it’s acceptable for internal use within the same package.
- The pipeline stops on the first error or requeue signal, matching the original behavior.

## Checklist

- [x] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.