### PR TITLE
fix: WorkloadSpec omitempty not work

### DIFF
--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -277,13 +277,15 @@ var defaultWorkload = WorkloadSpec{
 }
 
 // GetWorkload returns the WorkloadSpec for this role.
-// If Workload is nil, it returns the default workload spec.
+// If Workload is nil, it returns a copy of the default workload spec.
 // Deprecated: Use pattern-based approach instead (StandalonePattern, LeaderWorkerPattern).
 func (r *RoleSpec) GetWorkload() *WorkloadSpec {
 	if r.Workload != nil {
 		return r.Workload
 	}
-	return &defaultWorkload
+	// Return a copy to prevent mutation of the package-level default.
+	defaultCopy := defaultWorkload
+	return &defaultCopy
 }
 
 // GetDiscoveryConfigMode returns the discovery config mode from annotations.

--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -269,6 +269,23 @@ func (r *RoleSpec) HasTemplate() bool {
 	return r.GetTemplate() != nil || r.GetTemplateRef() != nil
 }
 
+// defaultWorkload is the default WorkloadSpec for roles.
+// This matches the +kubebuilder:default marker on the Workload field.
+var defaultWorkload = WorkloadSpec{
+	APIVersion: "workloads.x-k8s.io/v1alpha2",
+	Kind:       "RoleInstanceSet",
+}
+
+// GetWorkload returns the WorkloadSpec for this role.
+// If Workload is nil, it returns the default workload spec.
+// Deprecated: Use pattern-based approach instead (StandalonePattern, LeaderWorkerPattern).
+func (r *RoleSpec) GetWorkload() *WorkloadSpec {
+	if r.Workload != nil {
+		return r.Workload
+	}
+	return &defaultWorkload
+}
+
 // GetDiscoveryConfigMode returns the discovery config mode from annotations.
 func (rbg *RoleBasedGroup) GetDiscoveryConfigMode() constants.DiscoveryConfigMode {
 	if rbg == nil || rbg.Annotations == nil {
@@ -325,7 +342,7 @@ func IsStatefulRole(role *RoleSpec) bool {
 	if role == nil {
 		return false
 	}
-	switch role.Workload.String() {
+	switch role.GetWorkload().String() {
 	case constants.DeploymentWorkloadType:
 		return false
 	case constants.StatefulSetWorkloadType, constants.LeaderWorkerSetWorkloadType, "":

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -115,7 +115,7 @@ const (
 
 // RollingUpdate defines the parameters to be used for RollingUpdateStrategyType.
 type RollingUpdate struct {
-	// Type indicates the type of the InstanceSetUpdateStrategy.
+	// Type indicates the type of the RoleInstanceSetUpdateStrategy.
 	// Default is InPlaceIfPossible.
 	Type UpdateStrategyType `json:"type,omitempty"`
 
@@ -134,7 +134,7 @@ type RollingUpdate struct {
 	// +kubebuilder:default=0
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 
-	// Paused indicates that the InstanceSet is paused.
+	// Paused indicates that the RoleInstanceSet is paused.
 	Paused bool `json:"paused,omitempty"`
 
 	// InPlaceUpdateStrategy contains strategies for in-place update.
@@ -196,7 +196,7 @@ type RoleSpec struct {
 
 	// Workload type specification
 	// Deprecated: This field is deprecated and will be removed in future versions.
-	// The underlying workload will use InstanceSet.
+	// The underlying workload will use RoleInstanceSet.
 	// +kubebuilder:default={apiVersion:"workloads.x-k8s.io/v1alpha2", kind:"RoleInstanceSet"}
 	// +optional
 	Workload *WorkloadSpec `json:"workload,omitempty"`

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -199,7 +199,7 @@ type RoleSpec struct {
 	// The underlying workload will use InstanceSet.
 	// +kubebuilder:default={apiVersion:"workloads.x-k8s.io/v1alpha2", kind:"RoleInstanceSet"}
 	// +optional
-	Workload WorkloadSpec `json:"workload,omitempty"`
+	Workload *WorkloadSpec `json:"workload,omitempty"`
 
 	// Pattern defines the deployment pattern for this role (inline).
 	// Either standalonePattern or leaderWorkerPattern can be specified, not both.

--- a/api/workloads/v1alpha2/roletemplate_validation.go
+++ b/api/workloads/v1alpha2/roletemplate_validation.go
@@ -107,10 +107,11 @@ func validateRoleTemplateFields(
 		// Get workload safely (handles nil pointer with default value).
 		wl := role.GetWorkload()
 
-		// Defense-in-depth: CRD validates this, but controller validates as well.
-		if wl.Kind == "InstanceSet" {
+		// v1alpha2 CRD does not validate workload-kind-specific templateRef restrictions;
+		// enforce RoleInstanceSet restrictions here at the controller layer.
+		if wl.Kind == "RoleInstanceSet" {
 			return fmt.Errorf(
-				"spec.roles[%d].templateRef: not supported for InstanceSet workloads",
+				"spec.roles[%d].templateRef: not supported for RoleInstanceSet workloads",
 				index,
 			)
 		}

--- a/api/workloads/v1alpha2/roletemplate_validation.go
+++ b/api/workloads/v1alpha2/roletemplate_validation.go
@@ -104,8 +104,11 @@ func validateRoleTemplateFields(
 			)
 		}
 
+		// Get workload safely (handles nil pointer with default value).
+		wl := role.GetWorkload()
+
 		// Defense-in-depth: CRD validates this, but controller validates as well.
-		if role.Workload.Kind == "InstanceSet" {
+		if wl.Kind == "InstanceSet" {
 			return fmt.Errorf(
 				"spec.roles[%d].templateRef: not supported for InstanceSet workloads",
 				index,
@@ -113,7 +116,7 @@ func validateRoleTemplateFields(
 		}
 
 		// LWS workload and LeaderWorkerPattern do not support templateRef.
-		if role.Workload.Kind == "LeaderWorkerSet" || role.IsLeaderWorkerPattern() {
+		if wl.Kind == "LeaderWorkerSet" || role.IsLeaderWorkerPattern() {
 			return fmt.Errorf(
 				"spec.roles[%d].templateRef: not supported for LeaderWorkerSet/LeaderWorkerPattern workloads (use template with leaderTemplatePatch/workerTemplatePatch instead)",
 				index,

--- a/api/workloads/v1alpha2/zz_generated.deepcopy.go
+++ b/api/workloads/v1alpha2/zz_generated.deepcopy.go
@@ -1302,7 +1302,11 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.Workload = in.Workload
+	if in.Workload != nil {
+		in, out := &in.Workload, &out.Workload
+		*out = new(WorkloadSpec)
+		**out = **in
+	}
 	in.Pattern.DeepCopyInto(&out.Pattern)
 	if in.ServicePorts != nil {
 		in, out := &in.ServicePorts, &out.ServicePorts

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -262,7 +262,7 @@ func generateRBG(name, namespace, modelID, revision string, replicas int32, rctx
 							},
 						},
 					},
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "workloads.x-k8s.io/v1alpha2",
 						Kind:       "RoleInstanceSet",
 					},

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -32865,12 +32865,12 @@ spec:
                                 the role should be partitioned for updates.
                               x-kubernetes-int-or-string: true
                             paused:
-                              description: Paused indicates that the InstanceSet is
-                                paused.
+                              description: Paused indicates that the RoleInstanceSet
+                                is paused.
                               type: boolean
                             type:
                               description: |-
-                                Type indicates the type of the InstanceSetUpdateStrategy.
+                                Type indicates the type of the RoleInstanceSetUpdateStrategy.
                                 Default is InPlaceIfPossible.
                               type: string
                           type: object
@@ -40397,7 +40397,7 @@ spec:
                       description: |-
                         Workload type specification
                         Deprecated: This field is deprecated and will be removed in future versions.
-                        The underlying workload will use InstanceSet.
+                        The underlying workload will use RoleInstanceSet.
                       properties:
                         apiVersion:
                           default: workloads.x-k8s.io/v1alpha2

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -33680,12 +33680,12 @@ spec:
                                         updates.
                                       x-kubernetes-int-or-string: true
                                     paused:
-                                      description: Paused indicates that the InstanceSet
+                                      description: Paused indicates that the RoleInstanceSet
                                         is paused.
                                       type: boolean
                                     type:
                                       description: |-
-                                        Type indicates the type of the InstanceSetUpdateStrategy.
+                                        Type indicates the type of the RoleInstanceSetUpdateStrategy.
                                         Default is InPlaceIfPossible.
                                       type: string
                                   type: object
@@ -41497,7 +41497,7 @@ spec:
                               description: |-
                                 Workload type specification
                                 Deprecated: This field is deprecated and will be removed in future versions.
-                                The underlying workload will use InstanceSet.
+                                The underlying workload will use RoleInstanceSet.
                               properties:
                                 apiVersion:
                                   default: workloads.x-k8s.io/v1alpha2

--- a/internal/controller/workloads/discovery_config_mode_test.go
+++ b/internal/controller/workloads/discovery_config_mode_test.go
@@ -149,7 +149,7 @@ func TestReconcileRefinedDiscoveryConfigMap(t *testing.T) {
 		rbg.Spec.Roles = append(rbg.Spec.Roles, workloadsv1alpha2.RoleSpec{
 			Name:     "router",
 			Replicas: ptr.To(int32(1)),
-			Workload: workloadsv1alpha2.WorkloadSpec{
+			Workload: &workloadsv1alpha2.WorkloadSpec{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 			},
@@ -198,7 +198,7 @@ func TestReconcileRefinedDiscoveryConfigMap(t *testing.T) {
 				{
 					Name:     "router",
 					Replicas: ptr.To(int32(1)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},

--- a/internal/controller/workloads/pod_controller.go
+++ b/internal/controller/workloads/pod_controller.go
@@ -98,7 +98,7 @@ func (r *PodReconciler) restartRBG(ctx context.Context, rbg *workloadsv1alpha2.R
 		var errs error
 
 		for _, role := range roleList {
-			recon, err := reconciler.NewWorkloadReconciler(role.Workload, r.scheme, r.client)
+			recon, err := reconciler.NewWorkloadReconciler(role.GetWorkload(), r.scheme, r.client)
 			if err != nil {
 				errs = errors.Join(errs, err)
 				continue

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -567,6 +567,9 @@ func (r *RoleBasedGroupReconciler) getOrCreateWorkloadReconciler(
 	ctx context.Context,
 	workloadSpec *workloadsv1alpha2.WorkloadSpec,
 ) (reconciler.WorkloadReconciler, error) {
+	if workloadSpec == nil {
+		return nil, fmt.Errorf("workloadSpec cannot be nil")
+	}
 	workloadType := workloadSpec.String()
 
 	// Fast path: check if reconciler already exists with read lock

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -288,7 +288,7 @@ func (r *RoleBasedGroupReconciler) preCheck(ctx context.Context, rbg *workloadsv
 	var errs []error
 	for _, role := range rbg.Spec.Roles {
 		roleCtx := log.IntoContext(ctx, logger.WithValues("role", role.Name))
-		workloadReconciler, err := r.getOrCreateWorkloadReconciler(roleCtx, role.Workload)
+		workloadReconciler, err := r.getOrCreateWorkloadReconciler(roleCtx, role.GetWorkload())
 		if err != nil {
 			logger.Error(err, "Failed to create workload reconciler")
 			r.recorder.Eventf(
@@ -490,7 +490,7 @@ func (r *RoleBasedGroupReconciler) reconcileSingleRole(
 	logger := log.FromContext(ctx)
 
 	// Get or create workload reconciler
-	reconciler, err := r.getOrCreateWorkloadReconciler(ctx, role.Workload)
+	reconciler, err := r.getOrCreateWorkloadReconciler(ctx, role.GetWorkload())
 	if err != nil {
 		logger.Error(err, "Failed to get workload reconciler")
 		r.recorder.Eventf(
@@ -565,7 +565,7 @@ func (r *RoleBasedGroupReconciler) cleanup(ctx context.Context, rbg *workloadsv1
 
 func (r *RoleBasedGroupReconciler) getOrCreateWorkloadReconciler(
 	ctx context.Context,
-	workloadSpec workloadsv1alpha2.WorkloadSpec,
+	workloadSpec *workloadsv1alpha2.WorkloadSpec,
 ) (reconciler.WorkloadReconciler, error) {
 	workloadType := workloadSpec.String()
 
@@ -616,7 +616,7 @@ func (r *RoleBasedGroupReconciler) constructAndUpdateRoleStatuses(
 		logger := log.FromContext(ctx)
 		roleCtx := log.IntoContext(ctx, logger.WithValues("role", role.Name))
 
-		reconciler, err := r.getOrCreateWorkloadReconciler(ctx, role.Workload)
+		reconciler, err := r.getOrCreateWorkloadReconciler(ctx, role.GetWorkload())
 		if err != nil {
 			logger.Error(err, "Failed to get workload reconciler")
 			r.recorder.Eventf(

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -850,8 +850,8 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_Labels(t *testing.T) {
 				"kwota.meta.com/quota-allocation":      "my-qa",
 				"kwota.meta.com/workload-variant":      "gb200",
 				"kwota.meta.com/workload-variant-type": "Standalone",
-				constants.GroupNameLabelKey:             "test-rbg",
-				constants.RoleNameLabelKey:              "engine",
+				constants.GroupNameLabelKey:            "test-rbg",
+				constants.RoleNameLabelKey:             "engine",
 			},
 		},
 		{
@@ -863,14 +863,14 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_Labels(t *testing.T) {
 					Labels: map[string]string{
 						constants.GroupNameLabelKey: "user-override-attempt",
 						constants.RoleNameLabelKey:  "user-override-attempt",
-						"custom-label":             "custom-value",
+						"custom-label":              "custom-value",
 					},
 				},
 			},
 			wantLabels: map[string]string{
 				constants.GroupNameLabelKey: "test-rbg",
 				constants.RoleNameLabelKey:  "engine",
-				"custom-label":             "custom-value",
+				"custom-label":              "custom-value",
 			},
 		},
 		{
@@ -999,8 +999,8 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_LabelUpdate(t *testing
 	wantLabels := map[string]string{
 		"kwota.meta.com/quota-allocation": "my-qa",
 		"kwota.meta.com/workload-variant": "gb200",
-		constants.GroupNameLabelKey:        rbg.Name,
-		constants.RoleNameLabelKey:         roleName,
+		constants.GroupNameLabelKey:       rbg.Name,
+		constants.RoleNameLabelKey:        roleName,
 	}
 	if len(updated.Labels) != len(wantLabels) {
 		t.Errorf("expected %d labels, got %d: %v", len(wantLabels), len(updated.Labels), updated.Labels)

--- a/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
+++ b/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
@@ -385,7 +385,7 @@ func (r *RoleBasedGroupScalingAdapterReconciler) updateRoleReplicas(
 func (r *RoleBasedGroupScalingAdapterReconciler) extractLabelSelectorDefault(
 	rbg *workloadsv1alpha2.RoleBasedGroup, role *workloadsv1alpha2.RoleSpec,
 ) (string, error) {
-	apiVersion, kind := role.Workload.APIVersion, role.Workload.Kind
+	apiVersion, kind := role.GetWorkload().APIVersion, role.GetWorkload().Kind
 
 	targetGV, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -100,7 +100,7 @@ func (m *DefaultDependencyManager) CheckDependencyReady(
 		if err != nil {
 			return false, err
 		}
-		r, err := reconciler.NewWorkloadReconciler(depRole.Workload, m.scheme, m.client)
+		r, err := reconciler.NewWorkloadReconciler(depRole.GetWorkload(), m.scheme, m.client)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -300,14 +300,14 @@ func TestDefaultDependencyManager_CheckDependencyReady(t *testing.T) {
 				{
 					Name:         "role1",
 					Dependencies: []string{"role2"},
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
 				},
 				{
 					Name: "role2",
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},

--- a/pkg/discovery/env_builder.go
+++ b/pkg/discovery/env_builder.go
@@ -100,7 +100,7 @@ func (g *EnvBuilder) buildLocalRoleVars() []corev1.EnvVar {
 			})
 	}
 
-	if g.role.Workload.Kind == "RoleInstanceSet" {
+	if g.role.GetWorkload().Kind == "RoleInstanceSet" {
 		envVars = append(envVars,
 			corev1.EnvVar{
 				Name: constants.EnvRBGRoleInstanceName,
@@ -133,7 +133,7 @@ func (g *EnvBuilder) buildLocalRoleVars() []corev1.EnvVar {
 }
 
 func (g *EnvBuilder) roleIndexFieldPath() string {
-	if g.role != nil && g.role.Workload.String() == constants.RoleInstanceSetWorkloadType {
+	if g.role != nil && g.role.GetWorkload().String() == constants.RoleInstanceSetWorkloadType {
 		return fmt.Sprintf("metadata.labels['%s']", constants.RoleInstanceIndexLabelKey)
 	}
 

--- a/pkg/discovery/env_builder_test.go
+++ b/pkg/discovery/env_builder_test.go
@@ -43,7 +43,7 @@ func TestEnvBuilder_Build(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "stateful-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "apps/v1",
 					Kind:       "StatefulSet",
 				},
@@ -76,7 +76,7 @@ func TestEnvBuilder_Build(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "lws-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "leaderworkerset.x-k8s.io/v1",
 					Kind:       "LeaderWorkerSet",
 				},
@@ -109,7 +109,7 @@ func TestEnvBuilder_Build(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "deployment-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 				},
@@ -134,7 +134,7 @@ func TestEnvBuilder_Build(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "role-instance-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "workloads.x-k8s.io/v1alpha2",
 					Kind:       "RoleInstanceSet",
 				},
@@ -230,7 +230,7 @@ func TestEnvBuilder_buildLocalRoleVars(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "stateful-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "apps/v1",
 					Kind:       "StatefulSet",
 				},
@@ -263,7 +263,7 @@ func TestEnvBuilder_buildLocalRoleVars(t *testing.T) {
 			},
 			role: &workloadsv1alpha2.RoleSpec{
 				Name: "role-instance-role",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "workloads.x-k8s.io/v1alpha2",
 					Kind:       "RoleInstanceSet",
 				},

--- a/pkg/discovery/injector_test.go
+++ b/pkg/discovery/injector_test.go
@@ -405,7 +405,7 @@ func TestDefaultInjector_InjectConfig(t *testing.T) {
 			rbg: func() *workloadsv1alpha2.RoleBasedGroup {
 				rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").Obj()
 				rbg.SetDiscoveryConfigMode(constants.RefineDiscoveryConfigMode)
-				rbg.Spec.Roles[0].Workload = workloadsv1alpha2.WorkloadSpec{
+				rbg.Spec.Roles[0].Workload = &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
 				}
@@ -491,6 +491,10 @@ func TestDefaultInjector_InjectEnv(t *testing.T) {
 			role: &workloadsv1alpha2.RoleSpec{
 				Name:     "worker",
 				Replicas: ptr.To(int32(3)),
+				Workload: &workloadsv1alpha2.WorkloadSpec{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
 			},
 			// Container without the expected environment variables
 			initialPodSpec: &corev1.PodTemplateSpec{
@@ -543,6 +547,10 @@ func TestDefaultInjector_InjectEnv(t *testing.T) {
 			role: &workloadsv1alpha2.RoleSpec{
 				Name:     "worker",
 				Replicas: ptr.To(int32(3)),
+				Workload: &workloadsv1alpha2.WorkloadSpec{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
 			},
 			// Container with existing environment variables
 			initialPodSpec: &corev1.PodTemplateSpec{
@@ -628,7 +636,7 @@ func TestDefaultInjector_InjectLeaderWorkerSetEnv(t *testing.T) {
 	}
 	role := &workloadsv1alpha2.RoleSpec{
 		Name: "integrate",
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "workloads.x-k8s.io/v1alpha2",
 			Kind:       "RoleInstanceSet",
 		},

--- a/pkg/reconciler/common.go
+++ b/pkg/reconciler/common.go
@@ -73,7 +73,7 @@ func CleanupOrphanedObjs(ctx context.Context, c client.Client, rbg *workloadsv1a
 		}
 		found := false
 		for _, role := range rbg.Spec.Roles {
-			if role.Workload.Kind == obj.GetObjectKind().GroupVersionKind().Kind && rbg.GetWorkloadName(&role) == obj.GetName() {
+			if role.GetWorkload().Kind == obj.GetObjectKind().GroupVersionKind().Kind && rbg.GetWorkloadName(&role) == obj.GetName() {
 				found = true
 				break
 			}

--- a/pkg/reconciler/common_test.go
+++ b/pkg/reconciler/common_test.go
@@ -112,7 +112,7 @@ func TestCleanupOrphanedObjs(t *testing.T) {
 			Roles: []workloadsv1alpha2.RoleSpec{
 				{
 					Name: "valid-role",
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "workloads.x-k8s.io/v1alpha1",
 						Kind:       "InstanceSet",
 					},

--- a/pkg/reconciler/deploy_reconciler.go
+++ b/pkg/reconciler/deploy_reconciler.go
@@ -295,7 +295,7 @@ func (r *DeploymentReconciler) CleanupOrphanedWorkloads(
 		}
 		found := false
 		for _, role := range rbg.Spec.Roles {
-			if role.Workload.Kind == "Deployment" && rbg.GetWorkloadName(&role) == deploy.Name {
+			if role.GetWorkload().Kind == "Deployment" && rbg.GetWorkloadName(&role) == deploy.Name {
 				found = true
 				break
 			}

--- a/pkg/reconciler/deploy_reconciler_test.go
+++ b/pkg/reconciler/deploy_reconciler_test.go
@@ -51,7 +51,7 @@ func TestDeploymentReconciler_Reconciler(t *testing.T) {
 	deployRole := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: ptr.To(int32(3)),
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
@@ -191,7 +191,7 @@ func TestDeploymentReconciler_CheckWorkloadReady(t *testing.T) {
 	deployRole := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: &replicas,
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
@@ -309,7 +309,7 @@ func TestDeploymentReconciler_CleanupOrphanedWorkloads(t *testing.T) {
 	deployRole := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: &replicas,
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
@@ -431,7 +431,7 @@ func TestDeploymentReconciler_RecreateWorkload(t *testing.T) {
 	deployRole := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: &replicas,
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
@@ -600,7 +600,7 @@ func TestDeploymentReconciler_constructDeployApplyConfiguration(t *testing.T) {
 	deployRole := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: &replicas,
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
@@ -687,7 +687,7 @@ func TestConstructDeploymentApplyConfiguration_LabelsAndAnnotations(t *testing.T
 	role := &workloadsv1alpha2.RoleSpec{
 		Name:     "test-role",
 		Replicas: ptr.To(int32(3)),
-		Workload: workloadsv1alpha2.WorkloadSpec{
+		Workload: &workloadsv1alpha2.WorkloadSpec{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},

--- a/pkg/reconciler/lws_reconciler.go
+++ b/pkg/reconciler/lws_reconciler.go
@@ -198,7 +198,7 @@ func (r *LeaderWorkerSetReconciler) CleanupOrphanedWorkloads(
 		}
 		found := false
 		for _, role := range rbg.Spec.Roles {
-			if role.Workload.Kind == "LeaderWorkerSet" && rbg.GetWorkloadName(&role) == lws.Name {
+			if role.GetWorkload().Kind == "LeaderWorkerSet" && rbg.GetWorkloadName(&role) == lws.Name {
 				found = true
 				break
 			}

--- a/pkg/reconciler/lws_reconciler_test.go
+++ b/pkg/reconciler/lws_reconciler_test.go
@@ -236,7 +236,7 @@ func TestLeaderWorkerSetReconciler_CleanupOrphanedWorkloads(t *testing.T) {
 				{
 					Name:     "role1",
 					Replicas: ptr.To(int32(2)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "leaderworkerset.x-k8s.io/v1",
 						Kind:       "LeaderWorkerSet",
 					},

--- a/pkg/reconciler/svc_reconciler.go
+++ b/pkg/reconciler/svc_reconciler.go
@@ -139,7 +139,7 @@ func (r *ServiceReconciler) getObjectByKind(
 ) (client.Object, error) {
 	workloadName := rbg.GetWorkloadName(role)
 
-	switch role.Workload.String() {
+	switch role.GetWorkload().String() {
 	case constants.RoleInstanceSetWorkloadType:
 		obj := &workloadsv1alpha2.RoleInstanceSet{}
 		err := r.client.Get(ctx, types.NamespacedName{Name: workloadName, Namespace: rbg.Namespace}, obj)
@@ -149,7 +149,7 @@ func (r *ServiceReconciler) getObjectByKind(
 		err := r.client.Get(ctx, types.NamespacedName{Name: workloadName, Namespace: rbg.Namespace}, obj)
 		return obj, err
 	default:
-		return nil, fmt.Errorf("unsupported workload type: %s", role.Workload.String())
+		return nil, fmt.Errorf("unsupported workload type: %s", role.GetWorkload().String())
 	}
 }
 

--- a/pkg/reconciler/workload_reconciler.go
+++ b/pkg/reconciler/workload_reconciler.go
@@ -53,7 +53,7 @@ type PodGroupManagerSetter interface {
 }
 
 func NewWorkloadReconciler(
-	workload workloadsv1alpha2.WorkloadSpec, scheme *runtime.Scheme, client client.Client,
+	workload *workloadsv1alpha2.WorkloadSpec, scheme *runtime.Scheme, client client.Client,
 ) (WorkloadReconciler, error) {
 	switch {
 	case workload.String() == constants.DeploymentWorkloadType:

--- a/pkg/reconciler/workload_reconciler_test.go
+++ b/pkg/reconciler/workload_reconciler_test.go
@@ -86,7 +86,7 @@ func TestNewWorkloadReconciler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				reconciler, err := NewWorkloadReconciler(tt.workloadType, scheme, fakeClient)
+				reconciler, err := NewWorkloadReconciler(&tt.workloadType, scheme, fakeClient)
 
 				if tt.expectError {
 					if err == nil {

--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -432,7 +432,7 @@ func TestGetPatchAndRestore(t *testing.T) {
 				{
 					Name:     "role-sts",
 					Replicas: ptr.To(int32(1)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
@@ -461,7 +461,7 @@ func TestGetPatchAndRestore(t *testing.T) {
 				{
 					Name:     "role-lws",
 					Replicas: ptr.To(int32(1)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "leaderworkerset.x-k8s.io/v1",
 						Kind:       "LeaderWorkerSet",
 					},
@@ -709,7 +709,7 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 				{
 					Name:     "router",
 					Replicas: ptr.To(int32(3)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},
@@ -795,7 +795,7 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 				{
 					Name:     "decode",
 					Replicas: ptr.To(int32(5)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
@@ -843,7 +843,7 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 				{
 					Name:     "prefill",
 					Replicas: ptr.To(int32(3)),
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},
@@ -970,7 +970,7 @@ func getRBGWithRoleTemplates() *workloadsv1alpha2.RoleBasedGroup {
 							},
 						},
 					},
-					Workload: workloadsv1alpha2.WorkloadSpec{
+					Workload: &workloadsv1alpha2.WorkloadSpec{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},

--- a/test/e2e/framework/rbg_v2_expect.go
+++ b/test/e2e/framework/rbg_v2_expect.go
@@ -212,5 +212,5 @@ func (f *Framework) ExpectWorkloadV2ExclusiveTopology(
 
 // workloadTypeFromRoleV2 maps a v1alpha2 RoleSpec to the corresponding workload type string.
 func workloadTypeFromRoleV2(role workloadsv1alpha2.RoleSpec) string {
-	return role.Workload.String()
+	return role.GetWorkload().String()
 }

--- a/test/e2e/testcase/v1alpha2/debug.go
+++ b/test/e2e/testcase/v1alpha2/debug.go
@@ -57,7 +57,7 @@ func dumpDebugInfo(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup
 		workloadName := rbg.GetWorkloadName(&role)
 		fmt.Printf("\n--- Role: %s, Workload: %s ---\n", role.Name, workloadName)
 
-		switch role.Workload.String() {
+		switch role.GetWorkload().String() {
 		case constants.DeploymentWorkloadType:
 			dumpV2DeploymentWorkload(f, rbg.Namespace, workloadName)
 		case constants.StatefulSetWorkloadType:

--- a/test/e2e/testcase/v1alpha2/port_allocator.go
+++ b/test/e2e/testcase/v1alpha2/port_allocator.go
@@ -76,7 +76,7 @@ func buildPortAllocatorTestRBG(namespace string) *workloadsv1alpha2.RoleBasedGro
 		WithRoles([]workloadsv1alpha2.RoleSpec{
 			{
 				Name: "prefill",
-				Workload: workloadsv1alpha2.WorkloadSpec{
+				Workload: &workloadsv1alpha2.WorkloadSpec{
 					APIVersion: "workloads.x-k8s.io/v1alpha2",
 					Kind:       "RoleInstanceSet",
 				},

--- a/test/wrappers/v1alpha2/role_wrapper.go
+++ b/test/wrappers/v1alpha2/role_wrapper.go
@@ -70,7 +70,7 @@ func (rw *StandaloneRoleWrapper) WithRestartPolicy(rp workloadsv1alpha2.RestartP
 }
 
 func (rw *StandaloneRoleWrapper) WithWorkload(apiVersion, kind string) *StandaloneRoleWrapper {
-	rw.Workload = workloadsv1alpha2.WorkloadSpec{
+	rw.Workload = &workloadsv1alpha2.WorkloadSpec{
 		APIVersion: apiVersion,
 		Kind:       kind,
 	}
@@ -114,7 +114,7 @@ func BuildStandaloneRole(name string) *StandaloneRoleWrapper {
 			RolloutStrategy: &workloadsv1alpha2.RolloutStrategy{
 				Type: workloadsv1alpha2.RollingUpdateStrategyType,
 			},
-			Workload: workloadsv1alpha2.WorkloadSpec{
+			Workload: &workloadsv1alpha2.WorkloadSpec{
 				APIVersion: "workloads.x-k8s.io/v1alpha2",
 				Kind:       "RoleInstanceSet",
 			},
@@ -193,7 +193,7 @@ func BuildLeaderWorkerRole(name string) *LeaderWorkerRoleWrapper {
 			RolloutStrategy: &workloadsv1alpha2.RolloutStrategy{
 				Type: workloadsv1alpha2.RollingUpdateStrategyType,
 			},
-			Workload: workloadsv1alpha2.WorkloadSpec{
+			Workload: &workloadsv1alpha2.WorkloadSpec{
 				APIVersion: "leaderworkerset.x-k8s.io/v1",
 				Kind:       "LeaderWorkerSet",
 			},


### PR DESCRIPTION
### Ⅰ. Motivation
omitempty has no effect on non-pointer struct fields. Changed WorkloadSpec to a pointer type.

When creating an `RBG` resource via Go code and omitting the `Workload` field, it serializes to:
```json
"workload": {
  "apiVersion": "",
  "kind": ""
}
```

```
roleSpec = workloadsv1alpha2.RoleSpec{
    Name:     "inference",
    Replicas: &replicas,
    Pattern: workloadsv1alpha2.Pattern{
        StandalonePattern: &workloadsv1alpha2.StandalonePattern{
            TemplateSource: workloadsv1alpha2.TemplateSource{
                Template: rctx.PodTemplate,
            },
        },
    },
}
// Before fix: "workload": {"apiVersion": "", "kind": ""}
// After fix:  (field omitted entirely)
```