### PR TITLE
rbgcli: adds multi-node LLM inference serving support 

### DIFF
--- a/cmd/cli/cmd/llm/chat/chat.go
+++ b/cmd/cli/cmd/llm/chat/chat.go
@@ -141,19 +141,38 @@ port-forward tunnel, and communicates over the OpenAI /v1/chat/completions API.`
 			}
 
 			// 2. Find a ready pod for the service.
+			// For LeaderWorkerPattern (multi-node), only the leader (ComponentIndex=0) serves the API.
+			// For StandalonePattern (single-node), ComponentIndex is not set, so we fall back to any ready pod.
 			k8sClient, err := util.GetK8SClientSet(cf)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
-			labelSelector := labels.SelectorFromSet(labels.Set{
-				constants.GroupNameLabelKey: name,
-				constants.RoleNameLabelKey:  "inference",
+
+			// First try to find a leader pod (ComponentIndex=0) for multi-node deployments
+			leaderSelector := labels.SelectorFromSet(labels.Set{
+				constants.GroupNameLabelKey:      name,
+				constants.RoleNameLabelKey:       "inference",
+				constants.ComponentIndexLabelKey: "0",
 			}).String()
 			pods, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-				LabelSelector: labelSelector,
+				LabelSelector: leaderSelector,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to list pods: %w", err)
+			}
+
+			// If no leader pod found, fall back to any pod with the role (for single-node deployments)
+			if len(pods.Items) == 0 {
+				fallbackSelector := labels.SelectorFromSet(labels.Set{
+					constants.GroupNameLabelKey: name,
+					constants.RoleNameLabelKey:  "inference",
+				}).String()
+				pods, err = k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fallbackSelector,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to list pods: %w", err)
+				}
 			}
 
 			podName := ""
@@ -165,7 +184,7 @@ port-forward tunnel, and communicates over the OpenAI /v1/chat/completions API.`
 				}
 			}
 			if podName == "" {
-				return fmt.Errorf("no ready pods found for service %q (selector: %s)", name, labelSelector)
+				return fmt.Errorf("no ready pods found for service %q", name)
 			}
 
 			// 3. Resolve the local port.

