### PR TITLE
fix(rbgsa-controller): use time.Second for RequeueAfter durations

### DIFF
--- a/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
+++ b/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -131,7 +132,7 @@ func (r *RoleBasedGroupScalingAdapterReconciler) Reconcile(ctx context.Context, 
 			}
 		}
 		// TODO: currently reconcile unbound adapter by a default reconcile interval, need to implement a rbg event-driven manager
-		return ctrl.Result{RequeueAfter: 10}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// add owner reference
@@ -139,7 +140,7 @@ func (r *RoleBasedGroupScalingAdapterReconciler) Reconcile(ctx context.Context, 
 		if err := r.UpdateAdapterOwnerReference(ctx, rbgScalingAdapter, rbg); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: 1}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	// check scale target exist succeed, init adapter status with phase bound, selector and initial replicas
@@ -182,7 +183,7 @@ func (r *RoleBasedGroupScalingAdapterReconciler) Reconcile(ctx context.Context, 
 			rbgScalingAdapter, corev1.EventTypeNormal, SuccessfulBound,
 			"Succeed to find scale target role [%s] of rbg [%s]", targetRoleName, rbgName,
 		)
-		return ctrl.Result{RequeueAfter: 1}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	desiredReplicas, currentReplicas := rbgScalingAdapter.Spec.Replicas, targetRole.Replicas

--- a/internal/controller/workloads/rolebasedgroupscalingadapter_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroupscalingadapter_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,21 +110,34 @@ func TestRoleBasedGroupScalingAdapterReconciler_Reconcile(t *testing.T) {
 		},
 	}
 
+	// Create an adapter referencing a role that doesn't exist in the RBG, to test the unbound (10s) requeue path
+	unboundRbgSA := rbgsa.DeepCopy()
+	unboundRbgSA.Spec.ScaleTargetRef.Role = "non-existent-role"
+
 	// Define test cases
 	tests := []struct {
-		name             string
-		client           client.Client
-		expectError      bool
-		expectRequeue    bool
-		expectedPhase    constants.AdapterPhase
-		expectedReplicas *int32
+		name                 string
+		client               client.Client
+		expectError          bool
+		expectRequeue        bool
+		expectedRequeueAfter time.Duration
+		expectedPhase        constants.AdapterPhase
+		expectedReplicas     *int32
 	}{
 		{
-			name:          "adapter bound successfully",
-			client:        fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(rbgsa, rbg, sts).Build(),
-			expectError:   false,
-			expectRequeue: true,
-			expectedPhase: constants.AdapterPhaseBound,
+			name:                 "adapter bound successfully",
+			client:               fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(rbgsa, rbg, sts).Build(),
+			expectError:          false,
+			expectRequeue:        true,
+			expectedRequeueAfter: 1 * time.Second,
+			expectedPhase:        constants.AdapterPhaseBound,
+		},
+		{
+			name:                 "unbound adapter with missing role requeues after 10s",
+			client:               fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(unboundRbgSA, rbg, sts).Build(),
+			expectError:          false,
+			expectRequeue:        true,
+			expectedRequeueAfter: 10 * time.Second,
 		},
 		{
 			name: "bounded adapter scales role replicas",
@@ -182,6 +196,10 @@ func TestRoleBasedGroupScalingAdapterReconciler_Reconcile(t *testing.T) {
 
 				if tt.expectRequeue {
 					assert.True(t, result.RequeueAfter > 0)
+					if tt.expectedRequeueAfter > 0 {
+						assert.Equal(t, tt.expectedRequeueAfter, result.RequeueAfter,
+							"expected RequeueAfter to be %v, got %v", tt.expectedRequeueAfter, result.RequeueAfter)
+					}
 				} else {
 					assert.False(t, result.RequeueAfter > 0)
 					assert.Equal(t, int64(0), int64(result.RequeueAfter))


### PR DESCRIPTION
## Summary
- `RequeueAfter: 1` and `RequeueAfter: 10` use bare integers which are nanoseconds, not seconds, causing a hot reconcile loop
- Changed to `1 * time.Second` and `10 * time.Second` (3 occurrences)
- Added test case for the unbound adapter 10s requeue path and exact duration assertions

## Test plan
- [x] Unit tests added asserting exact `time.Duration` values (`1 * time.Second`, `10 * time.Second`)
- [x] New "unbound adapter with missing role requeues after 10s" test case
- [x] All existing tests pass