### PR TITLE
fix(rbg-controller): watch owned RoleBasedGroupScalingAdapter resources

### DIFF
--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -886,7 +886,7 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(WorkloadPredicate())).
 		Owns(&workloadsv1alpha2.RoleInstanceSet{}, builder.WithPredicates(WorkloadPredicate())).
 		Owns(&corev1.Service{}).
-		Owns(&workloadsv1alpha2.RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner).
+		Owns(&workloadsv1alpha2.RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner, builder.WithPredicates(RBGScalingAdapterPredicate())).
 		Named("workloads-rolebasedgroup")
 
 	err := utils.CheckCrdExists(r.apiReader, utils.LwsCrdName)

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -703,6 +703,10 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter(t *testing.T) {
 	_ = workloadsv1alpha2.AddToScheme(testScheme)
 
 	rbg := &workloadsv1alpha2.RoleBasedGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "workloads.x-k8s.io/v1alpha2",
+			Kind:       "RoleBasedGroup",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-rbg",
 			Namespace: "default",
@@ -784,16 +788,21 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter(t *testing.T) {
 					} else {
 						// Verify the adapter has an owner reference to the RBG,
 						// which is required for .Owns() watch to trigger reconciliation.
-						if len(adapter.OwnerReferences) == 0 {
-							t.Error("Expected adapter to have owner references, got none")
-						} else {
-							ownerRef := adapter.OwnerReferences[0]
-							if ownerRef.Name != rbg.Name {
-								t.Errorf("Expected owner ref name %q, got %q", rbg.Name, ownerRef.Name)
+						var found bool
+						for _, ref := range adapter.OwnerReferences {
+							if ref.Name == rbg.Name && ref.UID == rbg.UID {
+								found = true
+								if ref.APIVersion != rbg.APIVersion {
+									t.Errorf("Expected owner ref APIVersion %q, got %q", rbg.APIVersion, ref.APIVersion)
+								}
+								if ref.Kind != rbg.Kind {
+									t.Errorf("Expected owner ref Kind %q, got %q", rbg.Kind, ref.Kind)
+								}
+								break
 							}
-							if ownerRef.UID != rbg.UID {
-								t.Errorf("Expected owner ref UID %q, got %q", rbg.UID, ownerRef.UID)
-							}
+						}
+						if !found {
+							t.Errorf("Expected owner reference with Name=%q UID=%q, got %v", rbg.Name, rbg.UID, adapter.OwnerReferences)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- Add `.Owns(&RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner)` to the RBG controller's `SetupWithManager`
- Without this, if an RBGSA is manually deleted, the RBG controller won't notice until its next unrelated reconcile
- Uses `MatchEveryOwner` because RBGSA owner references don't set `Controller: true`, so the default `.Owns()` would silently never trigger

## Test plan
- [x] Extended "Create scaling adapter when not exists" test to verify owner reference correctness (name + UID)
- [x] All existing tests pass