### PR TITLE
feat: support user-defined model configuration

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -53,14 +53,14 @@ kubectl rbg llm chat my-qwen --prompt "Hello, how are you?"
 For production deployments, use the AI Configurator to generate optimized configurations:
 
 ```bash
-kubectl rbg llm generate --model QWEN3_32B --system h200_sxm --total-gpus 8 \
+kubectl rbg llm generate --model Qwen/Qwen3.5-9B --system h200_sxm --total-gpus 8 \
   --isl 4000 --osl 1000 --ttft 1000 --tpot 10
 ```
 
 Then deploy using the generated YAML:
 
 ```bash
-kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
+kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
 ```
 
 ## Commands
@@ -279,11 +279,11 @@ kubectl rbg llm generate [flags]
 
 ```bash
 # Generate configuration with TTFT and TPOT targets
-kubectl rbg llm generate --model QWEN3_32B --system h200_sxm --total-gpus 8 \
+kubectl rbg llm generate --model Qwen/Qwen3.5-9B --system h200_sxm --total-gpus 8 \
   --isl 4000 --osl 1000 --ttft 1000 --tpot 10
 
 # Generate with request latency target
-kubectl rbg llm generate --model LLAMA3_70B --system h100_sxm --total-gpus 16 \
+kubectl rbg llm generate --model meta-llama/Llama-3-70B --system h100_sxm --total-gpus 16 \
   --isl 8192 --osl 2048 --request-latency 5000
 ```
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -60,7 +60,7 @@ kubectl rbg llm generate --model Qwen/Qwen3.5-9B --system h200_sxm --total-gpus 
 Then deploy using the generated YAML:
 
 ```bash
-kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
+kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-5-9b-sglang-disagg.yaml
 ```
 
 ## Commands

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -88,7 +88,7 @@ type runContext struct {
 // It has no side effects and is independently testable.
 func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Config) (*runContext, error) {
 	// 1. Load and find model + mode config
-	models, err := runpkg.LoadBuiltinModels()
+	models, err := runpkg.LoadAllModels()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load model configs: %w", err)
 	}

--- a/cmd/cli/cmd/llm/run/model_config.go
+++ b/cmd/cli/cmd/llm/run/model_config.go
@@ -20,7 +20,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
+	cliconfig "sigs.k8s.io/rbgs/cmd/cli/config"
 	"sigs.k8s.io/yaml"
 )
 
@@ -55,23 +58,164 @@ type EnvVar struct {
 	Value string `yaml:"value"`
 }
 