--- a/cmd/cli/cmd/llm/chat/chat.go
+++ b/cmd/cli/cmd/llm/chat/chat.go
@@ -200,7 +200,7 @@ port-forward tunnel, and communicates over the OpenAI /v1/chat/completions API.`
 
 			// 5. Start port-forward tunnel.
 			fmt.Fprintf(os.Stderr, "Connecting to pod %s...\n", podName)
-			session, err := startPortForward(kubeconfig, namespace, podName, localPort, meta.Port, pfReadyTimeout)
+			session, err := StartPortForward(kubeconfig, namespace, podName, localPort, meta.Port, pfReadyTimeout)
 			if err != nil {
 				return fmt.Errorf("port-forward failed: %w", err)
 			}

--- a/cmd/cli/cmd/llm/chat/portforward.go
+++ b/cmd/cli/cmd/llm/chat/portforward.go
@@ -25,18 +25,20 @@ import (
 	"time"
 )
 
-// portForwardSession manages a kubectl port-forward subprocess lifetime.
-type portForwardSession struct {
+// PortForwardSession manages a kubectl port-forward subprocess lifetime.
+type PortForwardSession struct {
 	cmd      *exec.Cmd
-	stopChan chan struct{}
-	doneChan chan error
+	exitChan chan struct{} // closed when process exits, broadcasts to all waiters
+	mu       sync.RWMutex
+	alive    bool
+	stopped  bool
 }
 
-// startPortForward spawns a kubectl port-forward to the given pod and waits
+// StartPortForward spawns a kubectl port-forward to the given pod and waits
 // until the tunnel is ready (or returns an error). readyTimeout controls how
 // long to wait for the "Forwarding from" confirmation line. The caller must
 // call Stop() when the session is no longer needed.
-func startPortForward(kubeconfig, namespace, podName string, localPort, remotePort int32, readyTimeout time.Duration) (*portForwardSession, error) {
+func StartPortForward(kubeconfig, namespace, podName string, localPort, remotePort int32, readyTimeout time.Duration) (*PortForwardSession, error) {
 	args := []string{
 		"port-forward",
 		"-n", namespace,
@@ -62,8 +64,7 @@ func startPortForward(kubeconfig, namespace, podName string, localPort, remotePo
 		return nil, fmt.Errorf("port-forward start: %w", err)
 	}
 
-	stopChan := make(chan struct{})
-	doneChan := make(chan error, 1)
+	exitChan := make(chan struct{})
 	readyChan := make(chan struct{})
 
 	// Capture stderr so it can be included in error messages on failure.
@@ -97,25 +98,23 @@ func startPortForward(kubeconfig, namespace, podName string, localPort, remotePo
 		}
 	}()
 
-	// Stop goroutine: kill process when stopChan is closed.
+	// Monitor goroutine: wait for process to exit and close exitChan.
+	// This is the ONLY goroutine that calls cmd.Wait().
+	// Closing exitChan broadcasts to all waiters (Stop() and alive monitor).
 	go func() {
-		<-stopChan
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-		}
-	}()
-
-	// Wait goroutine: relay exit error to doneChan.
-	go func() {
-		doneChan <- cmd.Wait()
+		_ = cmd.Wait()
+		close(exitChan)
 	}()
 
 	// Wait for ready signal, process exit, or timeout.
 	select {
 	case <-readyChan:
 		// Tunnel is up.
-	case err := <-doneChan:
-		if err == nil {
+	case <-exitChan:
+		var err error
+		if cmd.ProcessState != nil && !cmd.ProcessState.Success() {
+			err = fmt.Errorf("port-forward exited with code %d", cmd.ProcessState.ExitCode())
+		} else {
 			err = fmt.Errorf("port-forward exited unexpectedly")
 		}
 		stderrMu.Lock()
@@ -126,24 +125,53 @@ func startPortForward(kubeconfig, namespace, podName string, localPort, remotePo
 		}
 		return nil, fmt.Errorf("port-forward failed before becoming ready: %w", err)
 	case <-time.After(readyTimeout):
-		close(stopChan)
+		// Kill the process on timeout
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
 		return nil, fmt.Errorf("timeout waiting for port-forward to become ready")
 	}
 
-	return &portForwardSession{
+	session := &PortForwardSession{
 		cmd:      cmd,
-		stopChan: stopChan,
-		doneChan: doneChan,
-	}, nil
+		exitChan: exitChan,
+		alive:    true,
+	}
+
+	// Update alive status when process exits
+	go func() {
+		<-exitChan
+		session.mu.Lock()
+		session.alive = false
+		session.mu.Unlock()
+	}()
+
+	return session, nil
+}
+
+// IsAlive returns true if the port-forward process is still running.
+func (s *PortForwardSession) IsAlive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.alive
 }
 
 // Stop terminates the port-forward subprocess.
-func (s *portForwardSession) Stop() {
-	select {
-	case <-s.stopChan:
-		// Already stopped.
-	default:
-		close(s.stopChan)
+func (s *PortForwardSession) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
 	}
-	<-s.doneChan
+	s.stopped = true
+	s.mu.Unlock()
+
+	// Kill the process if it's still running
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+
+	// Wait for process to exit (exitChan closed by monitor goroutine)
+	// Multiple goroutines can safely receive from a closed channel.
+	<-s.exitChan
 }

--- a/cmd/cli/cmd/llm/pull.go
+++ b/cmd/cli/cmd/llm/pull.go
@@ -295,7 +295,7 @@ const (
 
 	// DefaultPull* constants control Job behavior for model download jobs.
 	DefaultPullBackoffLimit            = int32(3)     // retry up to 3 times on failure
-	DefaultPullActiveDeadlineSeconds   = int64(7200)  // 2 hours max runtime for large models
+	DefaultPullActiveDeadlineSeconds   = int64(86400) // 24 hours max runtime for large models
 	DefaultPullTTLSecondsAfterFinished = int32(86400) // keep job 24 hours after completion
 )
 

--- a/cmd/cli/cmd/llm/pull_test.go
+++ b/cmd/cli/cmd/llm/pull_test.go
@@ -85,7 +85,7 @@ func TestBuildPullJob_Limits(t *testing.T) {
 	tpl := &corev1.PodTemplateSpec{}
 	job := buildPullJob("m", tpl)
 	assert.Equal(t, int32(3), *job.Spec.BackoffLimit)
-	assert.Equal(t, int64(7200), *job.Spec.ActiveDeadlineSeconds)
+	assert.Equal(t, int64(86400), *job.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int32(86400), *job.Spec.TTLSecondsAfterFinished)
 }
 

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -171,6 +171,7 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		Env:             envVars,
 		Resources:       resources,
 		DistributedSize: distributedSize,
+		ShmSize:         modeCfg.ShmSize,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate engine template: %w", err)

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -17,19 +17,28 @@ limitations under the License.
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/cmd/cli/cmd/llm/chat"
 	llmmeta "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/metadata"
 	runpkg "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/run"
 	cliconfig "sigs.k8s.io/rbgs/cmd/cli/config"
@@ -242,13 +251,14 @@ func assembleRBG(name, namespace string, pattern *workloadsv1alpha2.Pattern, met
 	}
 }
 
-// generateRBG generates a RoleBasedGroup and prints summary information.
+// generateRBG generates a RoleBasedGroup.
 // It performs: model config resolution → pattern generation → storage mounting → RBG assembly.
-func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfig.Config, cf *genericclioptions.ConfigFlags) (*workloadsv1alpha2.RoleBasedGroup, error) {
+// Returns the generated RBG and metadata.
+func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfig.Config, cf *genericclioptions.ConfigFlags) (*workloadsv1alpha2.RoleBasedGroup, llmmeta.RunMetadata, error) {
 	// 1. Resolve model/mode/engine config
 	modeRes, err := resolveModeConfig(modelID, p, userCfg)
 	if err != nil {
-		return nil, err
+		return nil, llmmeta.RunMetadata{}, err
 	}
 
 	// 2. Resolve storage and model path
@@ -257,17 +267,17 @@ func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfi
 	// 3. Build GenerateOptions
 	opts, err := buildGenerateOptions(name, modelID, storageRes.modelPath, modeRes.modeCfg, p)
 	if err != nil {
-		return nil, err
+		return nil, llmmeta.RunMetadata{}, err
 	}
 
 	// 4. Generate pattern
 	pattern, err := modeRes.enginePlugin.GeneratePattern(opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate engine pattern: %w", err)
+		return nil, llmmeta.RunMetadata{}, fmt.Errorf("failed to generate engine pattern: %w", err)
 	}
 	podTemplate := getPodTemplateFromPattern(pattern)
 	if podTemplate == nil || len(podTemplate.Spec.Containers) == 0 {
-		return nil, fmt.Errorf("engine %q generated pattern with no containers", modeRes.engineType)
+		return nil, llmmeta.RunMetadata{}, fmt.Errorf("engine %q generated pattern with no containers", modeRes.engineType)
 	}
 
 	// 5. Mount storage
@@ -280,12 +290,12 @@ func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfi
 		if !p.DryRun {
 			c, err := util.GetControllerRuntimeClient(cf)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create controller client: %w", err)
+				return nil, llmmeta.RunMetadata{}, fmt.Errorf("failed to create controller client: %w", err)
 			}
 			mountOpts.Client = c
 		}
 		if err := storageRes.storagePlugin.MountStorage(podTemplate, mountOpts); err != nil {
-			return nil, fmt.Errorf("failed to mount storage: %w", err)
+			return nil, llmmeta.RunMetadata{}, fmt.Errorf("failed to mount storage: %w", err)
 		}
 	}
 
@@ -308,18 +318,19 @@ func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfi
 	// 7. Assemble RBG
 	rbg := assembleRBG(name, namespace, pattern, metadata, p.Replicas)
 
-	// 8. Print summary
-	fmt.Println("# Generated RoleBasedGroup for Model Serving")
-	fmt.Printf("# Name:      %s\n", name)
-	fmt.Printf("# Namespace: %s\n", namespace)
-	fmt.Printf("# Model:     %s\n", modelID)
-	fmt.Printf("# Revision:  %s\n", p.Revision)
-	fmt.Printf("# Mode:      %s\n", modeRes.modeCfg.Name)
-	fmt.Printf("# Engine:    %s\n", modeRes.engineType)
-	fmt.Printf("# Replicas:  %d\n", p.Replicas)
-	fmt.Println("#")
+	return rbg, metadata, nil
+}
 
-	return rbg, nil
+// printGenerateSummary prints a human-readable summary of the generated RBG.
+func printGenerateSummary(w io.Writer, rbg *workloadsv1alpha2.RoleBasedGroup, metadata llmmeta.RunMetadata) {
+	_, _ = fmt.Fprintln(w, "# Generated RoleBasedGroup for Model Serving")
+	_, _ = fmt.Fprintf(w, "# Name:      %s\n", rbg.Name)
+	_, _ = fmt.Fprintf(w, "# Namespace: %s\n", rbg.GetNamespace())
+	_, _ = fmt.Fprintf(w, "# Model:     %s\n", metadata.ModelID)
+	_, _ = fmt.Fprintf(w, "# Revision:  %s\n", metadata.Revision)
+	_, _ = fmt.Fprintf(w, "# Mode:      %s\n", metadata.Mode)
+	_, _ = fmt.Fprintf(w, "# Engine:    %s\n", metadata.Engine)
+	_, _ = fmt.Fprintln(w, "#")
 }
 
 // getPodTemplateFromPattern extracts the pod template from a Pattern
@@ -351,16 +362,213 @@ func createRBG(ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup, cf *g
 	return nil
 }
 
+// waitForRBGReady waits for the RBG to be ready (Ready condition status is True)
+func waitForRBGReady(ctx context.Context, name, namespace string, cf *genericclioptions.ConfigFlags, timeout time.Duration) error {
+	client, err := util.GetRBGClient(cf)
+	if err != nil {
+		return fmt.Errorf("failed to create RBG client: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Waiting for RoleBasedGroup '%s' to be ready...\n", name)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var lastMsg string
+	err = wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		rbg, err := client.WorkloadsV1alpha2().RoleBasedGroups(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// Check if Ready condition is True
+		for _, cond := range rbg.Status.Conditions {
+			if cond.Type == string(workloadsv1alpha2.RoleBasedGroupReady) {
+				if cond.Status == metav1.ConditionTrue {
+					return true, nil
+				}
+				// Not ready yet, continue polling
+				lastMsg = cond.Message
+				return false, nil
+			}
+		}
+		// Ready condition not found yet, continue polling
+		return false, nil
+	})
+
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("timeout waiting for RoleBasedGroup '%s' to be ready: %s", name, lastMsg)
+		}
+		return fmt.Errorf("failed to wait for RoleBasedGroup ready: %w", err)
+	}
+
+	return nil
+}
+
+// findReadyPod finds a ready pod for the given RBG.
+// For LeaderWorkerPattern (multi-node), only the leader (ComponentIndex=0) serves the API.
+// For StandalonePattern (single-node), ComponentIndex is not set, so we fall back to any ready pod.
+func findReadyPod(ctx context.Context, name, namespace string, cf *genericclioptions.ConfigFlags) (string, error) {
+	k8sClient, err := util.GetK8SClientSet(cf)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	// First try to find a leader pod (ComponentIndex=0) for multi-node deployments
+	leaderSelector := labels.SelectorFromSet(labels.Set{
+		constants.GroupNameLabelKey:      name,
+		constants.RoleNameLabelKey:       "inference",
+		constants.ComponentIndexLabelKey: "0",
+	}).String()
+
+	pods, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: leaderSelector,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	// If no leader pod found, fall back to any pod with the role (for single-node deployments)
+	if len(pods.Items) == 0 {
+		fallbackSelector := labels.SelectorFromSet(labels.Set{
+			constants.GroupNameLabelKey: name,
+			constants.RoleNameLabelKey:  "inference",
+		}).String()
+		pods, err = k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fallbackSelector,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to list pods: %w", err)
+		}
+	}
+
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if isPodReady(p) {
+			return p.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no ready pods found for service %q", name)
+}
+
+// isPodReady checks if a pod is ready
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// testChatCompletionsWithReconnect tests the API with automatic port-forward reconstruction on disconnect
+// The session is automatically stopped when the function returns (success or error)
+func testChatCompletionsWithReconnect(
+	baseURL, modelName string,
+	timeout time.Duration,
+	pfSession *chat.PortForwardSession,
+	reconnectFunc func() (*chat.PortForwardSession, error),
+) error {
+	reqBody := map[string]interface{}{
+		"model":      modelName,
+		"messages":   []map[string]string{{"role": "user", "content": "Hello"}},
+		"stream":     false,
+		"max_tokens": 10,
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		pfSession.Stop()
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	requestTimeout := 30 * time.Second
+	if timeout < requestTimeout {
+		requestTimeout = timeout
+	}
+
+	client := &http.Client{Timeout: requestTimeout}
+	endpoint := baseURL + "/v1/chat/completions"
+
+	startTime := time.Now()
+	attempt := 0
+	reconnectAttempt := 0
+	currentSession := pfSession
+
+	for {
+		attempt++
+		remaining := timeout - time.Since(startTime)
+		if remaining <= 0 {
+			currentSession.Stop()
+			return fmt.Errorf("timeout waiting for API to be ready after %s", timeout)
+		}
+
+		// Check if port-forward is still alive before making request
+		if !currentSession.IsAlive() {
+			reconnectAttempt++
+			if reconnectAttempt%5 == 1 {
+				fmt.Fprintf(os.Stderr, "  Port-forward disconnected, attempting to reconnect... (attempt %d, elapsed: %s)\n", reconnectAttempt, time.Since(startTime).Round(time.Second))
+			}
+			currentSession.Stop()
+
+			newSession, err := reconnectFunc()
+			if err != nil {
+				return fmt.Errorf("failed to reconnect port-forward: %w", err)
+			}
+			currentSession = newSession
+			if reconnectAttempt%5 == 1 {
+				fmt.Fprintf(os.Stderr, "  Port-forward reconnected successfully\n")
+			}
+		}
+
+		resp, err := client.Post(endpoint, "application/json", bytes.NewReader(data))
+		if err == nil && resp.StatusCode == http.StatusOK {
+			_ = resp.Body.Close()
+			currentSession.Stop()
+			return nil
+		}
+
+		var errMsg string
+		if err != nil {
+			errMsg = fmt.Sprintf("error: %v", err)
+		} else {
+			body, _ := io.ReadAll(resp.Body)
+			errMsg = fmt.Sprintf("status: %d, body: %s", resp.StatusCode, string(body))
+			_ = resp.Body.Close()
+		}
+
+		if attempt%5 == 0 {
+			fmt.Fprintf(os.Stderr, "  API not ready yet (%s), retrying... (attempt %d, elapsed: %s)\n", errMsg, attempt, time.Since(startTime).Round(time.Second))
+		}
+
+		sleepDuration := 5 * time.Second
+		if remaining < sleepDuration {
+			sleepDuration = remaining
+		}
+		time.Sleep(sleepDuration)
+	}
+}
+
 func newRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 	var (
-		replicas int32
-		mode     string
-		engine   string
-		envVars  []string
-		argsList []string
-		storage  string
-		revision string
-		dryRun   bool
+		replicas       int32
+		mode           string
+		engine         string
+		envVars        []string
+		argsList       []string
+		storage        string
+		revision       string
+		dryRun         bool
+		waitReady      bool
+		waitTimeout    time.Duration
+		testAPI        bool
+		testAPITimeout time.Duration
+		localPort      int32
 	)
 
 	cmd := &cobra.Command{
@@ -417,7 +625,7 @@ Examples:
 			}
 
 			// Generate RBG (includes config resolution, pattern generation, storage mounting)
-			rbg, err := generateRBG(name, modelID, namespace, RunParams{
+			params := RunParams{
 				Mode:     mode,
 				Engine:   engine,
 				Storage:  storage,
@@ -426,10 +634,13 @@ Examples:
 				ArgsList: argsList,
 				DryRun:   dryRun,
 				Replicas: replicas,
-			}, userCfg, cf)
+			}
+			rbg, metadata, err := generateRBG(name, modelID, namespace, params, userCfg, cf)
 			if err != nil {
 				return err
 			}
+
+			printGenerateSummary(os.Stdout, rbg, metadata)
 
 			if dryRun {
 				fmt.Println("# DRY RUN: No workload will be created")
@@ -445,6 +656,51 @@ Examples:
 			}
 
 			fmt.Printf("✓ RoleBasedGroup '%s' created successfully in namespace '%s'\n", name, namespace)
+
+			// Wait for RBG to be ready if requested
+			if waitReady || testAPI {
+				if err := waitForRBGReady(ctx, name, namespace, cf, waitTimeout); err != nil {
+					return err
+				}
+				fmt.Printf("✓ RoleBasedGroup '%s' is ready\n", name)
+			}
+
+			// Test API if requested
+			if testAPI {
+				// Find a ready pod
+				podName, err := findReadyPod(ctx, name, namespace, cf)
+				if err != nil {
+					return fmt.Errorf("failed to find ready pod: %w", err)
+				}
+
+				// Get kubeconfig path for port-forward
+				kubeconfig := ""
+				if cf.KubeConfig != nil {
+					kubeconfig = *cf.KubeConfig
+				}
+
+				// Start port-forward
+				fmt.Fprintf(os.Stderr, "Testing API endpoint...\n")
+				pfSession, err := chat.StartPortForward(kubeconfig, namespace, podName, localPort, metadata.Port, 30*time.Second)
+				if err != nil {
+					return fmt.Errorf("failed to start port-forward: %w", err)
+				}
+
+				// Test the API with automatic port-forward reconstruction
+				baseURL := fmt.Sprintf("http://localhost:%d", localPort)
+				if err := testChatCompletionsWithReconnect(baseURL, name, testAPITimeout, pfSession, func() (*chat.PortForwardSession, error) {
+					// Reconnect function: find new ready pod and restart port-forward
+					newPodName, err := findReadyPod(ctx, name, namespace, cf)
+					if err != nil {
+						return nil, err
+					}
+					return chat.StartPortForward(kubeconfig, namespace, newPodName, localPort, metadata.Port, 30*time.Second)
+				}); err != nil {
+					return fmt.Errorf("API test failed: %w", err)
+				}
+				fmt.Printf("✓ API endpoint is ready (/v1/chat/completions)\n")
+			}
+
 			return nil
 		},
 	}
@@ -457,6 +713,11 @@ Examples:
 	cmd.Flags().StringVar(&storage, "storage", "", "Storage to use (overrides default)")
 	cmd.Flags().StringVar(&revision, "revision", "main", "Model revision")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the generated template without creating the workload")
+	cmd.Flags().BoolVar(&waitReady, "wait", true, "Wait for the RoleBasedGroup to be ready before returning")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 20*time.Minute, "Timeout for waiting for RoleBasedGroup to be ready")
+	cmd.Flags().BoolVar(&testAPI, "test-api", true, "Test the /v1/chat/completions API endpoint after the service is ready")
+	cmd.Flags().DurationVar(&testAPITimeout, "test-api-timeout", 5*time.Minute, "Timeout for testing the API endpoint")
+	cmd.Flags().Int32Var(&localPort, "local-port", 32432, "Local port for port-forward when testing API")
 
 	return cmd
 }

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -157,8 +157,14 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 	// 6. Build resource requirements from ResourceList
 	var resources corev1.ResourceRequirements
 	if len(modeCfg.Resources) > 0 {
-		resources.Requests = modeCfg.Resources
-		resources.Limits = modeCfg.Resources
+		requests := corev1.ResourceList{}
+		limits := corev1.ResourceList{}
+		for k, v := range modeCfg.Resources {
+			requests[k] = v
+			limits[k] = v
+		}
+		resources.Requests = requests
+		resources.Limits = limits
 	}
 
 	// 7. Generate pod template using engine plugin with all options

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
@@ -74,12 +73,13 @@ type RunParams struct {
 
 // runContext holds the fully resolved artifacts produced by resolveRunContext.
 type runContext struct {
-	PodTemplate   *corev1.PodTemplateSpec
-	EngineType    string
-	ModeName      string
-	ResolvedPort  int32
-	StoragePlugin storageplugin.Plugin
-	StorageName   string
+	PodTemplate     *corev1.PodTemplateSpec
+	EngineType      string
+	ModeName        string
+	ResolvedPort    int32
+	StoragePlugin   storageplugin.Plugin
+	StorageName     string
+	DistributedSize int32 // Multi-node deployment size, <= 1 means standalone
 }
 
 // resolveRunContext performs all pure data resolution for the run command:
@@ -137,55 +137,46 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		modelPath = "/model/" + sanitizeModelID(modelID) + "/" + sanitizeModelID(p.Revision)
 	}
 
-	// 4. Generate base pod template and validate
-	podTemplate, err := enginePlugin.GenerateTemplate(name, modelID, modelPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate engine template: %w", err)
+	// 4. Extract distributed size from mode config
+	distributedSize := int32(0)
+	if modeCfg.Distributed != nil && modeCfg.Distributed.Size > 1 {
+		distributedSize = modeCfg.Distributed.Size
 	}
-	if len(podTemplate.Spec.Containers) == 0 {
-		return nil, fmt.Errorf("engine %q generated template with no containers", engineType)
-	}
-	container := &podTemplate.Spec.Containers[0]
 
-	// 5. Overlay mode config
-	if modeCfg.Image != "" {
-		container.Image = modeCfg.Image
-	}
-	container.Args = append(container.Args, modeCfg.Args...)
-	container.Args = append(container.Args, p.ArgsList...)
-
-	for _, e := range modeCfg.Env {
-		container.Env = append(container.Env, corev1.EnvVar{Name: e.Name, Value: e.Value})
-	}
+	// 5. Build environment variables
+	envVars := make([]corev1.EnvVar, len(modeCfg.Env))
+	copy(envVars, modeCfg.Env)
 	for _, ev := range p.EnvVars {
 		parts := strings.SplitN(ev, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
 		}
-		container.Env = append(container.Env, corev1.EnvVar{Name: parts[0], Value: parts[1]})
+		envVars = append(envVars, corev1.EnvVar{Name: parts[0], Value: parts[1]})
 	}
 
-	// 6. Apply resource overrides
-	effGPU := modeCfg.Resources.GPU
-	effCPU := modeCfg.Resources.CPU
-	effMemory := modeCfg.Resources.Memory
-	if effGPU > 0 {
-		if container.Resources.Limits == nil {
-			container.Resources.Limits = make(corev1.ResourceList)
-		}
-		container.Resources.Limits[corev1.ResourceName("nvidia.com/gpu")] = resource.MustParse(fmt.Sprintf("%d", effGPU))
+	// 6. Build resource requirements from ResourceList
+	var resources corev1.ResourceRequirements
+	if len(modeCfg.Resources) > 0 {
+		resources.Requests = modeCfg.Resources
+		resources.Limits = modeCfg.Resources
 	}
-	if effCPU > 0 {
-		if container.Resources.Requests == nil {
-			container.Resources.Requests = make(corev1.ResourceList)
-		}
-		container.Resources.Requests[corev1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%d", effCPU))
+
+	// 7. Generate pod template using engine plugin with all options
+	podTemplate, err := enginePlugin.GenerateTemplate(engineplugin.GenerateOptions{
+		Name:            name,
+		ModelID:         modelID,
+		ModelPath:       modelPath,
+		Image:           modeCfg.Image,
+		Args:            append(modeCfg.Args, p.ArgsList...),
+		Env:             envVars,
+		Resources:       resources,
+		DistributedSize: distributedSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate engine template: %w", err)
 	}
-	if effMemory != "" {
-		if container.Resources.Requests == nil {
-			container.Resources.Requests = make(corev1.ResourceList)
-		}
-		container.Resources.Requests[corev1.ResourceMemory] = resource.MustParse(effMemory)
+	if len(podTemplate.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("engine %q generated template with no containers", engineType)
 	}
 
 	if podTemplate.ObjectMeta.Labels == nil {
@@ -202,12 +193,13 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 	}
 
 	return &runContext{
-		PodTemplate:   podTemplate,
-		EngineType:    engineType,
-		ModeName:      modeCfg.Name,
-		ResolvedPort:  resolvedPort,
-		StoragePlugin: storagePlugin,
-		StorageName:   storageName,
+		PodTemplate:     podTemplate,
+		EngineType:      engineType,
+		ModeName:        modeCfg.Name,
+		ResolvedPort:    resolvedPort,
+		StoragePlugin:   storagePlugin,
+		StorageName:     storageName,
+		DistributedSize: distributedSize,
 	}, nil
 }
 
@@ -234,6 +226,50 @@ func generateRBG(name, namespace, modelID, revision string, replicas int32, rctx
 	// Set standard labels on pod template
 	rctx.PodTemplate.ObjectMeta.Labels[llmmeta.RunCommandSourceLabelKey] = llmmeta.RunCommandSourceLabelValue
 
+	// Build role spec based on deployment mode (standalone or distributed)
+	// Note: Workload field is deprecated and should not be set.
+	// The controller will automatically use the appropriate workload type
+	// based on the pattern (StandalonePattern -> RoleInstanceSet, LeaderWorkerPattern -> LeaderWorkerSet).
+	var roleSpec workloadsv1alpha2.RoleSpec
+	if rctx.DistributedSize > 1 {
+		// Multi-node deployment using LeaderWorkerPattern
+		roleSpec = workloadsv1alpha2.RoleSpec{
+			Name:     "inference",
+			Replicas: &replicas,
+			Pattern: workloadsv1alpha2.Pattern{
+				LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{
+					Size: &rctx.DistributedSize,
+					TemplateSource: workloadsv1alpha2.TemplateSource{
+						Template: rctx.PodTemplate,
+					},
+				},
+			},
+			// TODO: Remove workload field after PR #261
+			Workload: workloadsv1alpha2.WorkloadSpec{
+				APIVersion: "workloads.x-k8s.io/v1alpha2",
+				Kind:       "RoleInstanceSet",
+			},
+		}
+	} else {
+		// Single-node deployment using StandalonePattern
+		roleSpec = workloadsv1alpha2.RoleSpec{
+			Name:     "inference",
+			Replicas: &replicas,
+			Pattern: workloadsv1alpha2.Pattern{
+				StandalonePattern: &workloadsv1alpha2.StandalonePattern{
+					TemplateSource: workloadsv1alpha2.TemplateSource{
+						Template: rctx.PodTemplate,
+					},
+				},
+			},
+			// TODO: Remove workload field after PR #261
+			Workload: workloadsv1alpha2.WorkloadSpec{
+				APIVersion: "workloads.x-k8s.io/v1alpha2",
+				Kind:       "RoleInstanceSet",
+			},
+		}
+	}
+
 	// Create the RoleBasedGroup
 	return &workloadsv1alpha2.RoleBasedGroup{
 		TypeMeta: metav1.TypeMeta{
@@ -251,23 +287,7 @@ func generateRBG(name, namespace, modelID, revision string, replicas int32, rctx
 			},
 		},
 		Spec: workloadsv1alpha2.RoleBasedGroupSpec{
-			Roles: []workloadsv1alpha2.RoleSpec{
-				{
-					Name:     "inference",
-					Replicas: &replicas,
-					Pattern: workloadsv1alpha2.Pattern{
-						StandalonePattern: &workloadsv1alpha2.StandalonePattern{
-							TemplateSource: workloadsv1alpha2.TemplateSource{
-								Template: rctx.PodTemplate,
-							},
-						},
-					},
-					Workload: workloadsv1alpha2.WorkloadSpec{
-						APIVersion: "workloads.x-k8s.io/v1alpha2",
-						Kind:       "RoleInstanceSet",
-					},
-				},
-			},
+			Roles: []workloadsv1alpha2.RoleSpec{roleSpec},
 		},
 	}
 }

--- a/cmd/cli/cmd/llm/run.go
+++ b/cmd/cli/cmd/llm/run.go
@@ -69,25 +69,20 @@ type RunParams struct {
 	Revision string
 	EnvVars  []string
 	ArgsList []string
+	DryRun   bool
+	Replicas int32
 }
 
-// runContext holds the fully resolved artifacts produced by resolveRunContext.
-type runContext struct {
-	PodTemplate     *corev1.PodTemplateSpec
-	EngineType      string
-	ModeName        string
-	ResolvedPort    int32
-	StoragePlugin   storageplugin.Plugin
-	StorageName     string
-	DistributedSize int32 // Multi-node deployment size, <= 1 means standalone
+// modeConfigResult holds the result of mode config resolution.
+type modeConfigResult struct {
+	modelCfg     *runpkg.ModelConfig
+	modeCfg      *runpkg.ModeConfig
+	enginePlugin engineplugin.Plugin
+	engineType   string
 }
 
-// resolveRunContext performs all pure data resolution for the run command:
-// model/mode lookup → engine resolution → storage/model-path resolution →
-// pod template construction → resource overlay → port extraction.
-// It has no side effects and is independently testable.
-func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Config) (*runContext, error) {
-	// 1. Load and find model + mode config
+// resolveModeConfig resolves model, mode, and engine configuration.
+func resolveModeConfig(modelID string, p RunParams, userCfg *cliconfig.Config) (*modeConfigResult, error) {
 	models, err := runpkg.LoadAllModels()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load model configs: %w", err)
@@ -101,7 +96,6 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		return nil, err
 	}
 
-	// 2. Resolve engine type (flag overrides mode config)
 	engineType := modeCfg.Engine
 	if p.Engine != "" {
 		engineType = p.Engine
@@ -115,10 +109,27 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		return nil, fmt.Errorf("failed to initialize engine %q: %w", engineType, err)
 	}
 
-	// 3. Resolve storage plugin and model path
+	return &modeConfigResult{
+		modelCfg:     modelCfg,
+		modeCfg:      modeCfg,
+		enginePlugin: enginePlugin,
+		engineType:   engineType,
+	}, nil
+}
+
+// storageResult holds the result of storage resolution.
+type storageResult struct {
+	modelPath     string
+	storagePlugin storageplugin.Plugin
+	storageName   string
+}
+
+// resolveStorageAndModelPath resolves storage plugin and model path.
+func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.Config) *storageResult {
 	var modelPath string
 	var storagePlugin storageplugin.Plugin
 	var storageName string
+
 	if userCfg != nil {
 		storageName = userCfg.CurrentStorage
 		if p.Storage != "" {
@@ -137,24 +148,30 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		modelPath = "/model/" + sanitizeModelID(modelID) + "/" + sanitizeModelID(p.Revision)
 	}
 
-	// 4. Extract distributed size from mode config
+	return &storageResult{
+		modelPath:     modelPath,
+		storagePlugin: storagePlugin,
+		storageName:   storageName,
+	}
+}
+
+// buildGenerateOptions builds GenerateOptions from mode config and run params.
+func buildGenerateOptions(name, modelID, modelPath string, modeCfg *runpkg.ModeConfig, p RunParams) (engineplugin.GenerateOptions, error) {
 	distributedSize := int32(0)
 	if modeCfg.Distributed != nil && modeCfg.Distributed.Size > 1 {
 		distributedSize = modeCfg.Distributed.Size
 	}
 
-	// 5. Build environment variables
 	envVars := make([]corev1.EnvVar, len(modeCfg.Env))
 	copy(envVars, modeCfg.Env)
 	for _, ev := range p.EnvVars {
 		parts := strings.SplitN(ev, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
+			return engineplugin.GenerateOptions{}, fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
 		}
 		envVars = append(envVars, corev1.EnvVar{Name: parts[0], Value: parts[1]})
 	}
 
-	// 6. Build resource requirements from ResourceList
 	var resources corev1.ResourceRequirements
 	if len(modeCfg.Resources) > 0 {
 		requests := corev1.ResourceList{}
@@ -167,8 +184,7 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		resources.Limits = limits
 	}
 
-	// 7. Generate pod template using engine plugin with all options
-	podTemplate, err := enginePlugin.GenerateTemplate(engineplugin.GenerateOptions{
+	return engineplugin.GenerateOptions{
 		Name:            name,
 		ModelID:         modelID,
 		ModelPath:       modelPath,
@@ -178,106 +194,33 @@ func resolveRunContext(name, modelID string, p RunParams, userCfg *cliconfig.Con
 		Resources:       resources,
 		DistributedSize: distributedSize,
 		ShmSize:         modeCfg.ShmSize,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate engine template: %w", err)
-	}
-	if len(podTemplate.Spec.Containers) == 0 {
-		return nil, fmt.Errorf("engine %q generated template with no containers", engineType)
-	}
-
-	if podTemplate.ObjectMeta.Labels == nil {
-		podTemplate.ObjectMeta.Labels = make(map[string]string)
-	}
-
-	// 7. Extract resolved port from the generated template (ground truth for what is deployed)
-	var resolvedPort int32
-	for _, cp := range podTemplate.Spec.Containers[0].Ports {
-		if cp.Name == "http" {
-			resolvedPort = cp.ContainerPort
-			break
-		}
-	}
-
-	return &runContext{
-		PodTemplate:     podTemplate,
-		EngineType:      engineType,
-		ModeName:        modeCfg.Name,
-		ResolvedPort:    resolvedPort,
-		StoragePlugin:   storagePlugin,
-		StorageName:     storageName,
-		DistributedSize: distributedSize,
 	}, nil
 }
 
-// generateRBG creates a v1alpha2 RoleBasedGroup from the pod template and configuration
-func generateRBG(name, namespace, modelID, revision string, replicas int32, rctx *runContext) *workloadsv1alpha2.RoleBasedGroup {
-	// Build metadata annotation as JSON
-	metadata := llmmeta.RunMetadata{
-		ModelID:  modelID,
-		Engine:   rctx.EngineType,
-		Mode:     rctx.ModeName,
-		Revision: revision,
-		Port:     rctx.ResolvedPort,
+// assembleRBG assembles a RoleBasedGroup from pattern and metadata.
+func assembleRBG(name, namespace string, pattern *workloadsv1alpha2.Pattern, metadata llmmeta.RunMetadata, replicas int32) *workloadsv1alpha2.RoleBasedGroup {
+	podTemplate := getPodTemplateFromPattern(pattern)
+	if podTemplate.ObjectMeta.Labels == nil {
+		podTemplate.ObjectMeta.Labels = make(map[string]string)
 	}
+	podTemplate.ObjectMeta.Labels[llmmeta.RunCommandSourceLabelKey] = llmmeta.RunCommandSourceLabelValue
+
 	metadataJSON, err := json.Marshal(metadata)
 	if err != nil {
 		klog.V(1).Infof("failed to marshal run metadata: %v", err)
 	}
 
-	// Ensure pod template has labels
-	if rctx.PodTemplate.ObjectMeta.Labels == nil {
-		rctx.PodTemplate.ObjectMeta.Labels = make(map[string]string)
+	roleSpec := workloadsv1alpha2.RoleSpec{
+		Name:     "inference",
+		Replicas: &replicas,
+		Pattern:  *pattern,
+		// TODO: Remove workload field after PR #261
+		Workload: workloadsv1alpha2.WorkloadSpec{
+			APIVersion: "workloads.x-k8s.io/v1alpha2",
+			Kind:       "RoleInstanceSet",
+		},
 	}
 
-	// Set standard labels on pod template
-	rctx.PodTemplate.ObjectMeta.Labels[llmmeta.RunCommandSourceLabelKey] = llmmeta.RunCommandSourceLabelValue
-
-	// Build role spec based on deployment mode (standalone or distributed)
-	// Note: Workload field is deprecated and should not be set.
-	// The controller will automatically use the appropriate workload type
-	// based on the pattern (StandalonePattern -> RoleInstanceSet, LeaderWorkerPattern -> LeaderWorkerSet).
-	var roleSpec workloadsv1alpha2.RoleSpec
-	if rctx.DistributedSize > 1 {
-		// Multi-node deployment using LeaderWorkerPattern
-		roleSpec = workloadsv1alpha2.RoleSpec{
-			Name:     "inference",
-			Replicas: &replicas,
-			Pattern: workloadsv1alpha2.Pattern{
-				LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{
-					Size: &rctx.DistributedSize,
-					TemplateSource: workloadsv1alpha2.TemplateSource{
-						Template: rctx.PodTemplate,
-					},
-				},
-			},
-			// TODO: Remove workload field after PR #261
-			Workload: workloadsv1alpha2.WorkloadSpec{
-				APIVersion: "workloads.x-k8s.io/v1alpha2",
-				Kind:       "RoleInstanceSet",
-			},
-		}
-	} else {
-		// Single-node deployment using StandalonePattern
-		roleSpec = workloadsv1alpha2.RoleSpec{
-			Name:     "inference",
-			Replicas: &replicas,
-			Pattern: workloadsv1alpha2.Pattern{
-				StandalonePattern: &workloadsv1alpha2.StandalonePattern{
-					TemplateSource: workloadsv1alpha2.TemplateSource{
-						Template: rctx.PodTemplate,
-					},
-				},
-			},
-			// TODO: Remove workload field after PR #261
-			Workload: workloadsv1alpha2.WorkloadSpec{
-				APIVersion: "workloads.x-k8s.io/v1alpha2",
-				Kind:       "RoleInstanceSet",
-			},
-		}
-	}
-
-	// Create the RoleBasedGroup
 	return &workloadsv1alpha2.RoleBasedGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "workloads.x-k8s.io/v1alpha2",
@@ -299,14 +242,108 @@ func generateRBG(name, namespace, modelID, revision string, replicas int32, rctx
 	}
 }
 
+// generateRBG generates a RoleBasedGroup and prints summary information.
+// It performs: model config resolution → pattern generation → storage mounting → RBG assembly.
+func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfig.Config, cf *genericclioptions.ConfigFlags) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	// 1. Resolve model/mode/engine config
+	modeRes, err := resolveModeConfig(modelID, p, userCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Resolve storage and model path
+	storageRes := resolveStorageAndModelPath(modelID, p, userCfg)
+
+	// 3. Build GenerateOptions
+	opts, err := buildGenerateOptions(name, modelID, storageRes.modelPath, modeRes.modeCfg, p)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Generate pattern
+	pattern, err := modeRes.enginePlugin.GeneratePattern(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate engine pattern: %w", err)
+	}
+	podTemplate := getPodTemplateFromPattern(pattern)
+	if podTemplate == nil || len(podTemplate.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("engine %q generated pattern with no containers", modeRes.engineType)
+	}
+
+	// 5. Mount storage
+	if storageRes.storagePlugin != nil && storageRes.storageName != "" {
+		mountOpts := storageplugin.MountOptions{
+			StorageName: storageRes.storageName,
+			Namespace:   namespace,
+			DryRun:      p.DryRun,
+		}
+		if !p.DryRun {
+			c, err := util.GetControllerRuntimeClient(cf)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create controller client: %w", err)
+			}
+			mountOpts.Client = c
+		}
+		if err := storageRes.storagePlugin.MountStorage(podTemplate, mountOpts); err != nil {
+			return nil, fmt.Errorf("failed to mount storage: %w", err)
+		}
+	}
+
+	// 6. Extract port and build metadata
+	var resolvedPort int32
+	for _, cp := range podTemplate.Spec.Containers[0].Ports {
+		if cp.Name == "http" {
+			resolvedPort = cp.ContainerPort
+			break
+		}
+	}
+	metadata := llmmeta.RunMetadata{
+		ModelID:  modelID,
+		Engine:   modeRes.engineType,
+		Mode:     modeRes.modeCfg.Name,
+		Revision: p.Revision,
+		Port:     resolvedPort,
+	}
+
+	// 7. Assemble RBG
+	rbg := assembleRBG(name, namespace, pattern, metadata, p.Replicas)
+
+	// 8. Print summary
+	fmt.Println("# Generated RoleBasedGroup for Model Serving")
+	fmt.Printf("# Name:      %s\n", name)
+	fmt.Printf("# Namespace: %s\n", namespace)
+	fmt.Printf("# Model:     %s\n", modelID)
+	fmt.Printf("# Revision:  %s\n", p.Revision)
+	fmt.Printf("# Mode:      %s\n", modeRes.modeCfg.Name)
+	fmt.Printf("# Engine:    %s\n", modeRes.engineType)
+	fmt.Printf("# Replicas:  %d\n", p.Replicas)
+	fmt.Println("#")
+
+	return rbg, nil
+}
+
+// getPodTemplateFromPattern extracts the pod template from a Pattern
+func getPodTemplateFromPattern(pattern *workloadsv1alpha2.Pattern) *corev1.PodTemplateSpec {
+	if pattern == nil {
+		return nil
+	}
+	if pattern.StandalonePattern != nil && pattern.StandalonePattern.Template != nil {
+		return pattern.StandalonePattern.Template
+	}
+	if pattern.LeaderWorkerPattern != nil && pattern.LeaderWorkerPattern.Template != nil {
+		return pattern.LeaderWorkerPattern.Template
+	}
+	return nil
+}
+
 // createRBG creates a v1alpha2 RoleBasedGroup in Kubernetes
-func createRBG(ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup, namespace string, cf *genericclioptions.ConfigFlags) error {
+func createRBG(ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup, cf *genericclioptions.ConfigFlags) error {
 	client, err := util.GetRBGClient(cf)
 	if err != nil {
 		return fmt.Errorf("failed to create RBG client: %w", err)
 	}
 
-	_, err = client.WorkloadsV1alpha2().RoleBasedGroups(namespace).Create(ctx, rbg, metav1.CreateOptions{})
+	_, err = client.WorkloadsV1alpha2().RoleBasedGroups(rbg.Namespace).Create(ctx, rbg, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create RoleBasedGroup: %w", err)
 	}
@@ -371,6 +408,7 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			modelID := args[1]
+			namespace := util.GetNamespace(cf)
 
 			// Load user config (best-effort — optional for engine and storage resolution)
 			userCfg, cfgErr := cliconfig.Load()
@@ -378,73 +416,30 @@ Examples:
 				klog.V(1).Infof("Warning: failed to load user config: %v", cfgErr)
 			}
 
-			// Resolve all pure data: model/mode/engine/storage/template/port
-			rctx, err := resolveRunContext(name, modelID, RunParams{
+			// Generate RBG (includes config resolution, pattern generation, storage mounting)
+			rbg, err := generateRBG(name, modelID, namespace, RunParams{
 				Mode:     mode,
 				Engine:   engine,
 				Storage:  storage,
 				Revision: revision,
 				EnvVars:  envVars,
 				ArgsList: argsList,
-			}, userCfg)
+				DryRun:   dryRun,
+				Replicas: replicas,
+			}, userCfg, cf)
 			if err != nil {
 				return err
 			}
 
-			// Get namespace
-			namespace := util.GetNamespace(cf)
-
-			// Mount storage: in dry-run mode, only add volumes/mounts without provisioning K8s resources
-			if rctx.StoragePlugin != nil && rctx.StorageName != "" {
-				mountOpts := storageplugin.MountOptions{
-					StorageName: rctx.StorageName,
-					Namespace:   namespace,
-					DryRun:      dryRun,
-				}
-				if !dryRun {
-					c, err := util.GetControllerRuntimeClient(cf)
-					if err != nil {
-						return fmt.Errorf("failed to create controller client: %w", err)
-					}
-					mountOpts.Client = c
-				}
-				if err := rctx.StoragePlugin.MountStorage(rctx.PodTemplate, mountOpts); err != nil {
-					return fmt.Errorf("failed to mount storage: %w", err)
-				}
-			}
-
-			// Generate RoleBasedGroup from the (now fully configured) pod template
-			rbg := generateRBG(name, namespace, modelID, revision, replicas, rctx)
-
 			if dryRun {
-				fmt.Println("# Generated RoleBasedGroup for Model Serving (DRY RUN)")
-				fmt.Printf("# Name:      %s\n", name)
-				fmt.Printf("# Namespace: %s\n", namespace)
-				fmt.Printf("# Model:     %s\n", modelID)
-				fmt.Printf("# Revision:  %s\n", revision)
-				fmt.Printf("# Mode:      %s\n", rctx.ModeName)
-				fmt.Printf("# Engine:    %s\n", rctx.EngineType)
-				fmt.Printf("# Replicas:  %d\n", replicas)
-				fmt.Println("#")
 				fmt.Println("# DRY RUN: No workload will be created")
 				fmt.Println()
 				return printRBG(rbg)
 			}
 
-			// Print summary
-			fmt.Println("# Generated RoleBasedGroup for Model Serving")
-			fmt.Printf("# Name:      %s\n", name)
-			fmt.Printf("# Namespace: %s\n", namespace)
-			fmt.Printf("# Model:     %s\n", modelID)
-			fmt.Printf("# Revision:  %s\n", revision)
-			fmt.Printf("# Mode:      %s\n", rctx.ModeName)
-			fmt.Printf("# Engine:    %s\n", rctx.EngineType)
-			fmt.Printf("# Replicas:  %d\n", replicas)
-			fmt.Println("#")
-
-			// Create the v1alpha2 RoleBasedGroup workload
+			// Create the RoleBasedGroup workload
 			ctx := context.Background()
-			if err := createRBG(ctx, rbg, namespace, cf); err != nil {
+			if err := createRBG(ctx, rbg, cf); err != nil {
 				klog.ErrorS(err, "Failed to create RoleBasedGroup")
 				return err
 			}

--- a/cmd/cli/cmd/llm/run/model_config.go
+++ b/cmd/cli/cmd/llm/run/model_config.go
@@ -46,6 +46,7 @@ type ModeConfig struct {
 	Args        []string            `yaml:"args"`
 	Env         []corev1.EnvVar     `yaml:"env"`
 	Distributed *DistributedConfig  `yaml:"distributed,omitempty"` // Multi-node deployment config
+	ShmSize     string              `yaml:"shmSize,omitempty"`     // Shared memory size (e.g., "8Gi", "16Gi")
 }
 
 // DistributedConfig describes multi-node deployment configuration.

--- a/cmd/cli/cmd/llm/run/model_config.go
+++ b/cmd/cli/cmd/llm/run/model_config.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	cliconfig "sigs.k8s.io/rbgs/cmd/cli/config"
 	"sigs.k8s.io/yaml"
 )
@@ -37,26 +38,20 @@ type ModelConfig struct {
 
 // ModeConfig describes a single run mode for a model.
 type ModeConfig struct {
-	Name        string         `yaml:"name"`
-	Description string         `yaml:"description"`
-	Engine      string         `yaml:"engine"`
-	Image       string         `yaml:"image"`
-	Resources   ResourceConfig `yaml:"resources"`
-	Args        []string       `yaml:"args"`
-	Env         []EnvVar       `yaml:"env"`
+	Name        string              `yaml:"name"`
+	Description string              `yaml:"description"`
+	Engine      string              `yaml:"engine"`
+	Image       string              `yaml:"image"`
+	Resources   corev1.ResourceList `yaml:"resources"`
+	Args        []string            `yaml:"args"`
+	Env         []corev1.EnvVar     `yaml:"env"`
+	Distributed *DistributedConfig  `yaml:"distributed,omitempty"` // Multi-node deployment config
 }
 
-// ResourceConfig describes compute resources for a mode.
-type ResourceConfig struct {
-	GPU    int    `yaml:"gpu"`
-	CPU    int    `yaml:"cpu"`
-	Memory string `yaml:"memory"`
-}
-
-// EnvVar describes an environment variable.
-type EnvVar struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+// DistributedConfig describes multi-node deployment configuration.
+// Size > 1 enables leader-worker pattern for distributed inference.
+type DistributedConfig struct {
+	Size int32 `yaml:"size"` // Total nodes (1 leader + N workers)
 }
 
 // modelWithSource tracks a model config and its source file

--- a/cmd/cli/cmd/llm/run/model_config_test.go
+++ b/cmd/cli/cmd/llm/run/model_config_test.go
@@ -41,8 +41,8 @@ func TestLoadUserModelsFromDirectory(t *testing.T) {
       engine: vllm
       image: vllm/vllm-openai:latest
       resources:
-        gpu: 1
-        cpu: 2
+        nvidia.com/gpu: "1"
+        cpu: "2"
         memory: 8Gi
       args:
         - "--tensor-parallel-size=1"
@@ -51,8 +51,8 @@ func TestLoadUserModelsFromDirectory(t *testing.T) {
       engine: sglang
       image: lmsys/sglang:latest
       resources:
-        gpu: 2
-        cpu: 4
+        nvidia.com/gpu: "2"
+        cpu: "4"
         memory: 16Gi
       args:
         - "--mem-fraction-static=0.9"
@@ -94,8 +94,9 @@ func TestLoadUserModelsFromDirectory(t *testing.T) {
 			if model.Modes[0].Engine != "vllm" {
 				t.Errorf("Expected first mode engine 'vllm', got %q", model.Modes[0].Engine)
 			}
-			if model.Modes[0].Resources.GPU != 1 {
-				t.Errorf("Expected first mode GPU 1, got %d", model.Modes[0].Resources.GPU)
+			// Verify first mode resources (nvidia.com/gpu)
+			if gpu, ok := model.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "1" {
+				t.Errorf("Expected first mode GPU 1, got %v", model.Modes[0].Resources["nvidia.com/gpu"])
 			}
 
 			// Verify second mode
@@ -133,7 +134,7 @@ func TestLoadUserModelsMultipleFiles(t *testing.T) {
       engine: vllm
       image: vllm/vllm-openai:latest
       resources:
-        gpu: 1
+        nvidia.com/gpu: "1"
 `
 	if err := os.WriteFile(modelFile1, []byte(modelContent1), 0600); err != nil {
 		t.Fatalf("Failed to write model file 1: %v", err)
@@ -148,7 +149,7 @@ func TestLoadUserModelsMultipleFiles(t *testing.T) {
       engine: sglang
       image: lmsys/sglang:latest
       resources:
-        gpu: 2
+        nvidia.com/gpu: "2"
 `
 	if err := os.WriteFile(modelFile2, []byte(modelContent2), 0600); err != nil {
 		t.Fatalf("Failed to write model file 2: %v", err)
@@ -208,7 +209,7 @@ func TestLoadUserModelsInvalidFile(t *testing.T) {
       engine: vllm
       image: vllm/vllm-openai:latest
       resources:
-        gpu: 1
+        nvidia.com/gpu: "1"
 `
 	if err := os.WriteFile(validFile, []byte(validContent), 0600); err != nil {
 		t.Fatalf("Failed to write valid file: %v", err)
@@ -257,7 +258,7 @@ func TestLoadAllModelsUserOverridesBuiltin(t *testing.T) {
       engine: vllm
       image: my-custom-image:latest
       resources:
-        gpu: 1
+        nvidia.com/gpu: "1"
 `
 	if err := os.WriteFile(overrideFile, []byte(overrideContent), 0600); err != nil {
 		t.Fatalf("Failed to write override file: %v", err)
@@ -313,7 +314,7 @@ func TestLoadAllModelsUserDuplicate(t *testing.T) {
       engine: vllm
       image: image-a:latest
       resources:
-        gpu: 1
+        nvidia.com/gpu: "1"
 `
 	if err := os.WriteFile(file1, []byte(content1), 0600); err != nil {
 		t.Fatalf("Failed to write file1: %v", err)
@@ -327,7 +328,7 @@ func TestLoadAllModelsUserDuplicate(t *testing.T) {
       engine: vllm
       image: image-b:latest
       resources:
-        gpu: 2
+        nvidia.com/gpu: "2"
 `
 	if err := os.WriteFile(file2, []byte(content2), 0600); err != nil {
 		t.Fatalf("Failed to write file2: %v", err)
@@ -360,8 +361,9 @@ func TestLoadAllModelsUserDuplicate(t *testing.T) {
 	if foundModel.Name != "Definition A" {
 		t.Errorf("Expected first definition 'Definition A', got %q", foundModel.Name)
 	}
-	if foundModel.Modes[0].Resources.GPU != 1 {
-		t.Errorf("Expected first definition GPU 1, got %d", foundModel.Modes[0].Resources.GPU)
+	// Verify resources from first definition (file-a.yaml)
+	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "1" {
+		t.Errorf("Expected first definition GPU 1, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
 	}
 }
 
@@ -383,7 +385,7 @@ func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
       engine: vllm
       image: image-1:latest
       resources:
-        gpu: 1
+        nvidia.com/gpu: "1"
 - id: "my-org/triple-model"
   name: "Definition 2"
   modes:
@@ -391,7 +393,7 @@ func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
       engine: vllm
       image: image-2:latest
       resources:
-        gpu: 2
+        nvidia.com/gpu: "2"
 - id: "my-org/triple-model"
   name: "Definition 3"
   modes:
@@ -399,7 +401,7 @@ func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
       engine: vllm
       image: image-3:latest
       resources:
-        gpu: 3
+        nvidia.com/gpu: "3"
 `
 	if err := os.WriteFile(file1, []byte(content1), 0600); err != nil {
 		t.Fatalf("Failed to write file1: %v", err)
@@ -432,8 +434,9 @@ func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
 	if foundModel.Name != "Definition 1" {
 		t.Errorf("Expected first definition 'Definition 1', got %q", foundModel.Name)
 	}
-	if foundModel.Modes[0].Resources.GPU != 1 {
-		t.Errorf("Expected first definition GPU 1, got %d", foundModel.Modes[0].Resources.GPU)
+	// Verify resources from first definition
+	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "1" {
+		t.Errorf("Expected first definition GPU 1, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
 	}
 }
 
@@ -451,8 +454,8 @@ func TestLoadAllModelsCustomModelConfigPath(t *testing.T) {
       engine: vllm
       image: vllm/vllm-openai:latest
       resources:
-        gpu: 1
-        cpu: 2
+        nvidia.com/gpu: "1"
+        cpu: "2"
         memory: 8Gi
       args:
         - "--tensor-parallel-size=1"

--- a/cmd/cli/cmd/llm/run/models.yaml
+++ b/cmd/cli/cmd/llm/run/models.yaml
@@ -56,3 +56,4 @@
         - "--tp-size=2"
       distributed:
         size: 2
+      shmSize: "2Gi"

--- a/cmd/cli/cmd/llm/run/models.yaml
+++ b/cmd/cli/cmd/llm/run/models.yaml
@@ -56,3 +56,17 @@
       distributed:
         size: 2
       shmSize: "2Gi"
+
+    - name: distributed-vllm-tp
+      description: "vLLM distributed inference - pure tensor parallel across nodes"
+      engine: vllm
+      image: vllm/vllm-openai:nightly
+      resources:
+        nvidia.com/gpu: "2"
+        cpu: "4"
+        memory: "16Gi"
+      args:
+        - "--tensor-parallel-size=2"
+      distributed:
+        size: 2
+      shmSize: "2Gi"

--- a/cmd/cli/cmd/llm/run/models.yaml
+++ b/cmd/cli/cmd/llm/run/models.yaml
@@ -43,7 +43,6 @@
         - "--mem-fraction-static=0.8"
         - "--max-prefill-tokens=16384"
 
-    # TODO: test only, remove later
     - name: distributed-tp2
       description: "Distributed inference with tensor parallel size 2 on 2 nodes"
       engine: sglang

--- a/cmd/cli/cmd/llm/run/models.yaml
+++ b/cmd/cli/cmd/llm/run/models.yaml
@@ -1,3 +1,4 @@
+# TODO: Add more models and modes
 - id: "Qwen/Qwen3.5-0.8B"
   name: "Qwen 3.5 0.8B"
   modes:
@@ -6,9 +7,9 @@
       engine: vllm
       image: vllm/vllm-openai:nightly
       resources:
-        gpu: 1
-        cpu: 4
-        memory: 16Gi
+        nvidia.com/gpu: "1"
+        cpu: "4"
+        memory: "16Gi"
       args:
         - "--tensor-parallel-size=1"
         - "--max-model-len=8192"
@@ -21,9 +22,9 @@
       engine: vllm
       image: vllm/vllm-openai:nightly
       resources:
-        gpu: 2
-        cpu: 8
-        memory: 32Gi
+        nvidia.com/gpu: "2"
+        cpu: "8"
+        memory: "32Gi"
       args:
         - "--tensor-parallel-size=2"
         - "--max-model-len=16384"
@@ -33,38 +34,25 @@
     - name: latency
       description: "Minimize latency, suitable for real-time inference"
       engine: sglang
-      image: lmsys/sglang:latest
+      image: lmsysorg/sglang:latest
       resources:
-        gpu: 1
-        cpu: 4
-        memory: 16Gi
+        nvidia.com/gpu: "1"
+        cpu: "4"
+        memory: "16Gi"
       args:
         - "--mem-fraction-static=0.8"
         - "--max-prefill-tokens=16384"
 
-- id: "Qwen/*"
-  name: "Qwen Series Models"
-  modes:
-    - name: standard
-      description: "Standard config for Qwen series"
-      engine: vllm
-      image: vllm/vllm-openai:nightly
+    # TODO: test only, remove later
+    - name: distributed-tp2
+      description: "Distributed inference with tensor parallel size 2 on 2 nodes"
+      engine: sglang
+      image: lmsysorg/sglang:latest
       resources:
-        gpu: 1
-        cpu: 4
-        memory: 32Gi
+        nvidia.com/gpu: "1"
+        cpu: "4"
+        memory: "16Gi"
       args:
-        - "--tensor-parallel-size=1"
-
-- id: "*"
-  name: "Default Config"
-  modes:
-    - name: standard
-      description: "Default standard config"
-      engine: vllm
-      image: vllm/vllm-openai:latest
-      resources:
-        gpu: 1
-        cpu: 2
-        memory: 16Gi
-      args: []
+        - "--tp-size=2"
+      distributed:
+        size: 2

--- a/cmd/cli/cmd/llm/run_test.go
+++ b/cmd/cli/cmd/llm/run_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package llm
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	llmmeta "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/metadata"
 )
 
 // --- newRunCmd: command metadata ---
@@ -138,103 +141,138 @@ func TestRunEnvVarParsing_EmptyValue(t *testing.T) {
 	assert.Equal(t, "", parts[1])
 }
 
-// --- resolveRunContext ---
+// --- generateRBG ---
 
-func TestResolveRunContext_DefaultMode_VLLMEngine(t *testing.T) {
+func TestGenerateRBG_DefaultMode_VLLMEngine(t *testing.T) {
 	// Qwen/Qwen3.5-0.8B standard mode uses vllm with port 8000
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "vllm", rctx.EngineType)
-	assert.Equal(t, "standard", rctx.ModeName)
-	assert.Equal(t, int32(8000), rctx.ResolvedPort)
-	assert.NotNil(t, rctx.PodTemplate)
-	assert.Nil(t, rctx.StoragePlugin)
+	assert.Equal(t, "my-svc", rbg.Name)
+	assert.Equal(t, "default", rbg.Namespace)
+
+	// Check metadata annotation
+	var metadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "vllm", metadata.Engine)
+	assert.Equal(t, "standard", metadata.Mode)
+	assert.Equal(t, int32(8000), metadata.Port)
 }
 
-func TestResolveRunContext_LatencyMode_SGLangEngine(t *testing.T) {
+func TestGenerateRBG_LatencyMode_SGLangEngine(t *testing.T) {
 	// Qwen/Qwen3.5-0.8B latency mode uses sglang with port 30000
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Mode:     "latency",
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "sglang", rctx.EngineType)
-	assert.Equal(t, "latency", rctx.ModeName)
-	assert.Equal(t, int32(30000), rctx.ResolvedPort)
+
+	var metadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "sglang", metadata.Engine)
+	assert.Equal(t, "latency", metadata.Mode)
+	assert.Equal(t, int32(30000), metadata.Port)
 }
 
-func TestResolveRunContext_EngineOverride(t *testing.T) {
+func TestGenerateRBG_EngineOverride(t *testing.T) {
 	// Engine flag overrides the mode's default engine
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Engine:   "sglang",
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "sglang", rctx.EngineType)
-	assert.Equal(t, int32(30000), rctx.ResolvedPort)
+
+	var metadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "sglang", metadata.Engine)
 }
 
-func TestResolveRunContext_EnvVarInjection(t *testing.T) {
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+func TestGenerateRBG_EnvVarInjection(t *testing.T) {
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		EnvVars:  []string{"MY_KEY=my_value"},
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
 	envMap := map[string]string{}
-	for _, e := range rctx.PodTemplate.Spec.Containers[0].Env {
+	for _, e := range podTemplate.Spec.Containers[0].Env {
 		envMap[e.Name] = e.Value
 	}
 	assert.Equal(t, "my_value", envMap["MY_KEY"])
 }
 
-func TestResolveRunContext_InvalidEnvVar(t *testing.T) {
-	_, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+func TestGenerateRBG_InvalidEnvVar(t *testing.T) {
+	_, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		EnvVars:  []string{"NOEQUALSSIGN"},
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid environment variable format")
 }
 
-func TestResolveRunContext_UnknownModel(t *testing.T) {
+func TestGenerateRBG_UnknownModel(t *testing.T) {
 	// Unknown model should return error when no wildcard config exists
-	_, err := resolveRunContext("my-svc", "unknown/unknown-model", RunParams{
+	_, err := generateRBG("my-svc", "unknown/unknown-model", "default", RunParams{
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no configuration found for model")
 }
 
-func TestResolveRunContext_UnknownEngine_Errors(t *testing.T) {
-	_, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+func TestGenerateRBG_UnknownEngine_Errors(t *testing.T) {
+	_, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Engine:   "nonexistent-engine",
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown engine type")
 }
 
-func TestResolveRunContext_AdditionalArgs(t *testing.T) {
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+func TestGenerateRBG_AdditionalArgs(t *testing.T) {
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		ArgsList: []string{"--custom-flag", "value"},
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
-	args := rctx.PodTemplate.Spec.Containers[0].Args
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	args := podTemplate.Spec.Containers[0].Args
 	assert.Contains(t, args, "--custom-flag")
 	assert.Contains(t, args, "value")
 }
 
-func TestResolveRunContext_FallbackModelPath(t *testing.T) {
+func TestGenerateRBG_FallbackModelPath(t *testing.T) {
 	// Without storage config, model path uses the /model/ fallback
-	rctx, err := resolveRunContext("my-svc", "Qwen/Qwen3.5-0.8B", RunParams{
+	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
-	}, nil)
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
 	require.NoError(t, err)
-	// vllm passes model path via --model arg
-	args := rctx.PodTemplate.Spec.Containers[0].Args
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	args := podTemplate.Spec.Containers[0].Args
 	var modelPathArg string
 	for i, a := range args {
 		if a == "--model" && i+1 < len(args) {

--- a/cmd/cli/cmd/llm/run_test.go
+++ b/cmd/cli/cmd/llm/run_test.go
@@ -18,6 +18,7 @@ package llm
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -27,6 +28,16 @@ import (
 
 	llmmeta "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/metadata"
 )
+
+// TestMain sets up an isolated test environment for all tests in this package.
+// We set RBG_MODEL_CONFIG to a non-existent path to prevent loading user models,
+// ensuring tests only use the built-in models.yaml definitions.
+func TestMain(m *testing.M) {
+	// Set RBG_MODEL_CONFIG to a non-existent path to skip user model loading
+	// This ensures tests use only built-in models, making them deterministic
+	_ = os.Setenv("RBG_MODEL_CONFIG", "/nonexistent/path/for/testing")
+	os.Exit(m.Run())
+}
 
 // --- newRunCmd: command metadata ---
 
@@ -145,7 +156,7 @@ func TestRunEnvVarParsing_EmptyValue(t *testing.T) {
 
 func TestGenerateRBG_DefaultMode_VLLMEngine(t *testing.T) {
 	// Qwen/Qwen3.5-0.8B standard mode uses vllm with port 8000
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, metadata, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		Replicas: 1,
 		DryRun:   true,
@@ -154,18 +165,23 @@ func TestGenerateRBG_DefaultMode_VLLMEngine(t *testing.T) {
 	assert.Equal(t, "my-svc", rbg.Name)
 	assert.Equal(t, "default", rbg.Namespace)
 
-	// Check metadata annotation
-	var metadata llmmeta.RunMetadata
-	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
-	require.NoError(t, err)
+	// Check returned metadata
 	assert.Equal(t, "vllm", metadata.Engine)
 	assert.Equal(t, "standard", metadata.Mode)
 	assert.Equal(t, int32(8000), metadata.Port)
+
+	// Check metadata annotation
+	var annotationMetadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &annotationMetadata)
+	require.NoError(t, err)
+	assert.Equal(t, "vllm", annotationMetadata.Engine)
+	assert.Equal(t, "standard", annotationMetadata.Mode)
+	assert.Equal(t, int32(8000), annotationMetadata.Port)
 }
 
 func TestGenerateRBG_LatencyMode_SGLangEngine(t *testing.T) {
 	// Qwen/Qwen3.5-0.8B latency mode uses sglang with port 30000
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, metadata, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Mode:     "latency",
 		Revision: "main",
 		Replicas: 1,
@@ -173,17 +189,23 @@ func TestGenerateRBG_LatencyMode_SGLangEngine(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	var metadata llmmeta.RunMetadata
-	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
-	require.NoError(t, err)
+	// Check returned metadata
 	assert.Equal(t, "sglang", metadata.Engine)
 	assert.Equal(t, "latency", metadata.Mode)
 	assert.Equal(t, int32(30000), metadata.Port)
+
+	// Check metadata annotation
+	var annotationMetadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &annotationMetadata)
+	require.NoError(t, err)
+	assert.Equal(t, "sglang", annotationMetadata.Engine)
+	assert.Equal(t, "latency", annotationMetadata.Mode)
+	assert.Equal(t, int32(30000), annotationMetadata.Port)
 }
 
 func TestGenerateRBG_EngineOverride(t *testing.T) {
 	// Engine flag overrides the mode's default engine
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, metadata, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Engine:   "sglang",
 		Revision: "main",
 		Replicas: 1,
@@ -191,14 +213,18 @@ func TestGenerateRBG_EngineOverride(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 
-	var metadata llmmeta.RunMetadata
-	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &metadata)
-	require.NoError(t, err)
+	// Check returned metadata
 	assert.Equal(t, "sglang", metadata.Engine)
+
+	// Check metadata annotation
+	var annotationMetadata llmmeta.RunMetadata
+	err = json.Unmarshal([]byte(rbg.Annotations[llmmeta.RunCommandMetadataAnnotationKey]), &annotationMetadata)
+	require.NoError(t, err)
+	assert.Equal(t, "sglang", annotationMetadata.Engine)
 }
 
 func TestGenerateRBG_EnvVarInjection(t *testing.T) {
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		EnvVars:  []string{"MY_KEY=my_value"},
 		Replicas: 1,
@@ -215,7 +241,7 @@ func TestGenerateRBG_EnvVarInjection(t *testing.T) {
 }
 
 func TestGenerateRBG_InvalidEnvVar(t *testing.T) {
-	_, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	_, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		EnvVars:  []string{"NOEQUALSSIGN"},
 		Replicas: 1,
@@ -227,7 +253,7 @@ func TestGenerateRBG_InvalidEnvVar(t *testing.T) {
 
 func TestGenerateRBG_UnknownModel(t *testing.T) {
 	// Unknown model should return error when no wildcard config exists
-	_, err := generateRBG("my-svc", "unknown/unknown-model", "default", RunParams{
+	_, _, err := generateRBG("my-svc", "unknown/unknown-model", "default", RunParams{
 		Revision: "main",
 		Replicas: 1,
 		DryRun:   true,
@@ -237,7 +263,7 @@ func TestGenerateRBG_UnknownModel(t *testing.T) {
 }
 
 func TestGenerateRBG_UnknownEngine_Errors(t *testing.T) {
-	_, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	_, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Engine:   "nonexistent-engine",
 		Revision: "main",
 		Replicas: 1,
@@ -248,7 +274,7 @@ func TestGenerateRBG_UnknownEngine_Errors(t *testing.T) {
 }
 
 func TestGenerateRBG_AdditionalArgs(t *testing.T) {
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		ArgsList: []string{"--custom-flag", "value"},
 		Replicas: 1,
@@ -264,7 +290,7 @@ func TestGenerateRBG_AdditionalArgs(t *testing.T) {
 
 func TestGenerateRBG_FallbackModelPath(t *testing.T) {
 	// Without storage config, model path uses the /model/ fallback
-	rbg, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
 		Revision: "main",
 		Replicas: 1,
 		DryRun:   true,

--- a/cmd/cli/cmd/llm/run_test.go
+++ b/cmd/cli/cmd/llm/run_test.go
@@ -199,12 +199,12 @@ func TestResolveRunContext_InvalidEnvVar(t *testing.T) {
 }
 
 func TestResolveRunContext_UnknownModel(t *testing.T) {
-	// Unknown model falls back to wildcard "*" config
-	rctx, err := resolveRunContext("my-svc", "unknown/unknown-model", RunParams{
+	// Unknown model should return error when no wildcard config exists
+	_, err := resolveRunContext("my-svc", "unknown/unknown-model", RunParams{
 		Revision: "main",
 	}, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "vllm", rctx.EngineType)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no configuration found for model")
 }
 
 func TestResolveRunContext_UnknownEngine_Errors(t *testing.T) {

--- a/cmd/cli/plugin/engine/interface.go
+++ b/cmd/cli/plugin/engine/interface.go
@@ -23,6 +23,18 @@ import (
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
+// GenerateOptions contains all information needed to generate a pod template.
+type GenerateOptions struct {
+	Name            string
+	ModelID         string
+	ModelPath       string
+	Image           string          // Override image (empty to use default)
+	Args            []string        // Additional arguments
+	Env             []corev1.EnvVar // Additional environment variables
+	Resources       corev1.ResourceRequirements
+	DistributedSize int32 // Multi-node deployment size, <=1 means standalone
+}
+
 // Plugin defines the interface for inference engines.
 type Plugin interface {
 	Name() string
@@ -33,8 +45,12 @@ type Plugin interface {
 	// Init initializes the engine with credentials/config.
 	Init(config map[string]interface{}) error
 
-	// GenerateTemplate generates a PodTemplateSpec used to start the model engine.
-	GenerateTemplate(name string, modelID string, modelPath string) (*corev1.PodTemplateSpec, error)
+	// GenerateTemplate generates a complete PodTemplateSpec for the model engine.
+	// The implementation should handle all engine-specific logic including:
+	// - Container configuration (image, command, args)
+	// - Port configuration
+	// - Distributed deployment parameters (if DistributedSize > 1)
+	GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error)
 }
 
 // Factory is a constructor for an engine plugin.

--- a/cmd/cli/plugin/engine/interface.go
+++ b/cmd/cli/plugin/engine/interface.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
@@ -46,12 +47,11 @@ type Plugin interface {
 	// Init initializes the engine with credentials/config.
 	Init(config map[string]interface{}) error
 
-	// GenerateTemplate generates a complete PodTemplateSpec for the model engine.
-	// The implementation should handle all engine-specific logic including:
-	// - Container configuration (image, command, args)
-	// - Port configuration
-	// - Distributed deployment parameters (if DistributedSize > 1)
-	GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error)
+	// GeneratePattern generates a complete Pattern for the model engine.
+	// The returned Pattern can be either:
+	// - StandalonePattern for single-node deployment
+	// - LeaderWorkerPattern for multi-node deployment (with LeaderTemplatePatch/WorkerTemplatePatch if needed)
+	GeneratePattern(opts GenerateOptions) (*workloadsv1alpha2.Pattern, error)
 }
 
 // Factory is a constructor for an engine plugin.

--- a/cmd/cli/plugin/engine/interface.go
+++ b/cmd/cli/plugin/engine/interface.go
@@ -32,7 +32,8 @@ type GenerateOptions struct {
 	Args            []string        // Additional arguments
 	Env             []corev1.EnvVar // Additional environment variables
 	Resources       corev1.ResourceRequirements
-	DistributedSize int32 // Multi-node deployment size, <=1 means standalone
+	DistributedSize int32  // Multi-node deployment size, <=1 means standalone
+	ShmSize         string // Shared memory size (e.g., "8Gi", "16Gi"), empty means no shared memory
 }
 
 // Plugin defines the interface for inference engines.

--- a/cmd/cli/plugin/engine/sglang.go
+++ b/cmd/cli/plugin/engine/sglang.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
@@ -64,8 +65,42 @@ func (s *SGLangEngine) Init(config map[string]interface{}) error {
 	return nil
 }
 
-// GenerateTemplate generates a pod template for running SGLang
-func (s *SGLangEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
+// GeneratePattern generates a Pattern for running SGLang.
+// For multi-node deployment, SGLang uses the same template for both leader and worker,
+// with --node-rank distinguishing their roles at runtime.
+func (s *SGLangEngine) GeneratePattern(opts GenerateOptions) (*workloadsv1alpha2.Pattern, error) {
+	podTemplate, err := s.generatePodTemplate(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.DistributedSize > 1 {
+		// Multi-node deployment using LeaderWorkerPattern
+		return &workloadsv1alpha2.Pattern{
+			LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{
+				Size: &opts.DistributedSize,
+				TemplateSource: workloadsv1alpha2.TemplateSource{
+					Template: podTemplate,
+				},
+				// SGLang doesn't need LeaderTemplatePatch/WorkerTemplatePatch
+				// because leader and worker use the same startup args,
+				// with --node-rank=$(RBG_LWP_WORKER_INDEX) distinguishing roles at runtime.
+			},
+		}, nil
+	}
+
+	// Single-node deployment using StandalonePattern
+	return &workloadsv1alpha2.Pattern{
+		StandalonePattern: &workloadsv1alpha2.StandalonePattern{
+			TemplateSource: workloadsv1alpha2.TemplateSource{
+				Template: podTemplate,
+			},
+		},
+	}, nil
+}
+
+// generatePodTemplate generates the base PodTemplateSpec for SGLang
+func (s *SGLangEngine) generatePodTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
 	// Use override image if provided, otherwise use default
 	image := s.Image
 	if opts.Image != "" {

--- a/cmd/cli/plugin/engine/sglang.go
+++ b/cmd/cli/plugin/engine/sglang.go
@@ -17,7 +17,10 @@ limitations under the License.
 package engine
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
@@ -98,7 +101,7 @@ func (s *SGLangEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTempla
 	}
 	env = append(env, opts.Env...)
 
-	return &corev1.PodTemplateSpec{
+	podSpec := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -118,5 +121,32 @@ func (s *SGLangEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTempla
 				},
 			},
 		},
-	}, nil
+	}
+
+	// Add shared memory volume if ShmSize is specified
+	if opts.ShmSize != "" {
+		shmQuantity, err := resource.ParseQuantity(opts.ShmSize)
+		if err != nil {
+			return nil, fmt.Errorf("invalid shmSize %q: %w", opts.ShmSize, err)
+		}
+
+		// Add volume to pod
+		podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, corev1.Volume{
+			Name: "shm",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: &shmQuantity,
+				},
+			},
+		})
+
+		// Add volume mount to container
+		podSpec.Spec.Containers[0].VolumeMounts = append(podSpec.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      "shm",
+			MountPath: "/dev/shm",
+		})
+	}
+
+	return podSpec, nil
 }

--- a/cmd/cli/plugin/engine/sglang.go
+++ b/cmd/cli/plugin/engine/sglang.go
@@ -62,33 +62,59 @@ func (s *SGLangEngine) Init(config map[string]interface{}) error {
 }
 
 // GenerateTemplate generates a pod template for running SGLang
-func (s *SGLangEngine) GenerateTemplate(name string, modelID string, modelPath string) (*corev1.PodTemplateSpec, error) {
+func (s *SGLangEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
+	// Use override image if provided, otherwise use default
+	image := s.Image
+	if opts.Image != "" {
+		image = opts.Image
+	}
+
+	// Build base args
+	args := []string{
+		"--model-path",
+		opts.ModelPath,
+		"--served-model-name",
+		opts.Name,
+	}
+
+	// Add distributed deployment args for multi-node setup
+	if opts.DistributedSize > 1 {
+		args = append(args,
+			"--dist-init-addr=$(RBG_LWP_LEADER_ADDRESS):6379",
+			"--nnodes=$(RBG_LWP_GROUP_SIZE)",
+			"--node-rank=$(RBG_LWP_WORKER_INDEX)",
+		)
+	}
+
+	// Add user-provided args
+	args = append(args, opts.Args...)
+
+	// Build env vars
+	env := []corev1.EnvVar{
+		{
+			Name:  "SGLANG_MODEL_PATH",
+			Value: opts.ModelPath,
+		},
+	}
+	env = append(env, opts.Env...)
+
 	return &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:            "sglang",
-					Image:           s.Image,
+					Image:           image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"python", "-m", "sglang.launch_server"},
-					Args: []string{
-						"--model-path",
-						modelPath,
-						"--model-name",
-						name,
-					},
+					Args:            args,
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
 							ContainerPort: s.Port,
 						},
 					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "SGLANG_MODEL_PATH",
-							Value: modelPath,
-						},
-					},
+					Env:       env,
+					Resources: opts.Resources,
 				},
 			},
 		},

--- a/cmd/cli/plugin/engine/sglang_test.go
+++ b/cmd/cli/plugin/engine/sglang_test.go
@@ -56,17 +56,21 @@ func TestSGLangEngine_Init_Custom(t *testing.T) {
 	assert.Equal(t, int32(8888), s.Port)
 }
 
-func TestSGLangEngine_GenerateTemplate(t *testing.T) {
+func TestSGLangEngine_GeneratePattern(t *testing.T) {
 	s := &SGLangEngine{}
 	require.NoError(t, s.Init(map[string]interface{}{}))
 
-	tpl, err := s.GenerateTemplate(GenerateOptions{
+	pattern, err := s.GeneratePattern(GenerateOptions{
 		Name:      "mymodel",
 		ModelID:   "org/model",
 		ModelPath: "/models/mymodel",
 	})
 	require.NoError(t, err)
-	require.NotNil(t, tpl)
+	require.NotNil(t, pattern)
+	require.NotNil(t, pattern.StandalonePattern)
+	require.NotNil(t, pattern.StandalonePattern.Template)
+
+	tpl := pattern.StandalonePattern.Template
 	require.Len(t, tpl.Spec.Containers, 1)
 
 	c := tpl.Spec.Containers[0]
@@ -82,16 +86,17 @@ func TestSGLangEngine_GenerateTemplate(t *testing.T) {
 	assert.Equal(t, "http", c.Ports[0].Name)
 }
 
-func TestSGLangEngine_GenerateTemplate_EnvVar(t *testing.T) {
+func TestSGLangEngine_GeneratePattern_EnvVar(t *testing.T) {
 	s := &SGLangEngine{}
 	require.NoError(t, s.Init(map[string]interface{}{}))
 
-	tpl, err := s.GenerateTemplate(GenerateOptions{
+	pattern, err := s.GeneratePattern(GenerateOptions{
 		Name:      "m",
 		ModelID:   "id",
 		ModelPath: "/path/to/model",
 	})
 	require.NoError(t, err)
+	tpl := pattern.StandalonePattern.Template
 	envMap := map[string]string{}
 	for _, e := range tpl.Spec.Containers[0].Env {
 		envMap[e.Name] = e.Value
@@ -99,11 +104,11 @@ func TestSGLangEngine_GenerateTemplate_EnvVar(t *testing.T) {
 	assert.Equal(t, "/path/to/model", envMap["SGLANG_MODEL_PATH"])
 }
 
-func TestSGLangEngine_GenerateTemplate_Distributed(t *testing.T) {
+func TestSGLangEngine_GeneratePattern_Distributed(t *testing.T) {
 	s := &SGLangEngine{}
 	require.NoError(t, s.Init(map[string]interface{}{}))
 
-	tpl, err := s.GenerateTemplate(GenerateOptions{
+	pattern, err := s.GeneratePattern(GenerateOptions{
 		Name:            "mymodel",
 		ModelID:         "org/model",
 		ModelPath:       "/models/mymodel",
@@ -111,7 +116,12 @@ func TestSGLangEngine_GenerateTemplate_Distributed(t *testing.T) {
 		DistributedSize: 2,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, tpl)
+	require.NotNil(t, pattern)
+	require.NotNil(t, pattern.LeaderWorkerPattern)
+	require.Equal(t, int32(2), *pattern.LeaderWorkerPattern.Size)
+	require.NotNil(t, pattern.LeaderWorkerPattern.Template)
+
+	tpl := pattern.LeaderWorkerPattern.Template
 	require.Len(t, tpl.Spec.Containers, 1)
 
 	c := tpl.Spec.Containers[0]

--- a/cmd/cli/plugin/engine/sglang_test.go
+++ b/cmd/cli/plugin/engine/sglang_test.go
@@ -75,7 +75,7 @@ func TestSGLangEngine_GenerateTemplate(t *testing.T) {
 	assert.Equal(t, []string{"python", "-m", "sglang.launch_server"}, c.Command)
 	assert.Contains(t, c.Args, "--model-path")
 	assert.Contains(t, c.Args, "/models/mymodel")
-	assert.Contains(t, c.Args, "--model-name")
+	assert.Contains(t, c.Args, "--served-model-name")
 	assert.Contains(t, c.Args, "mymodel")
 	require.Len(t, c.Ports, 1)
 	assert.Equal(t, int32(30000), c.Ports[0].ContainerPort)

--- a/cmd/cli/plugin/engine/sglang_test.go
+++ b/cmd/cli/plugin/engine/sglang_test.go
@@ -60,7 +60,11 @@ func TestSGLangEngine_GenerateTemplate(t *testing.T) {
 	s := &SGLangEngine{}
 	require.NoError(t, s.Init(map[string]interface{}{}))
 
-	tpl, err := s.GenerateTemplate("mymodel", "org/model", "/models/mymodel")
+	tpl, err := s.GenerateTemplate(GenerateOptions{
+		Name:      "mymodel",
+		ModelID:   "org/model",
+		ModelPath: "/models/mymodel",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 	require.Len(t, tpl.Spec.Containers, 1)
@@ -82,13 +86,41 @@ func TestSGLangEngine_GenerateTemplate_EnvVar(t *testing.T) {
 	s := &SGLangEngine{}
 	require.NoError(t, s.Init(map[string]interface{}{}))
 
-	tpl, err := s.GenerateTemplate("m", "id", "/path/to/model")
+	tpl, err := s.GenerateTemplate(GenerateOptions{
+		Name:      "m",
+		ModelID:   "id",
+		ModelPath: "/path/to/model",
+	})
 	require.NoError(t, err)
 	envMap := map[string]string{}
 	for _, e := range tpl.Spec.Containers[0].Env {
 		envMap[e.Name] = e.Value
 	}
 	assert.Equal(t, "/path/to/model", envMap["SGLANG_MODEL_PATH"])
+}
+
+func TestSGLangEngine_GenerateTemplate_Distributed(t *testing.T) {
+	s := &SGLangEngine{}
+	require.NoError(t, s.Init(map[string]interface{}{}))
+
+	tpl, err := s.GenerateTemplate(GenerateOptions{
+		Name:            "mymodel",
+		ModelID:         "org/model",
+		ModelPath:       "/models/mymodel",
+		Args:            []string{"--tp-size=2"},
+		DistributedSize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tpl)
+	require.Len(t, tpl.Spec.Containers, 1)
+
+	c := tpl.Spec.Containers[0]
+	// Check distributed args are injected
+	assert.Contains(t, c.Args, "--dist-init-addr=$(RBG_LWP_LEADER_ADDRESS):6379")
+	assert.Contains(t, c.Args, "--nnodes=$(RBG_LWP_GROUP_SIZE)")
+	assert.Contains(t, c.Args, "--node-rank=$(RBG_LWP_WORKER_INDEX)")
+	// Check user args are preserved
+	assert.Contains(t, c.Args, "--tp-size=2")
 }
 
 func TestGet_SGLang_InitAndReturn(t *testing.T) {

--- a/cmd/cli/plugin/engine/vllm.go
+++ b/cmd/cli/plugin/engine/vllm.go
@@ -17,10 +17,13 @@ limitations under the License.
 package engine
 
 import (
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
@@ -64,15 +67,75 @@ func (v *VLLMEngine) Init(config map[string]interface{}) error {
 	return nil
 }
 
-// GenerateTemplate generates a pod template for running vLLM
-func (v *VLLMEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
-	// Use override image if provided, otherwise use default
-	image := v.Image
-	if opts.Image != "" {
-		image = opts.Image
+// GeneratePattern generates a Pattern for running vLLM.
+// For multi-node deployment, vLLM requires --headless flag for worker nodes.
+func (v *VLLMEngine) GeneratePattern(opts GenerateOptions) (*workloadsv1alpha2.Pattern, error) {
+	podTemplate, err := v.generatePodTemplate(opts)
+	if err != nil {
+		return nil, err
 	}
 
-	// Build base args
+	if opts.DistributedSize > 1 {
+		// Multi-node deployment using LeaderWorkerPattern
+		// vLLM requires --headless for worker nodes
+		// WorkerTemplatePatch must contain complete args because Strategic Merge Patch
+		// replaces args entirely rather than appending.
+		workerPatch, err := v.generateWorkerPatch(opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate worker patch: %w", err)
+		}
+
+		return &workloadsv1alpha2.Pattern{
+			LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{
+				Size: &opts.DistributedSize,
+				TemplateSource: workloadsv1alpha2.TemplateSource{
+					Template: podTemplate,
+				},
+				WorkerTemplatePatch: workerPatch,
+			},
+		}, nil
+	}
+
+	// Single-node deployment using StandalonePattern
+	return &workloadsv1alpha2.Pattern{
+		StandalonePattern: &workloadsv1alpha2.StandalonePattern{
+			TemplateSource: workloadsv1alpha2.TemplateSource{
+				Template: podTemplate,
+			},
+		},
+	}, nil
+}
+
+// generateWorkerPatch creates a patch for worker nodes with complete args.
+// Note: Strategic Merge Patch replaces args entirely, so we must include all args.
+func (v *VLLMEngine) generateWorkerPatch(opts GenerateOptions) (*runtime.RawExtension, error) {
+	// Generate complete worker args (same as leader but with --headless appended)
+	workerArgs := v.generateArgs(opts, true)
+
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []map[string]interface{}{
+				{
+					"name": "vllm",
+					"args": workerArgs,
+				},
+			},
+		},
+	}
+
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runtime.RawExtension{
+		Raw: patchJSON,
+	}, nil
+}
+
+// generateArgs generates the args for vLLM container.
+// If isWorker is true, --headless flag is appended for worker nodes.
+func (v *VLLMEngine) generateArgs(opts GenerateOptions, isWorker bool) []string {
 	args := []string{
 		"--model",
 		opts.ModelPath,
@@ -80,8 +143,37 @@ func (v *VLLMEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplate
 		opts.Name,
 	}
 
+	// Add distributed deployment args for multi-node setup
+	if opts.DistributedSize > 1 {
+		args = append(args,
+			"--nnodes", "$(RBG_LWP_GROUP_SIZE)",
+			"--node-rank", "$(RBG_LWP_WORKER_INDEX)",
+			"--master-addr", "$(RBG_LWP_LEADER_ADDRESS)",
+		)
+	}
+
 	// Add user-provided args
 	args = append(args, opts.Args...)
+
+	// Worker nodes need --headless flag
+	if isWorker {
+		args = append(args, "--headless")
+	}
+
+	return args
+}
+
+// generatePodTemplate generates the base PodTemplateSpec for vLLM.
+// The base template is used for leader nodes in multi-node deployment.
+func (v *VLLMEngine) generatePodTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
+	// Use override image if provided, otherwise use default
+	image := v.Image
+	if opts.Image != "" {
+		image = opts.Image
+	}
+
+	// Build args for leader/base template (isWorker=false)
+	args := v.generateArgs(opts, false)
 
 	podSpec := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{

--- a/cmd/cli/plugin/engine/vllm.go
+++ b/cmd/cli/plugin/engine/vllm.go
@@ -62,26 +62,40 @@ func (v *VLLMEngine) Init(config map[string]interface{}) error {
 }
 
 // GenerateTemplate generates a pod template for running vLLM
-func (v *VLLMEngine) GenerateTemplate(name string, modelID string, modelPath string) (*corev1.PodTemplateSpec, error) {
+func (v *VLLMEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplateSpec, error) {
+	// Use override image if provided, otherwise use default
+	image := v.Image
+	if opts.Image != "" {
+		image = opts.Image
+	}
+
+	// Build base args
+	args := []string{
+		"--model",
+		opts.ModelPath,
+		"--served-model-name",
+		opts.Name,
+	}
+
+	// Add user-provided args
+	args = append(args, opts.Args...)
+
 	return &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:            "vllm",
-					Image:           v.Image,
+					Image:           image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Args: []string{
-						"--model",
-						modelPath,
-						"--served-model-name",
-						name,
-					},
+					Args:            args,
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
 							ContainerPort: v.Port,
 						},
 					},
+					Env:       opts.Env,
+					Resources: opts.Resources,
 				},
 			},
 		},

--- a/cmd/cli/plugin/engine/vllm.go
+++ b/cmd/cli/plugin/engine/vllm.go
@@ -17,7 +17,10 @@ limitations under the License.
 package engine
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
@@ -80,7 +83,7 @@ func (v *VLLMEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplate
 	// Add user-provided args
 	args = append(args, opts.Args...)
 
-	return &corev1.PodTemplateSpec{
+	podSpec := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -99,5 +102,32 @@ func (v *VLLMEngine) GenerateTemplate(opts GenerateOptions) (*corev1.PodTemplate
 				},
 			},
 		},
-	}, nil
+	}
+
+	// Add shared memory volume if ShmSize is specified
+	if opts.ShmSize != "" {
+		shmQuantity, err := resource.ParseQuantity(opts.ShmSize)
+		if err != nil {
+			return nil, fmt.Errorf("invalid shmSize %q: %w", opts.ShmSize, err)
+		}
+
+		// Add volume to pod
+		podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, corev1.Volume{
+			Name: "shm",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: &shmQuantity,
+				},
+			},
+		})
+
+		// Add volume mount to container
+		podSpec.Spec.Containers[0].VolumeMounts = append(podSpec.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      "shm",
+			MountPath: "/dev/shm",
+		})
+	}
+
+	return podSpec, nil
 }

--- a/cmd/cli/plugin/engine/vllm_test.go
+++ b/cmd/cli/plugin/engine/vllm_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,17 +57,21 @@ func TestVLLMEngine_Init_Custom(t *testing.T) {
 	assert.Equal(t, int32(9090), v.Port)
 }
 
-func TestVLLMEngine_GenerateTemplate(t *testing.T) {
+func TestVLLMEngine_GeneratePattern(t *testing.T) {
 	v := &VLLMEngine{}
 	require.NoError(t, v.Init(map[string]interface{}{}))
 
-	tpl, err := v.GenerateTemplate(GenerateOptions{
+	pattern, err := v.GeneratePattern(GenerateOptions{
 		Name:      "mymodel",
 		ModelID:   "org/model",
 		ModelPath: "/models/mymodel",
 	})
 	require.NoError(t, err)
-	require.NotNil(t, tpl)
+	require.NotNil(t, pattern)
+	require.NotNil(t, pattern.StandalonePattern)
+	require.NotNil(t, pattern.StandalonePattern.Template)
+
+	tpl := pattern.StandalonePattern.Template
 	require.Len(t, tpl.Spec.Containers, 1)
 
 	c := tpl.Spec.Containers[0]
@@ -79,6 +84,95 @@ func TestVLLMEngine_GenerateTemplate(t *testing.T) {
 	require.Len(t, c.Ports, 1)
 	assert.Equal(t, int32(8000), c.Ports[0].ContainerPort)
 	assert.Equal(t, "http", c.Ports[0].Name)
+}
+
+func TestVLLMEngine_GeneratePattern_Distributed(t *testing.T) {
+	v := &VLLMEngine{}
+	require.NoError(t, v.Init(map[string]interface{}{}))
+
+	pattern, err := v.GeneratePattern(GenerateOptions{
+		Name:            "mymodel",
+		ModelID:         "org/model",
+		ModelPath:       "/models/mymodel",
+		Args:            []string{"--tensor-parallel-size=2"},
+		DistributedSize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pattern)
+	require.NotNil(t, pattern.LeaderWorkerPattern)
+	require.Equal(t, int32(2), *pattern.LeaderWorkerPattern.Size)
+	require.NotNil(t, pattern.LeaderWorkerPattern.Template)
+	require.NotNil(t, pattern.LeaderWorkerPattern.WorkerTemplatePatch)
+
+	tpl := pattern.LeaderWorkerPattern.Template
+	require.Len(t, tpl.Spec.Containers, 1)
+
+	c := tpl.Spec.Containers[0]
+	// Check distributed args are injected (args are separate elements)
+	assert.Contains(t, c.Args, "--nnodes")
+	assert.Contains(t, c.Args, "$(RBG_LWP_GROUP_SIZE)")
+	assert.Contains(t, c.Args, "--node-rank")
+	assert.Contains(t, c.Args, "$(RBG_LWP_WORKER_INDEX)")
+	assert.Contains(t, c.Args, "--master-addr")
+	assert.Contains(t, c.Args, "$(RBG_LWP_LEADER_ADDRESS)")
+	// Check user args are preserved
+	assert.Contains(t, c.Args, "--tensor-parallel-size=2")
+	// Leader should NOT have --headless
+	assert.NotContains(t, c.Args, "--headless")
+}
+
+func TestVLLMEngine_GeneratePattern_Distributed_WorkerPatch(t *testing.T) {
+	v := &VLLMEngine{}
+	require.NoError(t, v.Init(map[string]interface{}{}))
+
+	pattern, err := v.GeneratePattern(GenerateOptions{
+		Name:            "mymodel",
+		ModelID:         "org/model",
+		ModelPath:       "/models/mymodel",
+		Args:            []string{"--tensor-parallel-size=2"},
+		DistributedSize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pattern.LeaderWorkerPattern.WorkerTemplatePatch)
+
+	// Parse the WorkerTemplatePatch to verify args
+	patch := pattern.LeaderWorkerPattern.WorkerTemplatePatch
+	var patchData map[string]interface{}
+	require.NoError(t, json.Unmarshal(patch.Raw, &patchData), "failed to parse WorkerTemplatePatch")
+
+	// Navigate to containers[0].args
+	spec, ok := patchData["spec"].(map[string]interface{})
+	require.True(t, ok, "patch should have spec")
+	containers, ok := spec["containers"].([]interface{})
+	require.True(t, ok, "spec should have containers")
+	require.Len(t, containers, 1, "should have one container")
+
+	container, ok := containers[0].(map[string]interface{})
+	require.True(t, ok, "container should be a map")
+	assert.Equal(t, "vllm", container["name"], "container name should be vllm")
+
+	args, ok := container["args"].([]interface{})
+	require.True(t, ok, "container should have args")
+
+	// Convert args to []string for easier assertions
+	var argsSlice []string
+	for _, arg := range args {
+		if s, ok := arg.(string); ok {
+			argsSlice = append(argsSlice, s)
+		}
+	}
+
+	// Verify worker patch contains ALL required args
+	// (Strategic Merge Patch replaces args entirely, so all args must be present)
+	assert.Contains(t, argsSlice, "--model", "worker args should contain --model")
+	assert.Contains(t, argsSlice, "/models/mymodel", "worker args should contain model path")
+	assert.Contains(t, argsSlice, "--served-model-name", "worker args should contain --served-model-name")
+	assert.Contains(t, argsSlice, "mymodel", "worker args should contain model name")
+	assert.Contains(t, argsSlice, "--nnodes", "worker args should contain --nnodes")
+	assert.Contains(t, argsSlice, "--node-rank", "worker args should contain --node-rank")
+	assert.Contains(t, argsSlice, "--master-addr", "worker args should contain --master-addr")
+	assert.Contains(t, argsSlice, "--tensor-parallel-size=2", "worker args should preserve user args")
+	assert.Contains(t, argsSlice, "--headless", "worker args should have --headless flag")
 }
 
 func TestGet_VLLM_InitAndReturn(t *testing.T) {

--- a/cmd/cli/plugin/engine/vllm_test.go
+++ b/cmd/cli/plugin/engine/vllm_test.go
@@ -60,7 +60,11 @@ func TestVLLMEngine_GenerateTemplate(t *testing.T) {
 	v := &VLLMEngine{}
 	require.NoError(t, v.Init(map[string]interface{}{}))
 
-	tpl, err := v.GenerateTemplate("mymodel", "org/model", "/models/mymodel")
+	tpl, err := v.GenerateTemplate(GenerateOptions{
+		Name:      "mymodel",
+		ModelID:   "org/model",
+		ModelPath: "/models/mymodel",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, tpl)
 	require.Len(t, tpl.Spec.Containers, 1)

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -850,8 +850,8 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_Labels(t *testing.T) {
 				"kwota.meta.com/quota-allocation":      "my-qa",
 				"kwota.meta.com/workload-variant":      "gb200",
 				"kwota.meta.com/workload-variant-type": "Standalone",
-				constants.GroupNameLabelKey:             "test-rbg",
-				constants.RoleNameLabelKey:              "engine",
+				constants.GroupNameLabelKey:            "test-rbg",
+				constants.RoleNameLabelKey:             "engine",
 			},
 		},
 		{
@@ -863,14 +863,14 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_Labels(t *testing.T) {
 					Labels: map[string]string{
 						constants.GroupNameLabelKey: "user-override-attempt",
 						constants.RoleNameLabelKey:  "user-override-attempt",
-						"custom-label":             "custom-value",
+						"custom-label":              "custom-value",
 					},
 				},
 			},
 			wantLabels: map[string]string{
 				constants.GroupNameLabelKey: "test-rbg",
 				constants.RoleNameLabelKey:  "engine",
-				"custom-label":             "custom-value",
+				"custom-label":              "custom-value",
 			},
 		},
 		{
@@ -999,8 +999,8 @@ func TestRoleBasedGroupReconciler_ReconcileScalingAdapter_LabelUpdate(t *testing
 	wantLabels := map[string]string{
 		"kwota.meta.com/quota-allocation": "my-qa",
 		"kwota.meta.com/workload-variant": "gb200",
-		constants.GroupNameLabelKey:        rbg.Name,
-		constants.RoleNameLabelKey:         roleName,
+		constants.GroupNameLabelKey:       rbg.Name,
+		constants.RoleNameLabelKey:        roleName,
 	}
 	if len(updated.Labels) != len(wantLabels) {
 		t.Errorf("expected %d labels, got %d: %v", len(wantLabels), len(updated.Labels), updated.Labels)


### PR DESCRIPTION
## Summary

Adds multi-node LLM inference serving support to `kubectl-rbg llm run` command, enabling deployment of distributed vLLM/SGLang inference clusters.

### Key Changes

**1. Multi-node Serving Support**
- Add `--distributed-nodes` flag to deploy multi-node distributed inference services
- Generate correct startup parameters for Leader and Worker roles
- Worker uses Strategic Merge Patch to inject complete args, preventing parameter override issues

**2. Port-forward Improvements**
- `llm chat` command correctly port-forwards to Leader Pod for LeaderWorkerPattern

**3. Shared Memory Configuration**
- Add `--shm-size` flag to configure shared memory size for large model inference workloads

**4. Code Refactoring**
- Unify `generateArgs` function for container startup argument construction
- Improve engine interface design for better maintainability

**5. Service Readiness Check**
- Check if LLM service is up before returning from llm run command
- Ensure the inference endpoint is ready before user interaction

### Files Changed

| File | Description |
|------|-------------|
| `cmd/cli/cmd/llm/run.go` | Core multi-node deployment logic |
| `cmd/cli/plugin/engine/vllm.go` | vLLM multi-node parameter generation |
| `cmd/cli/plugin/engine/sglang.go` | SGLang multi-node parameter generation |
| `cmd/cli/cmd/llm/chat/chat.go` | Port-forward logic fix |
| `cmd/cli/cmd/llm/chat/portforward.go` | Service readiness check |
| `cmd/cli/cmd/llm/pull.go` | Minor fix |
| Test files | Add unit tests for multi-node scenarios |