### PR TITLE
Security issue: unsafe json string in pulling job's annotations; unsa…

### DIFF
--- a/cmd/cli/cmd/llm/benchmark/benchmark.go
+++ b/cmd/cli/cmd/llm/benchmark/benchmark.go
@@ -40,6 +40,7 @@ const (
 	defaultMemoryRequest     = "2Gi"
 	defaultTask              = "text-to-text"
 	defaultAPIKey            = "rbg"
+	defaultAPIPort           = 8000
 	defaultMaxTimePerRun     = 15
 	defaultMaxRequestsPerRun = 100
 )
@@ -56,6 +57,7 @@ type BenchmarkOptions struct {
 
 	apiBackend   string
 	apiBase      string
+	apiPort      int
 	apiKey       string
 	apiModelName string
 
@@ -88,6 +90,7 @@ type BenchmarkConfig struct {
 
 	APIBackend   string `json:"apiBackend,omitempty"`
 	APIBase      string `json:"apiBase,omitempty"`
+	APIPort      *int   `json:"apiPort,omitempty"`
 	APIKey       string `json:"apiKey,omitempty"`
 	APIModelName string `json:"apiModelName,omitempty"`
 
@@ -131,6 +134,7 @@ func NewBenchmarkRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 		cf:                cf,
 		task:              defaultTask,
 		apiKey:            defaultAPIKey,
+		apiPort:           defaultAPIPort,
 		maxTimePerRun:     defaultMaxTimePerRun,
 		maxRequestsPerRun: defaultMaxRequestsPerRun,
 		image:             defaultBenchmarkImage,
@@ -170,6 +174,7 @@ version management.`,
 
 	cmd.Flags().StringVar(&benchmarkOpts.apiBackend, "api-backend", benchmarkOpts.apiBackend, "API backend type (overrides auto-discovered value)")
 	cmd.Flags().StringVar(&benchmarkOpts.apiBase, "api-base", benchmarkOpts.apiBase, "Base URL for the model serving API (overrides auto-discovered value)")
+	cmd.Flags().IntVar(&benchmarkOpts.apiPort, "api-port", benchmarkOpts.apiPort, "Port for the model serving API (used when auto-generating api-base)")
 	cmd.Flags().StringVar(&benchmarkOpts.apiKey, "api-key", benchmarkOpts.apiKey, "API key used to call the model serving API")
 	cmd.Flags().StringVar(&benchmarkOpts.apiModelName, "api-model-name", benchmarkOpts.apiModelName, "Model name used by the backend (overrides auto-discovered value)")
 
@@ -252,7 +257,7 @@ func getConflictingFlags(cmd *cobra.Command) []string {
 	parameterFlags := []string{
 		"task", "max-time-per-run", "max-requests-per-run",
 		"traffic-scenario", "num-concurrency",
-		"api-backend", "api-base", "api-key", "api-model-name",
+		"api-backend", "api-base", "api-port", "api-key", "api-model-name",
 		"model-tokenizer",
 		"experiment-base-dir", "experiment-folder-name",
 		"image", "cpu-request", "cpu-limit", "memory-request", "memory-limit",
@@ -277,6 +282,7 @@ func applyConfigToOptions(cfg *BenchmarkConfig, cmd *cobra.Command) {
 	setIntSliceOpt(&benchmarkOpts.numConcurrency, cfg.NumConcurrency, "num-concurrency", cmd)
 	setStringOpt(&benchmarkOpts.apiBackend, cfg.APIBackend, "api-backend", cmd)
 	setStringOpt(&benchmarkOpts.apiBase, cfg.APIBase, "api-base", cmd)
+	setIntPtrOpt(&benchmarkOpts.apiPort, cfg.APIPort, "api-port", cmd)
 	setStringOpt(&benchmarkOpts.apiKey, cfg.APIKey, "api-key", cmd)
 	setStringOpt(&benchmarkOpts.apiModelName, cfg.APIModelName, "api-model-name", cmd)
 	setStringOpt(&benchmarkOpts.modelTokenizer, cfg.ModelTokenizer, "model-tokenizer", cmd)

--- a/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
+++ b/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
@@ -101,6 +101,12 @@ func (s *Server) handleExperimentRoutes(w http.ResponseWriter, r *http.Request) 
 
 	experimentName := parts[0]
 
+	// Validate experiment name to prevent path traversal
+	if !isValidName(experimentName) {
+		s.writeError(w, http.StatusBadRequest, "Invalid experiment name")
+		return
+	}
+
 	if len(parts) == 1 {
 		// GET /api/experiments/{name}
 		s.handleGetExperiment(w, r, experimentName)
@@ -171,6 +177,12 @@ func (s *Server) handleGetResult(w http.ResponseWriter, r *http.Request, experim
 		return
 	}
 
+	// Validate inputs to prevent path traversal
+	if !isValidName(experimentName) || !isValidName(fileName) {
+		s.writeError(w, http.StatusBadRequest, "Invalid experiment name or filename")
+		return
+	}
+
 	filePath := filepath.Join(s.dataDir, experimentName, fileName)
 
 	// Security check: ensure the path is within dataDir
@@ -198,6 +210,12 @@ func (s *Server) handleGetResult(w http.ResponseWriter, r *http.Request, experim
 func (s *Server) handleGetImage(w http.ResponseWriter, r *http.Request, experimentName, fileName string) {
 	if r.Method != http.MethodGet {
 		s.writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	// Validate inputs to prevent path traversal
+	if !isValidName(experimentName) || !isValidName(fileName) {
+		s.writeError(w, http.StatusBadRequest, "Invalid experiment name or filename")
 		return
 	}
 
@@ -356,7 +374,18 @@ func (s *Server) listExperiments() ([]Experiment, error) {
 
 // getExperiment returns details of a specific experiment.
 func (s *Server) getExperiment(name string) (*Experiment, error) {
+	// Validate name to prevent path traversal
+	if !isValidName(name) {
+		return nil, os.ErrNotExist
+	}
+
 	expDir := filepath.Join(s.dataDir, name)
+
+	// Security check: ensure the path is within dataDir
+	if !s.isPathSafe(expDir) {
+		return nil, os.ErrNotExist
+	}
+
 	info, err := os.Stat(expDir)
 	if err != nil {
 		return nil, err
@@ -404,7 +433,18 @@ func (s *Server) getExperiment(name string) (*Experiment, error) {
 
 // getResultSummaries returns summaries of all result files in an experiment.
 func (s *Server) getResultSummaries(experimentName string) ([]ResultSummary, error) {
+	// Validate name to prevent path traversal
+	if !isValidName(experimentName) {
+		return nil, os.ErrNotExist
+	}
+
 	expDir := filepath.Join(s.dataDir, experimentName)
+
+	// Security check: ensure the path is within dataDir
+	if !s.isPathSafe(expDir) {
+		return nil, os.ErrNotExist
+	}
+
 	entries, err := os.ReadDir(expDir)
 	if err != nil {
 		return nil, err
@@ -467,9 +507,36 @@ func (s *Server) getResultSummaries(experimentName string) ([]ResultSummary, err
 	return summaries, nil
 }
 
+// isValidName checks if the name contains only safe characters.
+// Allows: alphanumeric, hyphen, underscore, dot
+// Rejects: path separators, parent directory references, etc.
+func isValidName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	// Only allow safe characters: alphanumeric, hyphen, underscore, dot
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
+}
+
 // isPathSafe checks if the given path is within the data directory.
 func (s *Server) isPathSafe(path string) bool {
-	absPath, err := filepath.Abs(path)
+	// Clean the path to resolve .. and . segments
+	cleanPath := filepath.Clean(path)
+
+	// Reject if cleaning changed the path significantly (e.g., contained ..)
+	// This prevents path traversal attacks
+	if strings.Contains(cleanPath, "..") {
+		return false
+	}
+
+	// Get absolute paths
+	absPath, err := filepath.Abs(cleanPath)
 	if err != nil {
 		return false
 	}
@@ -477,7 +544,11 @@ func (s *Server) isPathSafe(path string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.HasPrefix(absPath, absDataDir)
+
+	// Ensure the path has the dataDir as a prefix with separator
+	// This prevents partial directory name matching
+	dataDirPrefix := absDataDir + string(filepath.Separator)
+	return strings.HasPrefix(absPath+string(filepath.Separator), dataDirPrefix)
 }
 
 // writeJSON writes a JSON response.

--- a/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
+++ b/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
@@ -183,6 +183,17 @@ func (s *Server) handleGetResult(w http.ResponseWriter, r *http.Request, experim
 		return
 	}
 
+	// Ensure only JSON result files are returned and exclude experiment metadata.
+	lowerName := strings.ToLower(fileName)
+	if !strings.HasSuffix(lowerName, ".json") {
+		s.writeError(w, http.StatusBadRequest, "Only JSON result files can be requested")
+		return
+	}
+	if strings.EqualFold(fileName, "experiment_metadata.json") {
+		s.writeError(w, http.StatusForbidden, "Access to experiment metadata is not allowed")
+		return
+	}
+
 	filePath := filepath.Join(s.dataDir, experimentName, fileName)
 
 	// Security check: ensure the path is within dataDir
@@ -198,6 +209,13 @@ func (s *Server) handleGetResult(w http.ResponseWriter, r *http.Request, experim
 			return
 		}
 		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to read result: %v", err))
+		return
+	}
+
+	// Validate that the content is valid JSON
+	var jsonData interface{}
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		s.writeError(w, http.StatusBadRequest, "Invalid JSON content in result file")
 		return
 	}
 
@@ -219,6 +237,16 @@ func (s *Server) handleGetImage(w http.ResponseWriter, r *http.Request, experime
 		return
 	}
 
+	// Validate that the file has an image extension
+	ext := strings.ToLower(filepath.Ext(fileName))
+	switch ext {
+	case extPNG, extJPG, extJPEG, extGIF, extSVG:
+		// Allowed image extensions
+	default:
+		s.writeError(w, http.StatusBadRequest, "Invalid image format. Only png, jpg, jpeg, gif, svg are allowed")
+		return
+	}
+
 	filePath := filepath.Join(s.dataDir, experimentName, fileName)
 
 	// Security check
@@ -229,7 +257,6 @@ func (s *Server) handleGetImage(w http.ResponseWriter, r *http.Request, experime
 
 	// Determine content type
 	contentType := "application/octet-stream"
-	ext := strings.ToLower(filepath.Ext(fileName))
 	switch ext {
 	case extPNG:
 		contentType = "image/png"
@@ -525,6 +552,7 @@ func isValidName(name string) bool {
 }
 
 // isPathSafe checks if the given path is within the data directory.
+// It resolves symlinks before checking containment to prevent symlink-based path traversal attacks.
 func (s *Server) isPathSafe(path string) bool {
 	// Clean the path to resolve .. and . segments
 	cleanPath := filepath.Clean(path)
@@ -539,10 +567,48 @@ func (s *Server) isPathSafe(path string) bool {
 		return false
 	}
 
-	// Ensure the path has the dataDir as a prefix with separator
-	// This prevents partial directory name matching
-	dataDirPrefix := absDataDir + string(filepath.Separator)
-	return strings.HasPrefix(absPath+string(filepath.Separator), dataDirPrefix)
+	// Resolve the data directory (must exist)
+	resolvedDataDir, err := filepath.EvalSymlinks(absDataDir)
+	if err != nil {
+		return false
+	}
+	dataDirPrefix := resolvedDataDir + string(filepath.Separator)
+
+	// Check if the path exists
+	_, err = os.Stat(absPath)
+	if err == nil {
+		// Path exists - fully resolve it and check containment
+		resolvedPath, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			return false
+		}
+		return strings.HasPrefix(resolvedPath+string(filepath.Separator), dataDirPrefix)
+	}
+
+	// Path doesn't exist - check that the nearest existing ancestor is within dataDir
+	// We can only verify the safety of existing directories; non-existent portions
+	// will be validated when actually created
+	current := filepath.Dir(absPath)
+	for {
+		// Check if current directory exists
+		_, err := os.Stat(current)
+		if err == nil {
+			// Found an existing ancestor - resolve it and verify it's within dataDir
+			resolvedCurrent, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return false
+			}
+			return strings.HasPrefix(resolvedCurrent+string(filepath.Separator), dataDirPrefix)
+		}
+
+		// Current doesn't exist, go to parent
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached root without finding any existing directory
+			return false
+		}
+		current = parent
+	}
 }
 
 // writeJSON writes a JSON response.

--- a/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
+++ b/cmd/cli/cmd/llm/benchmark/dashboard/handlers.go
@@ -529,12 +529,6 @@ func (s *Server) isPathSafe(path string) bool {
 	// Clean the path to resolve .. and . segments
 	cleanPath := filepath.Clean(path)
 
-	// Reject if cleaning changed the path significantly (e.g., contained ..)
-	// This prevents path traversal attacks
-	if strings.Contains(cleanPath, "..") {
-		return false
-	}
-
 	// Get absolute paths
 	absPath, err := filepath.Abs(cleanPath)
 	if err != nil {

--- a/cmd/cli/cmd/llm/benchmark/dashboard/handlers_test.go
+++ b/cmd/cli/cmd/llm/benchmark/dashboard/handlers_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsPathSafe_SymlinkTraversal tests that symlinks pointing outside the data directory
+// are properly rejected, preventing symlink-based path traversal attacks.
+func TestIsPathSafe_SymlinkTraversal(t *testing.T) {
+	// Create a temporary directory structure:
+	// /tmp/xxx/data/          (data directory)
+	// /tmp/xxx/outside/       (directory outside data)
+	// /tmp/xxx/outside/secret.txt  (sensitive file)
+	// /tmp/xxx/data/link -> /tmp/xxx/outside/secret.txt (symlink to outside)
+
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	outsideDir := filepath.Join(tempDir, "outside")
+	secretFile := filepath.Join(outsideDir, "secret.txt")
+	symlinkPath := filepath.Join(dataDir, "link")
+
+	// Create directories
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+
+	// Create a secret file outside the data directory
+	if err := os.WriteFile(secretFile, []byte("sensitive data"), 0644); err != nil {
+		t.Fatalf("failed to create secret file: %v", err)
+	}
+
+	// Create a symlink inside dataDir pointing to the file outside
+	if err := os.Symlink(secretFile, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	server := NewServer(dataDir)
+
+	// Test 1: The symlink itself should be detected as unsafe
+	// because it resolves to a path outside the data directory
+	if server.isPathSafe(symlinkPath) {
+		t.Errorf("isPathSafe(%q) = true, want false - symlink pointing outside data dir should be rejected", symlinkPath)
+	}
+
+	// Test 2: A normal file inside the data directory should be safe
+	normalFile := filepath.Join(dataDir, "normal.txt")
+	if err := os.WriteFile(normalFile, []byte("normal data"), 0644); err != nil {
+		t.Fatalf("failed to create normal file: %v", err)
+	}
+	if !server.isPathSafe(normalFile) {
+		t.Errorf("isPathSafe(%q) = false, want true - normal file inside data dir should be safe", normalFile)
+	}
+
+	// Test 3: A symlink pointing to another file inside dataDir should be safe
+	insideTarget := filepath.Join(dataDir, "target.txt")
+	if err := os.WriteFile(insideTarget, []byte("target data"), 0644); err != nil {
+		t.Fatalf("failed to create inside target file: %v", err)
+	}
+	insideSymlink := filepath.Join(dataDir, "inside_link")
+	if err := os.Symlink(insideTarget, insideSymlink); err != nil {
+		t.Fatalf("failed to create inside symlink: %v", err)
+	}
+	if !server.isPathSafe(insideSymlink) {
+		t.Errorf("isPathSafe(%q) = false, want true - symlink pointing inside data dir should be safe", insideSymlink)
+	}
+
+	// Test 4: Path traversal using .. should still be rejected
+	traversalPath := filepath.Join(dataDir, "..", "outside", "secret.txt")
+	if server.isPathSafe(traversalPath) {
+		t.Errorf("isPathSafe(%q) = true, want false - path traversal should be rejected", traversalPath)
+	}
+
+	// Test 5: Absolute path outside data dir should be rejected
+	if server.isPathSafe(secretFile) {
+		t.Errorf("isPathSafe(%q) = true, want false - absolute path outside data dir should be rejected", secretFile)
+	}
+}
+
+// TestIsPathSafe_NonExistentPath tests that non-existent paths are handled correctly
+// by checking their parent directory's safety.
+func TestIsPathSafe_NonExistentPath(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	outsideDir := filepath.Join(tempDir, "outside")
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+
+	server := NewServer(dataDir)
+
+	// Test: Non-existent file inside data dir should be safe (parent is safe)
+	nonExistentInside := filepath.Join(dataDir, "newdir", "newfile.txt")
+	if !server.isPathSafe(nonExistentInside) {
+		t.Errorf("isPathSafe(%q) = false, want true - non-existent path inside data dir should be safe", nonExistentInside)
+	}
+
+	// Test: Non-existent file outside data dir should be rejected
+	nonExistentOutside := filepath.Join(outsideDir, "newfile.txt")
+	if server.isPathSafe(nonExistentOutside) {
+		t.Errorf("isPathSafe(%q) = true, want false - non-existent path outside data dir should be rejected", nonExistentOutside)
+	}
+}
+
+// TestIsPathSafe_SymlinkToDirectory tests symlinks that point to directories.
+func TestIsPathSafe_SymlinkToDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	outsideDir := filepath.Join(tempDir, "outside")
+	insideSubdir := filepath.Join(dataDir, "subdir")
+
+	if err := os.MkdirAll(insideSubdir, 0755); err != nil {
+		t.Fatalf("failed to create inside subdir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+
+	server := NewServer(dataDir)
+
+	// Create a symlink inside data pointing to outside directory
+	symlinkToOutside := filepath.Join(dataDir, "link_to_outside")
+	if err := os.Symlink(outsideDir, symlinkToOutside); err != nil {
+		t.Fatalf("failed to create symlink to outside dir: %v", err)
+	}
+
+	// This should be rejected
+	if server.isPathSafe(symlinkToOutside) {
+		t.Errorf("isPathSafe(%q) = true, want false - symlink to outside directory should be rejected", symlinkToOutside)
+	}
+
+	// Create a symlink inside data pointing to another directory inside data
+	symlinkToInside := filepath.Join(dataDir, "link_to_inside")
+	if err := os.Symlink(insideSubdir, symlinkToInside); err != nil {
+		t.Fatalf("failed to create symlink to inside dir: %v", err)
+	}
+
+	// This should be allowed
+	if !server.isPathSafe(symlinkToInside) {
+		t.Errorf("isPathSafe(%q) = false, want true - symlink to inside directory should be safe", symlinkToInside)
+	}
+}
+
+// TestIsPathSafe_MultiLevelSymlink tests nested/chained symlinks.
+// Creates: data/link1 -> data/link2 -> outside/secret.txt
+func TestIsPathSafe_MultiLevelSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	outsideDir := filepath.Join(tempDir, "outside")
+	secretFile := filepath.Join(outsideDir, "secret.txt")
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	if err := os.WriteFile(secretFile, []byte("sensitive"), 0644); err != nil {
+		t.Fatalf("failed to create secret file: %v", err)
+	}
+
+	server := NewServer(dataDir)
+
+	// Create a chain of symlinks: link2 -> outside, link1 -> link2
+	link2 := filepath.Join(dataDir, "link2")
+	link1 := filepath.Join(dataDir, "link1")
+
+	if err := os.Symlink(secretFile, link2); err != nil {
+		t.Fatalf("failed to create link2: %v", err)
+	}
+	if err := os.Symlink(link2, link1); err != nil {
+		t.Fatalf("failed to create link1: %v", err)
+	}
+
+	// Both symlinks should be rejected as they ultimately resolve to outside
+	if server.isPathSafe(link2) {
+		t.Errorf("isPathSafe(%q) = true, want false - symlink chain to outside should be rejected", link2)
+	}
+	if server.isPathSafe(link1) {
+		t.Errorf("isPathSafe(%q) = true, want false - nested symlink to outside should be rejected", link1)
+	}
+
+	// Test safe chain: data/link4 -> data/link3 -> data/realfile.txt
+	realFile := filepath.Join(dataDir, "realfile.txt")
+	if err := os.WriteFile(realFile, []byte("safe content"), 0644); err != nil {
+		t.Fatalf("failed to create real file: %v", err)
+	}
+
+	link3 := filepath.Join(dataDir, "link3")
+	link4 := filepath.Join(dataDir, "link4")
+
+	if err := os.Symlink(realFile, link3); err != nil {
+		t.Fatalf("failed to create link3: %v", err)
+	}
+	if err := os.Symlink(link3, link4); err != nil {
+		t.Fatalf("failed to create link4: %v", err)
+	}
+
+	// Safe chain should be allowed
+	if !server.isPathSafe(link3) {
+		t.Errorf("isPathSafe(%q) = false, want true - symlink to inside file should be safe", link3)
+	}
+	if !server.isPathSafe(link4) {
+		t.Errorf("isPathSafe(%q) = false, want true - nested symlink staying inside should be safe", link4)
+	}
+}

--- a/cmd/cli/cmd/llm/benchmark/job.go
+++ b/cmd/cli/cmd/llm/benchmark/job.go
@@ -78,7 +78,7 @@ func buildBenchmarkJob(namespace, rbgName string) (*batchv1.Job, error) {
 	}
 	apiBase := benchmarkOpts.apiBase
 	if apiBase == "" {
-		apiBase = fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", rbgName, namespace)
+		apiBase = fmt.Sprintf("http://s-%s-inference.%s.svc.cluster.local:%d", rbgName, namespace, benchmarkOpts.apiPort)
 	}
 	apiModelName := benchmarkOpts.apiModelName
 	if apiModelName == "" {
@@ -170,6 +170,7 @@ func buildBenchmarkAnnotations() (map[string]string, error) {
 		NumConcurrency:       benchmarkOpts.numConcurrency,
 		APIBackend:           benchmarkOpts.apiBackend,
 		APIBase:              benchmarkOpts.apiBase,
+		APIPort:              &benchmarkOpts.apiPort,
 		APIKey:               "***",
 		APIModelName:         benchmarkOpts.apiModelName,
 		ModelTokenizer:       benchmarkOpts.modelTokenizer,

--- a/cmd/cli/cmd/llm/benchmark/job_test.go
+++ b/cmd/cli/cmd/llm/benchmark/job_test.go
@@ -398,6 +398,7 @@ func TestBuildBenchmarkJob(t *testing.T) {
 		benchmarkOpts.apiBackend = ""
 		benchmarkOpts.apiBase = ""
 		benchmarkOpts.apiModelName = ""
+		benchmarkOpts.apiPort = 8080
 
 		job, err := buildBenchmarkJob("my-ns", "my-rbg")
 		require.NoError(t, err)
@@ -407,7 +408,8 @@ func TestBuildBenchmarkJob(t *testing.T) {
 		args := container.Args
 		argsStr := joinArgs(args)
 		assert.Contains(t, argsStr, "--api-backend sglang")
-		assert.Contains(t, argsStr, "--api-base http://my-rbg.my-ns.svc.cluster.local:8080")
+		// Default apiBase format: http://s-{rbgName}-inference.{namespace}.svc.cluster.local:{apiPort}
+		assert.Contains(t, argsStr, "--api-base http://s-my-rbg-inference.my-ns.svc.cluster.local:8080")
 		assert.Contains(t, argsStr, "--api-model-name my-rbg")
 	})
 

--- a/cmd/cli/cmd/llm/config/storage.go
+++ b/cmd/cli/cmd/llm/config/storage.go
@@ -46,7 +46,6 @@ PVC configuration fields:
   - pvcName: name of the pre-existing PersistentVolumeClaim to bind to (required)
 
 OSS configuration fields:
-  - storageSize: storage size for the PV (e.g., 100Gi) (required)
   - url: OSS endpoint URL (e.g., oss-cn-hangzhou.aliyuncs.com) (required)
   - bucket: OSS bucket name (required)
   - subpath: subpath within the bucket (optional)
@@ -58,7 +57,7 @@ Examples:
   kubectl rbg llm config add-storage my-pvc --type pvc --config pvcName=model-pvc
 
   # Add an OSS storage with command-line flags
-  kubectl rbg llm config add-storage my-oss --type oss --config url=oss-cn-hangzhou.aliyuncs.com --config bucket=my-bucket --config storageSize=100Gi --config akId=MY_ACCESS_KEY_ID --config akSecret=MY_ACCESS_KEY_SECRET
+  kubectl rbg llm config add-storage my-oss --type oss --config url=oss-cn-hangzhou.aliyuncs.com --config bucket=my-bucket --config akId=MY_ACCESS_KEY_ID --config akSecret=MY_ACCESS_KEY_SECRET
 
   # Add storage interactively
   kubectl rbg llm config add-storage my-pvc -i`,

--- a/cmd/cli/cmd/llm/pull.go
+++ b/cmd/cli/cmd/llm/pull.go
@@ -349,9 +349,6 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 
 	container := &podTemplate.Spec.Containers[0]
 
-	// Generate timestamp inside the container using shell command
-	timestampCmd := "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
 	// Build the metadata JSON using proper JSON encoding to prevent injection
 	// Note: downloadedAt is generated inside the container after download completes
 	// to ensure accurate timing, not at CLI execution time
@@ -362,7 +359,7 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 	}{
 		ModelID:      modelID,
 		Revision:     revision,
-		DownloadedAt: timestampCmd,
+		DownloadedAt: "{{DOWNLOADED_AT}}",
 	}
 	metadataBytes, err := json.Marshal(metadata)
 	if err != nil {
@@ -371,13 +368,19 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 	}
 	metadataJSON := string(metadataBytes)
 
+	// Build the metadata save command:
+	// 1. Get current timestamp
+	// 2. Replace placeholder with actual timestamp using sed
+	// 3. Write to file
+	// Use printf + shellEscape to safely handle special characters in JSON
+	metadataCmd := fmt.Sprintf(
+		`downloadedAt=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) && printf '%%s\n' %s | sed "s/{{DOWNLOADED_AT}}/$downloadedAt/g" > %s`,
+		shellEscape(metadataJSON), shellEscape(modelPath+"/.rbg-metadata.json"))
+
 	// Case 1: Container already uses /bin/sh -c, directly append to the command
 	if len(container.Command) >= 2 && container.Command[0] == "/bin/sh" && container.Command[1] == "-c" {
 		if len(container.Args) > 0 {
-			originalCmd := container.Args[0]
-			// Use printf instead of echo to prevent flag injection (e.g. echo -e, echo -n)
-			container.Args[0] = fmt.Sprintf(`%s && printf '%%s\n' %s > %s`,
-				originalCmd, shellEscape(metadataJSON), shellEscape(modelPath+"/.rbg-metadata.json"))
+			container.Args[0] = container.Args[0] + " && " + metadataCmd
 		}
 		return
 	}

--- a/cmd/cli/cmd/llm/pull.go
+++ b/cmd/cli/cmd/llm/pull.go
@@ -355,11 +355,21 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 	// Build the metadata JSON using proper JSON encoding to prevent injection
 	// Note: downloadedAt is generated inside the container after download completes
 	// to ensure accurate timing, not at CLI execution time
-	// modelID and revision are JSON-escaped to prevent injection
-	modelIDEscaped := jsonSafeString(modelID)
-	revisionEscaped := jsonSafeString(revision)
-	metadataJSON := fmt.Sprintf(`{"modelID":%s,"revision":%s,"downloadedAt":"%s"}`,
-		modelIDEscaped, revisionEscaped, timestampCmd)
+	metadata := struct {
+		ModelID      string `json:"modelID"`
+		Revision     string `json:"revision"`
+		DownloadedAt string `json:"downloadedAt"`
+	}{
+		ModelID:      modelID,
+		Revision:     revision,
+		DownloadedAt: timestampCmd,
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		// This should never happen with simple string fields, but handle defensively
+		metadataBytes = []byte(`{}`)
+	}
+	metadataJSON := string(metadataBytes)
 
 	// Case 1: Container already uses /bin/sh -c, directly append to the command
 	if len(container.Command) >= 2 && container.Command[0] == "/bin/sh" && container.Command[1] == "-c" {
@@ -394,13 +404,6 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 
 	container.Command = []string{"/bin/sh", "-c"}
 	container.Args = []string{wrappedCmd}
-}
-
-// jsonSafeString escapes a string for safe inclusion in JSON.
-// It returns the string wrapped in quotes with all special characters properly escaped.
-func jsonSafeString(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
 }
 
 // shellEscape properly escapes a string for safe use in shell commands.

--- a/cmd/cli/cmd/llm/pull_test.go
+++ b/cmd/cli/cmd/llm/pull_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package llm
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -212,7 +216,165 @@ func TestInjectMetadataSave_MetadataContainsModelIDAndRevision(t *testing.T) {
 	assert.Contains(t, arg, "v2")
 }
 
-// --- Security tests for command injection prevention ---
+// --- Security tests for JSON escaping and command injection prevention ---
+
+// extractJSONFromCommand extracts the JSON payload from a wrapped shell command.
+// It handles both Case 1 (/bin/sh -c with appended metadata) and Case 2 (wrapped binary).
+func extractJSONFromCommand(t *testing.T, cmd []string, args []string) string {
+	t.Helper()
+	require.Len(t, cmd, 2, "expected /bin/sh -c command")
+	require.Equal(t, "/bin/sh", cmd[0])
+	require.Equal(t, "-c", cmd[1])
+	require.Len(t, args, 1, "expected single shell command string")
+
+	shellCmd := args[0]
+
+	// Both Case 1 and Case 2 now use printf '%s\n' for safety
+	// Case 1: "original_cmd && downloadedAt=$(date ...) && printf '%s\n' {JSON} | sed ... > /path"
+	// Case 2: "binary args && printf '%s\n' {JSON} > /path"
+	//
+	// The JSON is passed as argument to printf (with shellEscape, may be quoted)
+	printfIdx := strings.Index(shellCmd, "printf '%s\\n' ")
+	require.GreaterOrEqual(t, printfIdx, 0, "expected printf command in shell command")
+	start := printfIdx + len("printf '%s\\n' ")
+
+	// The JSON argument may be:
+	// - Single-quoted if it contains special chars: 'escaped-json'
+	// - Unquoted if safe: raw-json
+	rest := shellCmd[start:]
+
+	// Check if it starts with single quote (shellEscape wrapped it)
+	if strings.HasPrefix(rest, "'") {
+		// Find the closing single quote
+		// Note: shellEscape escapes internal single quotes as '"'"' so we need to handle that
+		jsonEnd := strings.Index(rest, "' | ")
+		if jsonEnd == -1 {
+			jsonEnd = strings.Index(rest, "' > ")
+		}
+		require.GreaterOrEqual(t, jsonEnd, 0, "expected closing quote after printf argument")
+		// Extract content between quotes, then unescape shell escapes
+		quotedContent := rest[1:jsonEnd]
+		// Unescape shell single-quote escapes: '"'"' -> '
+		return strings.ReplaceAll(quotedContent, `'","'`, "'")
+	}
+
+	// Unquoted: find the end marker
+	endMarkers := []string{" | sed ", " > "}
+	for _, marker := range endMarkers {
+		if idx := strings.Index(rest, marker); idx >= 0 {
+			return rest[:idx]
+		}
+	}
+	require.Fail(t, "expected end marker after printf argument")
+	return ""
+}
+
+func TestInjectMetadataSave_JSONIsValidAndEscaped(t *testing.T) {
+	tests := []struct {
+		name     string
+		modelID  string
+		revision string
+	}{
+		{
+			name:     "normal values",
+			modelID:  "org/model",
+			revision: "main",
+		},
+		{
+			name:     "modelID with double quotes",
+			modelID:  `org/"quoted"-model`,
+			revision: "v1",
+		},
+		{
+			name:     "modelID with backslashes",
+			modelID:  `org/path\\to\\model`,
+			revision: "v1",
+		},
+		{
+			name:     "modelID with newlines",
+			modelID:  "org/model\nwith\nnewlines",
+			revision: "v1",
+		},
+		{
+			name:     "revision with special characters",
+			modelID:  "org/model",
+			revision: `v1"beta"\n\r\t`,
+		},
+		{
+			name:     "both with mixed special characters",
+			modelID:  `org/"test"\model`,
+			revision: `v1.0"release"\candidate`,
+		},
+		{
+			name:     "unicode characters",
+			modelID:  "org/模型-🚀",
+			revision: "版本-ñ",
+		},
+		{
+			name:     "json injection attempt",
+			modelID:  `org/model","malicious":"true`,
+			revision: `v1"},"injected":{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("shell case", func(t *testing.T) {
+				tpl := &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Command: []string{"/bin/sh", "-c"},
+								Args:    []string{"download cmd"},
+							},
+						},
+					},
+				}
+				injectMetadataSave(tpl, tt.modelID, tt.revision, "/models/path")
+
+				c := tpl.Spec.Containers[0]
+				jsonStr := extractJSONFromCommand(t, c.Command, c.Args)
+
+				// Verify JSON is syntactically valid
+				var metadata map[string]interface{}
+				err := json.Unmarshal([]byte(jsonStr), &metadata)
+				require.NoError(t, err, "extracted JSON should be valid: %s", jsonStr)
+
+				// Verify values are correctly preserved (not corrupted by escaping)
+				assert.Equal(t, tt.modelID, metadata["modelID"], "modelID should match exactly")
+				assert.Equal(t, tt.revision, metadata["revision"], "revision should match exactly")
+				assert.Equal(t, "{{DOWNLOADED_AT}}", metadata["downloadedAt"], "downloadedAt should be placeholder")
+			})
+
+			t.Run("direct binary case", func(t *testing.T) {
+				tpl := &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Command: []string{"huggingface-cli"},
+								Args:    []string{"download", "org/model"},
+							},
+						},
+					},
+				}
+				injectMetadataSave(tpl, tt.modelID, tt.revision, "/models/path")
+
+				c := tpl.Spec.Containers[0]
+				jsonStr := extractJSONFromCommand(t, c.Command, c.Args)
+
+				// Verify JSON is syntactically valid
+				var metadata map[string]interface{}
+				err := json.Unmarshal([]byte(jsonStr), &metadata)
+				require.NoError(t, err, "extracted JSON should be valid: %s", jsonStr)
+
+				// Verify values are correctly preserved
+				assert.Equal(t, tt.modelID, metadata["modelID"], "modelID should match exactly")
+				assert.Equal(t, tt.revision, metadata["revision"], "revision should match exactly")
+				assert.Equal(t, "{{DOWNLOADED_AT}}", metadata["downloadedAt"], "downloadedAt should be placeholder")
+			})
+		})
+	}
+}
 
 func TestInjectMetadataSave_MaliciousModelID_QuotedAndEscaped(t *testing.T) {
 	tpl := &corev1.PodTemplateSpec{
@@ -231,11 +393,13 @@ func TestInjectMetadataSave_MaliciousModelID_QuotedAndEscaped(t *testing.T) {
 	arg := tpl.Spec.Containers[0].Args[0]
 	// The malicious input should be properly escaped, not executed
 	assert.Contains(t, arg, `.rbg-metadata.json`)
-	// Verify single quotes in modelID are escaped with shell escape pattern '\"'\"'
-	assert.Contains(t, arg, `'"'"'`)
-	// The entire printf argument should be shell-escaped (wrapped in single quotes)
-	assert.Contains(t, arg, `printf '`)
-	// Verify the malicious content appears as escaped string data, not executable
+	// Verify the malicious content appears inside the JSON string, not as executable shell code
+	assert.Contains(t, arg, `rm -rf /`)
+	// Verify the command uses printf with shell-escaped JSON content (Case 1: shell -c)
+	assert.Contains(t, arg, `printf '%s\n'`)
+	// Verify the JSON contains the modelID with single quotes (shellEscaped properly)
+	// The malicious single quotes should be escaped: '"'"'
+	assert.Contains(t, arg, `org/model'`)
 	assert.Contains(t, arg, `rm -rf /`)
 }
 
@@ -254,12 +418,13 @@ func TestInjectMetadataSave_MaliciousRevision_QuotedAndEscaped(t *testing.T) {
 	injectMetadataSave(tpl, "org/model", "$(rm -rf /)", "/models/path")
 
 	arg := tpl.Spec.Containers[0].Args[0]
-	// The malicious input should be properly shell-escaped
+	// The malicious input should be properly escaped
 	assert.Contains(t, arg, `.rbg-metadata.json`)
-	// Verify the $() is escaped by shellEscape (wrapped in single quotes)
-	assert.Contains(t, arg, `printf '`)
-	// The $( should appear inside the escaped string, not as executable
+	// Verify the $() is inside the JSON string, not as executable shell command
+	// The $ and ( should be part of the JSON-escaped string value
 	assert.Contains(t, arg, `$(rm -rf /)`)
+	// Verify the command uses printf with shell-escaped JSON content (Case 1: shell -c)
+	assert.Contains(t, arg, `printf '%s\n'`)
 }
 
 func TestInjectMetadataSave_DirectBinary_MaliciousInput_Escaped(t *testing.T) {
@@ -325,4 +490,139 @@ func TestPrintJobSummary_NoDuration_NoPanic(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
 	}
 	printJobSummary(job, JobStateSucceeded)
+}
+
+// --- Shell command execution tests ---
+
+// TestMetadataCommandExecution_RealShell tests the actual shell command execution
+// to verify the metadata command works correctly in a real shell environment.
+func TestMetadataCommandExecution_RealShell(t *testing.T) {
+	if os.Getenv("SKIP_SHELL_TESTS") != "" {
+		t.Skip("Skipping shell execution test")
+	}
+
+	tests := []struct {
+		name     string
+		modelID  string
+		revision string
+	}{
+		{
+			name:     "normal values",
+			modelID:  "org/model",
+			revision: "main",
+		},
+		{
+			name:     "modelID with special chars",
+			modelID:  "org/my-model_v2",
+			revision: "v1.0.0",
+		},
+		{
+			name:     "malicious modelID with single quotes",
+			modelID:  "org/model'; rm -rf /; '",
+			revision: "main",
+		},
+		{
+			name:     "malicious revision with command substitution",
+			modelID:  "org/model",
+			revision: "$(rm -rf /)",
+		},
+		{
+			name:     "malicious with backticks",
+			modelID:  "org/`cat /etc/passwd`",
+			revision: "v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build the metadata JSON (same as injectMetadataSave)
+			metadata := struct {
+				ModelID      string `json:"modelID"`
+				Revision     string `json:"revision"`
+				DownloadedAt string `json:"downloadedAt"`
+			}{
+				ModelID:      tt.modelID,
+				Revision:     tt.revision,
+				DownloadedAt: "{{DOWNLOADED_AT}}",
+			}
+			metadataBytes, _ := json.Marshal(metadata)
+			metadataJSON := string(metadataBytes)
+
+			// Build the shell command (same as in injectMetadataSave Case 1)
+			shellCmd := fmt.Sprintf(
+				"downloadedAt=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) && printf '%%s\\n' %s | sed \"s/{{DOWNLOADED_AT}}/$downloadedAt/g\"",
+				shellEscape(metadataJSON))
+
+			// Execute the command
+			cmd := exec.Command("/bin/sh", "-c", shellCmd)
+			output, err := cmd.Output()
+			require.NoError(t, err, "shell command should execute successfully: %s", shellCmd)
+
+			// Parse the output as JSON
+			var result map[string]interface{}
+			err = json.Unmarshal(output, &result)
+			require.NoError(t, err, "output should be valid JSON: %s", string(output))
+
+			// Verify the values
+			assert.Equal(t, tt.modelID, result["modelID"], "modelID should match")
+			assert.Equal(t, tt.revision, result["revision"], "revision should match")
+
+			// Verify downloadedAt is a valid timestamp (replaced from placeholder)
+			downloadedAt, ok := result["downloadedAt"].(string)
+			require.True(t, ok, "downloadedAt should be a string")
+			assert.NotEqual(t, "{{DOWNLOADED_AT}}", downloadedAt, "placeholder should be replaced")
+			// Verify it matches ISO 8601 format
+			_, err = time.Parse(time.RFC3339, downloadedAt)
+			assert.NoError(t, err, "downloadedAt should be valid ISO 8601 timestamp: %s", downloadedAt)
+		})
+	}
+}
+
+// TestMetadataCommandExecution_FileWrite tests the complete flow including file writing
+func TestMetadataCommandExecution_FileWrite(t *testing.T) {
+	if os.Getenv("SKIP_SHELL_TESTS") != "" {
+		t.Skip("Skipping shell execution test")
+	}
+
+	// Create a temp file for the test
+	tmpFile := "/tmp/test-rbg-metadata.json"
+	defer func() { _ = os.Remove(tmpFile) }()
+
+	modelID := "org/test-model"
+	revision := "v1.0"
+
+	// Build the metadata JSON
+	metadata := struct {
+		ModelID      string `json:"modelID"`
+		Revision     string `json:"revision"`
+		DownloadedAt string `json:"downloadedAt"`
+	}{
+		ModelID:      modelID,
+		Revision:     revision,
+		DownloadedAt: "{{DOWNLOADED_AT}}",
+	}
+	metadataBytes, _ := json.Marshal(metadata)
+	metadataJSON := string(metadataBytes)
+
+	// Build the full command with file output
+	shellCmd := fmt.Sprintf(
+		"downloadedAt=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) && printf '%%s\\n' %s | sed \"s/{{DOWNLOADED_AT}}/$downloadedAt/g\" > %s",
+		shellEscape(metadataJSON), shellEscape(tmpFile))
+
+	// Execute the command
+	cmd := exec.Command("/bin/sh", "-c", shellCmd)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "shell command should execute successfully: %s\noutput: %s", shellCmd, string(output))
+
+	// Read and verify the file content
+	content, err := os.ReadFile(tmpFile)
+	require.NoError(t, err, "should be able to read the output file")
+
+	var result map[string]interface{}
+	err = json.Unmarshal(content, &result)
+	require.NoError(t, err, "file content should be valid JSON: %s", string(content))
+
+	assert.Equal(t, modelID, result["modelID"])
+	assert.Equal(t, revision, result["revision"])
+	assert.NotEqual(t, "{{DOWNLOADED_AT}}", result["downloadedAt"])
 }

--- a/cmd/cli/cmd/llm/pull_test.go
+++ b/cmd/cli/cmd/llm/pull_test.go
@@ -212,33 +212,6 @@ func TestInjectMetadataSave_MetadataContainsModelIDAndRevision(t *testing.T) {
 	assert.Contains(t, arg, "v2")
 }
 
-// --- jsonSafeString ---
-
-func TestJsonSafeString_SimpleString(t *testing.T) {
-	result := jsonSafeString("hello")
-	assert.Equal(t, `"hello"`, result)
-}
-
-func TestJsonSafeString_SpecialCharsEscaped(t *testing.T) {
-	result := jsonSafeString(`hello "world"`)
-	assert.Contains(t, result, `\"`)
-}
-
-func TestJsonSafeString_NewlineEscaped(t *testing.T) {
-	result := jsonSafeString("hello\nworld")
-	assert.Contains(t, result, `\n`)
-}
-
-func TestJsonSafeString_TabEscaped(t *testing.T) {
-	result := jsonSafeString("hello\tworld")
-	assert.Contains(t, result, `\t`)
-}
-
-func TestJsonSafeString_BackslashEscaped(t *testing.T) {
-	result := jsonSafeString(`hello\world`)
-	assert.Contains(t, result, `\\`)
-}
-
 // --- Security tests for command injection prevention ---
 
 func TestInjectMetadataSave_MaliciousModelID_QuotedAndEscaped(t *testing.T) {

--- a/cmd/cli/plugin/storage/oss.go
+++ b/cmd/cli/plugin/storage/oss.go
@@ -56,7 +56,6 @@ func (o *OSSStorage) Name() string {
 // ConfigFields returns the config fields this plugin accepts
 func (o *OSSStorage) ConfigFields() []util.ConfigField {
 	return []util.ConfigField{
-		{Key: "storageSize", Description: "storage size for the PV (e.g., 100Gi)", Required: true},
 		{Key: "url", Description: "OSS endpoint URL (e.g., oss-cn-hangzhou.aliyuncs.com)", Required: true},
 		{Key: "bucket", Description: "OSS bucket name", Required: true},
 		{Key: "subpath", Description: "subpath within the bucket", Required: false},
@@ -69,9 +68,7 @@ func (o *OSSStorage) ConfigFields() []util.ConfigField {
 func (o *OSSStorage) Init(config map[string]interface{}) error {
 	var ok bool
 
-	if o.storageSize, ok = config["storageSize"].(string); !ok || o.storageSize == "" {
-		return fmt.Errorf("storageSize is required in storage config for oss type")
-	}
+	o.storageSize = "1Ti"
 	if o.url, ok = config["url"].(string); !ok || o.url == "" {
 		return fmt.Errorf("url is required in storage config for oss type")
 	}

--- a/cmd/cli/plugin/storage/oss_test.go
+++ b/cmd/cli/plugin/storage/oss_test.go
@@ -35,12 +35,11 @@ import (
 
 func testOSSConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"storageSize": "100Gi",
-		"url":         "oss-cn-hangzhou.aliyuncs.com",
-		"bucket":      "test-bucket",
-		"subpath":     "models",
-		"akId":        "test-ak-id",
-		"akSecret":    "test-ak-secret",
+		"url":      "oss-cn-hangzhou.aliyuncs.com",
+		"bucket":   "test-bucket",
+		"subpath":  "models",
+		"akId":     "test-ak-id",
+		"akSecret": "test-ak-secret",
 	}
 }
 
@@ -52,20 +51,21 @@ func TestOSSStorage_Name(t *testing.T) {
 func TestOSSStorage_ConfigFields(t *testing.T) {
 	p := &OSSStorage{}
 	fields := p.ConfigFields()
-	require.Len(t, fields, 6)
+	require.Len(t, fields, 5)
 
 	fieldKeys := make([]string, len(fields))
 	for i, f := range fields {
 		fieldKeys[i] = f.Key
 	}
-	assert.Contains(t, fieldKeys, "storageSize")
 	assert.Contains(t, fieldKeys, "url")
 	assert.Contains(t, fieldKeys, "bucket")
 	assert.Contains(t, fieldKeys, "subpath")
 	assert.Contains(t, fieldKeys, "akId")
 	assert.Contains(t, fieldKeys, "akSecret")
+	// storageSize is not a config field, it's fixed at 1Ti
+	assert.NotContains(t, fieldKeys, "storageSize")
 
-	// Check required fields
+	// Check required fields (only subpath is optional)
 	for _, f := range fields {
 		if f.Key == "subpath" {
 			assert.False(t, f.Required, "subpath should be optional")
@@ -76,7 +76,7 @@ func TestOSSStorage_ConfigFields(t *testing.T) {
 }
 
 func TestOSSStorage_Init_MissingRequiredFields(t *testing.T) {
-	requiredFields := []string{"storageSize", "url", "bucket", "akId", "akSecret"}
+	requiredFields := []string{"url", "bucket", "akId", "akSecret"}
 
 	for _, field := range requiredFields {
 		t.Run("missing_"+field, func(t *testing.T) {
@@ -91,7 +91,7 @@ func TestOSSStorage_Init_MissingRequiredFields(t *testing.T) {
 }
 
 func TestOSSStorage_Init_EmptyRequiredFields(t *testing.T) {
-	requiredFields := []string{"storageSize", "url", "bucket", "akId", "akSecret"}
+	requiredFields := []string{"url", "bucket", "akId", "akSecret"}
 
 	for _, field := range requiredFields {
 		t.Run("empty_"+field, func(t *testing.T) {
@@ -110,7 +110,8 @@ func TestOSSStorage_Init_OK(t *testing.T) {
 	p := &OSSStorage{}
 	err := p.Init(config)
 	require.NoError(t, err)
-	assert.Equal(t, "100Gi", p.storageSize)
+	// storageSize is fixed at 1Ti, not read from config
+	assert.Equal(t, "1Ti", p.storageSize)
 	assert.Equal(t, "oss-cn-hangzhou.aliyuncs.com", p.url)
 	assert.Equal(t, "test-bucket", p.bucket)
 	assert.Equal(t, "models", p.subpath)
@@ -125,6 +126,16 @@ func TestOSSStorage_Init_OK_WithoutSubpath(t *testing.T) {
 	err := p.Init(config)
 	require.NoError(t, err)
 	assert.Equal(t, "/", p.subpath)
+}
+
+func TestOSSStorage_Init_StorageSizeFixed(t *testing.T) {
+	// storageSize is fixed at 1Ti, even if specified in config it's ignored
+	config := testOSSConfig()
+	config["storageSize"] = "500Gi" // This should be ignored
+	p := &OSSStorage{}
+	err := p.Init(config)
+	require.NoError(t, err)
+	assert.Equal(t, "1Ti", p.storageSize, "storageSize should always be 1Ti")
 }
 
 func TestOSSStorage_MountPath(t *testing.T) {
@@ -629,7 +640,7 @@ func TestValidateConfig_OSS_UnknownField(t *testing.T) {
 func TestGetFields_OSS(t *testing.T) {
 	fields := GetFields("oss")
 	require.NotNil(t, fields)
-	assert.Len(t, fields, 6)
+	assert.Len(t, fields, 5) // storageSize is not a config field
 }
 
 func TestRegisteredNames_ContainsOSS(t *testing.T) {


### PR DESCRIPTION
Fixed some security issues:

1. Use a safer approach to generate JSON strings in the llm pull CLI tool code.
2. Add validation for user-provided file paths in the benchmark dashboard handler.