-// LoadBuiltinModels loads the embedded model configurations.
-// If the environment variable RBG_MODELS_CONFIG is set, it loads from
-// that file instead (useful for local debugging/testing).
-func LoadBuiltinModels() ([]ModelConfig, error) {
-	data := embeddedModelsYAML
-	if overrideFile := os.Getenv("RBG_MODELS_CONFIG"); overrideFile != "" {
-		var err error
-		data, err = os.ReadFile(overrideFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read RBG_MODELS_CONFIG %q: %w", overrideFile, err)
-		}
+// modelWithSource tracks a model config and its source file
+type modelWithSource struct {
+	model  ModelConfig
+	source string
+}
+
+// LoadAllModels loads all available model configurations by merging:
+// 1. User-defined models (from <workspace>/models/*.yaml)
+// 2. Built-in models (embedded models.yaml)
+//
+// User models are placed before built-in models, so they take precedence during lookup.
+// Duplicate detection and warnings are performed during loading.
+func LoadAllModels() ([]ModelConfig, error) {
+	// 1. Load user-defined models with source tracking
+	userModels, err := loadUserModels()
+	if err != nil {
+		// Log warning but don't fail - user models are optional
+		fmt.Fprintf(os.Stderr, "Warning: failed to load user models: %v\n", err)
 	}
+
+	// 2. Load built-in models (always available)
+	builtinModels, err := loadBuiltinModels()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load builtin models: %w", err)
+	}
+
+	// 3. Detect and warn about duplicates
+	detectModelConflicts(userModels, builtinModels)
+
+	// 4. Merge: user models first (higher priority), then builtin models
+	allModels := make([]ModelConfig, 0, len(userModels)+len(builtinModels))
+	for _, m := range userModels {
+		allModels = append(allModels, m.model)
+	}
+	allModels = append(allModels, builtinModels...)
+
+	return allModels, nil
+}
+
+// detectModelConflicts checks for duplicate model definitions and warns appropriately
+// Each model ID gets at most one warning, aggregating all definition sources
+func detectModelConflicts(userModels []modelWithSource, builtinModels []ModelConfig) {
+	// 1. Collect all definitions for each model ID
+	// Important: Record user models FIRST (they have higher priority)
+	type definition struct {
+		source string // source file name
+	}
+
+	modelDefinitions := make(map[string][]definition)
+
+	// Record user models first (higher priority)
+	for _, um := range userModels {
+		modelDefinitions[um.model.ID] = append(modelDefinitions[um.model.ID], definition{
+			source: um.source,
+		})
+	}
+
+	// Then record builtin models
+	for _, m := range builtinModels {
+		modelDefinitions[m.ID] = append(modelDefinitions[m.ID], definition{
+			source: "builtin",
+		})
+	}
+
+	// 2. Emit aggregated warnings for models with multiple definitions
+	for modelID, defs := range modelDefinitions {
+		if len(defs) <= 1 {
+			continue // Only one definition, no conflict
+		}
+
+		// Count definitions per source file
+		fileCount := make(map[string]int)
+		for _, d := range defs {
+			fileCount[d.source]++
+		}
+
+		// Build warning message parts
+		parts := make([]string, 0, len(fileCount))
+		for file, count := range fileCount {
+			if count == 1 {
+				parts = append(parts, fmt.Sprintf("1 in %s", file))
+			} else {
+				parts = append(parts, fmt.Sprintf("%d in %s", count, file))
+			}
+		}
+
+		// First definition wins (user models come first)
+		firstSource := defs[0].source
+
+		fmt.Fprintf(os.Stderr,
+			"Warning: model %q has %d definitions (%s), first definition in %s will be used\n",
+			modelID, len(defs), strings.Join(parts, ", "), firstSource)
+	}
+}
+
+// loadBuiltinModels loads the embedded model configurations
+func loadBuiltinModels() ([]ModelConfig, error) {
 	var configs []ModelConfig
-	if err := yaml.Unmarshal(data, &configs); err != nil {
-		return nil, fmt.Errorf("failed to parse model configs: %w", err)
+	if err := yaml.Unmarshal(embeddedModelsYAML, &configs); err != nil {
+		return nil, fmt.Errorf("failed to parse builtin model configs: %w", err)
 	}
 	return configs, nil
+}
+
+// loadUserModels loads user-defined models from the models/ directory
+// Returns models with their source file information for conflict detection
+func loadUserModels() ([]modelWithSource, error) {
+	modelsDir := cliconfig.GetModelConfigDir()
+	if modelsDir == "" {
+		return nil, nil
+	}
+
+	// Check if directory exists
+	if _, err := os.Stat(modelsDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	// Read all YAML files in the directory
+	entries, err := os.ReadDir(modelsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read models directory: %w", err)
+	}
+
+	var allModels []modelWithSource
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		// Only process .yaml and .yml files
+		name := entry.Name()
+		if !(strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+
+		filePath := filepath.Join(modelsDir, name)
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to read model file %s: %v\n", filePath, err)
+			continue
+		}
+
+		var models []ModelConfig
+		if err := yaml.Unmarshal(data, &models); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse model file %s: %v\n", filePath, err)
+			continue
+		}
+
+		// Track source file for each model
+		for _, m := range models {
+			allModels = append(allModels, modelWithSource{
+				model:  m,
+				source: name, // Use filename for user-friendly messages
+			})
+		}
+	}
+
+	return allModels, nil
 }
 
 // FindModelConfig finds the best matching ModelConfig for modelID using:

--- a/cmd/cli/cmd/llm/run/model_config.go
+++ b/cmd/cli/cmd/llm/run/model_config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	cliconfig "sigs.k8s.io/rbgs/cmd/cli/config"
@@ -65,8 +66,10 @@ type modelWithSource struct {
 }
 
 // LoadAllModels loads all available model configurations by merging:
-// 1. User-defined models (from <workspace>/models/*.yaml)
-// 2. Built-in models (embedded models.yaml)
+//  1. User-defined models (from the directory returned by GetModelConfigDir(),
+//     default: ~/.rbg/models, overridable via RBG_MODEL_CONFIG env var;
+//     accepts both .yaml and .yml files)
+//  2. Built-in models (embedded models.yaml)
 //
 // User models are placed before built-in models, so they take precedence during lookup.
 // Duplicate detection and warnings are performed during loading.
@@ -123,7 +126,15 @@ func detectModelConflicts(userModels []modelWithSource, builtinModels []ModelCon
 	}
 
 	// 2. Emit aggregated warnings for models with multiple definitions
-	for modelID, defs := range modelDefinitions {
+	// Sort model IDs for deterministic output order
+	sortedModelIDs := make([]string, 0, len(modelDefinitions))
+	for modelID := range modelDefinitions {
+		sortedModelIDs = append(sortedModelIDs, modelID)
+	}
+	sort.Strings(sortedModelIDs)
+
+	for _, modelID := range sortedModelIDs {
+		defs := modelDefinitions[modelID]
 		if len(defs) <= 1 {
 			continue // Only one definition, no conflict
 		}
@@ -134,9 +145,17 @@ func detectModelConflicts(userModels []modelWithSource, builtinModels []ModelCon
 			fileCount[d.source]++
 		}
 
+		// Sort source files for deterministic output order
+		sortedFiles := make([]string, 0, len(fileCount))
+		for file := range fileCount {
+			sortedFiles = append(sortedFiles, file)
+		}
+		sort.Strings(sortedFiles)
+
 		// Build warning message parts
-		parts := make([]string, 0, len(fileCount))
-		for file, count := range fileCount {
+		parts := make([]string, 0, len(sortedFiles))
+		for _, file := range sortedFiles {
+			count := fileCount[file]
 			if count == 1 {
 				parts = append(parts, fmt.Sprintf("1 in %s", file))
 			} else {
@@ -170,8 +189,20 @@ func loadUserModels() ([]modelWithSource, error) {
 		return nil, nil
 	}
 
-	// Check if directory exists
-	if _, err := os.Stat(modelsDir); os.IsNotExist(err) {
+	envModelsDir, envModelsDirSet := os.LookupEnv("RBG_MODEL_CONFIG")
+	// Check if directory exists and is actually a directory
+	info, err := os.Stat(modelsDir)
+	if os.IsNotExist(err) {
+		if envModelsDirSet && envModelsDir != "" && envModelsDir == modelsDir {
+			fmt.Fprintf(os.Stderr, "Warning: model config directory %q from RBG_MODEL_CONFIG does not exist, skipping\n", modelsDir)
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat models directory: %w", err)
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "Warning: models path %q is not a directory, skipping\n", modelsDir)
 		return nil, nil
 	}
 
@@ -181,15 +212,21 @@ func loadUserModels() ([]modelWithSource, error) {
 		return nil, fmt.Errorf("failed to read models directory: %w", err)
 	}
 
+	// Sort entries by filename for deterministic order
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
 	var allModels []modelWithSource
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 
-		// Only process .yaml and .yml files
+		// Only process .yaml and .yml files (case-insensitive)
 		name := entry.Name()
-		if !(strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")) {
+		lowerName := strings.ToLower(name)
+		if !(strings.HasSuffix(lowerName, ".yaml") || strings.HasSuffix(lowerName, ".yml")) {
 			continue
 		}
 

--- a/cmd/cli/cmd/llm/run/model_config_test.go
+++ b/cmd/cli/cmd/llm/run/model_config_test.go
@@ -1,0 +1,506 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadUserModelsFromDirectory(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create a model YAML file
+	modelFile := filepath.Join(modelsDir, "custom-models.yaml")
+	modelContent := `- id: "test-org/test-model"
+  name: "Test Model"
+  modes:
+    - name: standard
+      description: "Test standard mode"
+      engine: vllm
+      image: vllm/vllm-openai:latest
+      resources:
+        gpu: 1
+        cpu: 2
+        memory: 8Gi
+      args:
+        - "--tensor-parallel-size=1"
+    - name: throughput
+      description: "Test throughput mode"
+      engine: sglang
+      image: lmsys/sglang:latest
+      resources:
+        gpu: 2
+        cpu: 4
+        memory: 16Gi
+      args:
+        - "--mem-fraction-static=0.9"
+`
+
+	if err := os.WriteFile(modelFile, []byte(modelContent), 0600); err != nil {
+		t.Fatalf("Failed to write model file: %v", err)
+	}
+
+	// Set the model config path to our temp directory
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Verify that user model is loaded
+	var foundUserModel bool
+	for _, model := range models {
+		if model.ID == "test-org/test-model" {
+			foundUserModel = true
+
+			// Verify model properties
+			if model.Name != "Test Model" {
+				t.Errorf("Expected model name 'Test Model', got %q", model.Name)
+			}
+
+			if len(model.Modes) != 2 {
+				t.Errorf("Expected 2 modes, got %d", len(model.Modes))
+			}
+
+			// Verify first mode
+			if model.Modes[0].Name != "standard" {
+				t.Errorf("Expected first mode name 'standard', got %q", model.Modes[0].Name)
+			}
+			if model.Modes[0].Engine != "vllm" {
+				t.Errorf("Expected first mode engine 'vllm', got %q", model.Modes[0].Engine)
+			}
+			if model.Modes[0].Resources.GPU != 1 {
+				t.Errorf("Expected first mode GPU 1, got %d", model.Modes[0].Resources.GPU)
+			}
+
+			// Verify second mode
+			if model.Modes[1].Name != "throughput" {
+				t.Errorf("Expected second mode name 'throughput', got %q", model.Modes[1].Name)
+			}
+			if model.Modes[1].Engine != "sglang" {
+				t.Errorf("Expected second mode engine 'sglang', got %q", model.Modes[1].Engine)
+			}
+
+			break
+		}
+	}
+
+	if !foundUserModel {
+		t.Error("User-defined model not found in loaded models")
+	}
+}
+
+func TestLoadUserModelsMultipleFiles(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create first model file
+	modelFile1 := filepath.Join(modelsDir, "model-a.yaml")
+	modelContent1 := `- id: "org/model-a"
+  name: "Model A"
+  modes:
+    - name: standard
+      engine: vllm
+      image: vllm/vllm-openai:latest
+      resources:
+        gpu: 1
+`
+	if err := os.WriteFile(modelFile1, []byte(modelContent1), 0600); err != nil {
+		t.Fatalf("Failed to write model file 1: %v", err)
+	}
+
+	// Create second model file
+	modelFile2 := filepath.Join(modelsDir, "model-b.yml")
+	modelContent2 := `- id: "org/model-b"
+  name: "Model B"
+  modes:
+    - name: standard
+      engine: sglang
+      image: lmsys/sglang:latest
+      resources:
+        gpu: 2
+`
+	if err := os.WriteFile(modelFile2, []byte(modelContent2), 0600); err != nil {
+		t.Fatalf("Failed to write model file 2: %v", err)
+	}
+
+	// Set the model config path to our temp directory
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Verify both models are loaded
+	var foundModelA, foundModelB bool
+	for _, model := range models {
+		if model.ID == "org/model-a" {
+			foundModelA = true
+		}
+		if model.ID == "org/model-b" {
+			foundModelB = true
+		}
+	}
+
+	if !foundModelA {
+		t.Error("Model A not found in loaded models")
+	}
+	if !foundModelB {
+		t.Error("Model B not found in loaded models")
+	}
+}
+
+func TestLoadUserModelsInvalidFile(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create an invalid YAML file
+	invalidFile := filepath.Join(modelsDir, "invalid.yaml")
+	invalidContent := `this is not valid yaml: [`
+	if err := os.WriteFile(invalidFile, []byte(invalidContent), 0600); err != nil {
+		t.Fatalf("Failed to write invalid file: %v", err)
+	}
+
+	// Create a valid model file
+	validFile := filepath.Join(modelsDir, "valid.yaml")
+	validContent := `- id: "org/valid-model"
+  name: "Valid Model"
+  modes:
+    - name: standard
+      engine: vllm
+      image: vllm/vllm-openai:latest
+      resources:
+        gpu: 1
+`
+	if err := os.WriteFile(validFile, []byte(validContent), 0600); err != nil {
+		t.Fatalf("Failed to write valid file: %v", err)
+	}
+
+	// Set the model config path to our temp directory
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models - should not fail, but should warn about invalid file
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("LoadAllModels should not fail on invalid files: %v", err)
+	}
+
+	// Verify valid model is still loaded
+	var foundValidModel bool
+	for _, model := range models {
+		if model.ID == "org/valid-model" {
+			foundValidModel = true
+			break
+		}
+	}
+
+	if !foundValidModel {
+		t.Error("Valid model not found after loading with invalid file present")
+	}
+}
+
+func TestLoadAllModelsUserOverridesBuiltin(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create a model file that overrides a builtin model
+	// Qwen/Qwen3.5-0.8B is defined in builtin models.yaml
+	overrideFile := filepath.Join(modelsDir, "override.yaml")
+	overrideContent := `- id: "Qwen/Qwen3.5-0.8B"
+  name: "My Override"
+  modes:
+    - name: standard
+      engine: vllm
+      image: my-custom-image:latest
+      resources:
+        gpu: 1
+`
+	if err := os.WriteFile(overrideFile, []byte(overrideContent), 0600); err != nil {
+		t.Fatalf("Failed to write override file: %v", err)
+	}
+
+	// Set the model config path
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Find the model - should get user override (first match)
+	var foundModel *ModelConfig
+	for i := range models {
+		if models[i].ID == "Qwen/Qwen3.5-0.8B" {
+			foundModel = &models[i]
+			break
+		}
+	}
+
+	if foundModel == nil {
+		t.Fatal("Model Qwen/Qwen3.5-0.8B not found")
+	}
+
+	// Should be the user override, not builtin
+	if foundModel.Name != "My Override" {
+		t.Errorf("Expected user override 'My Override', got %q", foundModel.Name)
+	}
+	if foundModel.Modes[0].Image != "my-custom-image:latest" {
+		t.Errorf("Expected user image 'my-custom-image:latest', got %q", foundModel.Modes[0].Image)
+	}
+}
+
+func TestLoadAllModelsUserDuplicate(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create two files with the same model ID
+	file1 := filepath.Join(modelsDir, "file-a.yaml")
+	content1 := `- id: "my-org/duplicate-model"
+  name: "Definition A"
+  modes:
+    - name: standard
+      engine: vllm
+      image: image-a:latest
+      resources:
+        gpu: 1
+`
+	if err := os.WriteFile(file1, []byte(content1), 0600); err != nil {
+		t.Fatalf("Failed to write file1: %v", err)
+	}
+
+	file2 := filepath.Join(modelsDir, "file-b.yaml")
+	content2 := `- id: "my-org/duplicate-model"
+  name: "Definition B"
+  modes:
+    - name: standard
+      engine: vllm
+      image: image-b:latest
+      resources:
+        gpu: 2
+`
+	if err := os.WriteFile(file2, []byte(content2), 0600); err != nil {
+		t.Fatalf("Failed to write file2: %v", err)
+	}
+
+	// Set the model config path
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Find the model - should get first definition (file-a.yaml)
+	var foundModel *ModelConfig
+	for i := range models {
+		if models[i].ID == "my-org/duplicate-model" {
+			foundModel = &models[i]
+			break
+		}
+	}
+
+	if foundModel == nil {
+		t.Fatal("Model my-org/duplicate-model not found")
+	}
+
+	// Should be from file-a.yaml (first alphabetically)
+	if foundModel.Name != "Definition A" {
+		t.Errorf("Expected first definition 'Definition A', got %q", foundModel.Name)
+	}
+	if foundModel.Modes[0].Resources.GPU != 1 {
+		t.Errorf("Expected first definition GPU 1, got %d", foundModel.Modes[0].Resources.GPU)
+	}
+}
+
+func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	modelsDir := filepath.Join(tmpDir, "models")
+
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		t.Fatalf("Failed to create models directory: %v", err)
+	}
+
+	// Create a file with 3 definitions of the same model
+	file1 := filepath.Join(modelsDir, "triple.yaml")
+	content1 := `- id: "my-org/triple-model"
+  name: "Definition 1"
+  modes:
+    - name: standard
+      engine: vllm
+      image: image-1:latest
+      resources:
+        gpu: 1
+- id: "my-org/triple-model"
+  name: "Definition 2"
+  modes:
+    - name: standard
+      engine: vllm
+      image: image-2:latest
+      resources:
+        gpu: 2
+- id: "my-org/triple-model"
+  name: "Definition 3"
+  modes:
+    - name: standard
+      engine: vllm
+      image: image-3:latest
+      resources:
+        gpu: 3
+`
+	if err := os.WriteFile(file1, []byte(content1), 0600); err != nil {
+		t.Fatalf("Failed to write file1: %v", err)
+	}
+
+	// Set the model config path
+	_ = os.Setenv("RBG_MODEL_CONFIG", modelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Find the model - should get first definition
+	var foundModel *ModelConfig
+	for i := range models {
+		if models[i].ID == "my-org/triple-model" {
+			foundModel = &models[i]
+			break
+		}
+	}
+
+	if foundModel == nil {
+		t.Fatal("Model my-org/triple-model not found")
+	}
+
+	// Should be the first definition
+	if foundModel.Name != "Definition 1" {
+		t.Errorf("Expected first definition 'Definition 1', got %q", foundModel.Name)
+	}
+	if foundModel.Modes[0].Resources.GPU != 1 {
+		t.Errorf("Expected first definition GPU 1, got %d", foundModel.Modes[0].Resources.GPU)
+	}
+}
+
+func TestLoadAllModelsCustomModelConfigPath(t *testing.T) {
+	// Create a custom models directory outside of workspace
+	customModelsDir := t.TempDir()
+
+	// Create a model file in the custom directory
+	modelFile := filepath.Join(customModelsDir, "custom-model.yaml")
+	modelContent := `- id: "custom-org/custom-model"
+  name: "Custom Model"
+  modes:
+    - name: standard
+      description: "Custom standard mode"
+      engine: vllm
+      image: vllm/vllm-openai:latest
+      resources:
+        gpu: 1
+        cpu: 2
+        memory: 8Gi
+      args:
+        - "--tensor-parallel-size=1"
+`
+	if err := os.WriteFile(modelFile, []byte(modelContent), 0600); err != nil {
+		t.Fatalf("Failed to write model file: %v", err)
+	}
+
+	// Set RBG_MODEL_CONFIG to custom directory
+	_ = os.Setenv("RBG_MODEL_CONFIG", customModelsDir)
+	defer func() { _ = os.Unsetenv("RBG_MODEL_CONFIG") }()
+
+	// Set RBG_CONFIG to a different directory (should be ignored for models)
+	workspaceDir := t.TempDir()
+	configFile := filepath.Join(workspaceDir, "config")
+	_ = os.Setenv("RBG_CONFIG", configFile)
+	defer func() { _ = os.Unsetenv("RBG_CONFIG") }()
+
+	// Load models
+	models, err := LoadAllModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	// Verify that custom model is loaded from RBG_MODEL_CONFIG path
+	var foundCustomModel bool
+	for _, model := range models {
+		if model.ID == "custom-org/custom-model" {
+			foundCustomModel = true
+
+			// Verify model properties
+			if model.Name != "Custom Model" {
+				t.Errorf("Expected model name 'Custom Model', got %q", model.Name)
+			}
+
+			if len(model.Modes) != 1 {
+				t.Errorf("Expected 1 mode, got %d", len(model.Modes))
+			}
+
+			if model.Modes[0].Engine != "vllm" {
+				t.Errorf("Expected engine 'vllm', got %q", model.Modes[0].Engine)
+			}
+
+			break
+		}
+	}
+
+	if !foundCustomModel {
+		t.Error("Custom model from RBG_MODEL_CONFIG path not found in loaded models")
+	}
+}

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	DefaultConfigDir  = ".rbg"
-	DefaultConfigFile = "config"
-	EnvConfigPath     = "RBG_CONFIG"
+	DefaultConfigDir      = ".rbg"
+	DefaultConfigFile     = "config"
+	DefaultModelConfigDir = "models"
+	EnvConfigPath         = "RBG_CONFIG"
+	EnvModelConfigPath    = "RBG_MODEL_CONFIG"
 )
 
 // Config represents the CLI configuration
@@ -84,6 +86,18 @@ func GetConfigPath() string {
 		return ""
 	}
 	return filepath.Join(home, DefaultConfigDir, DefaultConfigFile)
+}
+
+// GetModelConfigDir returns the path to the model config directory
+func GetModelConfigDir() string {
+	if envPath := os.Getenv(EnvModelConfigPath); envPath != "" {
+		return envPath
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, DefaultConfigDir, DefaultModelConfigDir)
 }
 
 // Load loads the configuration from file. It caches the result for subsequent calls.

--- a/doc/features/kubectl-rbg-llm-generate.md
+++ b/doc/features/kubectl-rbg-llm-generate.md
@@ -41,7 +41,7 @@ $ sudo mv bin/kubectl-rbg /usr/local/bin/
 ```bash
 kubectl rbg llm generate \
   --configurator-tool aiconfigurator \
-  --model QWEN3_32B \
+  --model Qwen/Qwen3.5-9B \
   --system h200_sxm \
   --total-gpus 8 \
   --backend sglang \
@@ -57,7 +57,7 @@ kubectl rbg llm generate \
 ```bash
 kubectl rbg llm generate \
   --configurator-tool aiconfigurator \
-  --model QWEN3_32B \
+  --model Qwen/Qwen3.5-9B \
   --system h200_sxm \
   --total-gpus 8 \
   --backend sglang \
@@ -71,7 +71,7 @@ kubectl rbg llm generate \
 
 #### Required Flags
 
-- `--model`: Model name (e.g., QWEN3_32B, LLAMA3.1_70B)
+- `--model`: Model name (e.g., Qwen/Qwen3.5-9B, meta-llama/Llama-3-70B)
 - `--system`: GPU system type (h100_sxm, a100_sxm, b200_sxm, gb200_sxm, l40s, h200_sxm)
 - `--total-gpus`: Total number of GPUs to use for deployment
 - `--isl`: Input sequence length
@@ -144,24 +144,24 @@ Generating RBG deployment YAMLs...
 ✓ Successfully generated 2 deployment recommendations:
 
 Plan 1: Prefill-Decode Disaggregated Mode
-  File: /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
+  File: /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
   Configuration:
     - Prefill Workers: 4 (each using 1 GPU)
     - Decode Workers: 1 (each using 4 GPU)
     - Total GPU Usage: 8
 
 Plan 2: Aggregated Mode
-  File: /tmp/rbg-llm-generate-output/qwen3-32b-sglang-agg.yaml
+  File: /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-agg.yaml
   Configuration:
     - Workers: 1 (each using 8 GPU)
     - Total GPU Usage: 8
 
 To deploy, run:
-  kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
+  kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
 or
-  kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-agg.yaml
+  kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-agg.yaml
 
-Note: Ensure the 'qwen3-32b' PVC exists in your cluster before deploying.
+Note: Ensure the 'qwen-qwen3-5-9b' PVC exists in your cluster before deploying.
 ```
 
 ## Deployment
@@ -175,7 +175,7 @@ Before deploying the generated YAML:
    apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
-     name: qwen3-32b
+     name: qwen-qwen3-5-9b
    spec:
      accessModes:
        - ReadOnlyMany
@@ -189,7 +189,7 @@ Before deploying the generated YAML:
 2. **Deploy the recommended configuration**:
 
    ```bash
-   kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
+   kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
    ```
 
 3. **Monitor deployment**:
@@ -216,7 +216,7 @@ Or visit: https://github.com/ai-dynamo/aiconfigurator
 ### No output directory found
 
 ```text
-Error: no output directory found matching pattern: QWEN3_32B_isl5000_osl1000_ttft1000_tpot10_*
+Error: no output directory found matching pattern: Qwen_Qwen3.5-9B_isl5000_osl1000_ttft1000_tpot10_*
 ```
 
 **Solution**:

--- a/doc/features/kubectl-rbg-llm-generate.md
+++ b/doc/features/kubectl-rbg-llm-generate.md
@@ -144,24 +144,24 @@ Generating RBG deployment YAMLs...
 ✓ Successfully generated 2 deployment recommendations:
 
 Plan 1: Prefill-Decode Disaggregated Mode
-  File: /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
+  File: /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
   Configuration:
     - Prefill Workers: 4 (each using 1 GPU)
     - Decode Workers: 1 (each using 4 GPU)
     - Total GPU Usage: 8
 
 Plan 2: Aggregated Mode
-  File: /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-agg.yaml
+  File: /tmp/rbg-llm-generate-output/qwen3-32b-sglang-agg.yaml
   Configuration:
     - Workers: 1 (each using 8 GPU)
     - Total GPU Usage: 8
 
 To deploy, run:
-  kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
+  kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
 or
-  kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-agg.yaml
+  kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-agg.yaml
 
-Note: Ensure the 'qwen-qwen3-5-9b' PVC exists in your cluster before deploying.
+Note: Ensure the 'qwen3-32b' PVC exists in your cluster before deploying.
 ```
 
 ## Deployment
@@ -175,7 +175,7 @@ Before deploying the generated YAML:
    apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
-     name: qwen-qwen3-5-9b
+     name: qwen3-32b
    spec:
      accessModes:
        - ReadOnlyMany
@@ -189,7 +189,7 @@ Before deploying the generated YAML:
 2. **Deploy the recommended configuration**:
 
    ```bash
-   kubectl apply -f /tmp/rbg-llm-generate-output/qwen-qwen3-5-9b-sglang-disagg.yaml
+   kubectl apply -f /tmp/rbg-llm-generate-output/qwen3-32b-sglang-disagg.yaml
    ```
 
 3. **Monitor deployment**:
@@ -216,7 +216,7 @@ Or visit: https://github.com/ai-dynamo/aiconfigurator
 ### No output directory found
 
 ```text
-Error: no output directory found matching pattern: Qwen_Qwen3.5-9B_isl5000_osl1000_ttft1000_tpot10_*
+Error: no output directory found matching pattern: Qwen/Qwen3-32B_isl5000_osl1000_ttft1000_tpot10_*
 ```
 
 **Solution**:


### PR DESCRIPTION
## Support User-Defined Model Configuration

### Summary

Add support for loading user-defined model configurations from local directory, merging with built-in models. User models take precedence.

Additionally, fix incorrect examples for the llm generate command found in the documentation.

### Changes

1. **Model Loading Mechanism**
   - Default path: `~/.rbg/models/`
   - Custom path via `RBG_MODEL_CONFIG` environment variable
   - Supports `.yaml` and `.yml` files

2. **Duplicate Detection**
   - Warns when same model ID has multiple definitions
   - Aggregates all sources for easier debugging

3. **New Constants/Functions**
   - `DefaultModelConfigDir`, `EnvModelConfigPath`
   - `GetModelConfigDir()`

### Environment Variables

| Variable | Purpose | Default |
|----------|---------|---------|
| `RBG_CONFIG` | CLI config file | `~/.rbg/config` |
| `RBG_MODEL_CONFIG` | Model config directory | `~/.rbg/models` |

### Files Changed

- `cmd/cli/cmd/llm/run/model_config.go` - New loading logic
- `cmd/cli/cmd/llm/run/model_config_test.go` - Unit tests (7 cases)
- `cmd/cli/config/config.go` - New constants/functions
- `cmd/cli/cmd/llm/run.go` - Switch to new loader
- `cmd/cli/README.md`, `doc/features/kubectl-rbg-llm-generate.md` - Docs update
