### PR TITLE
fix(roleinstance): nil pointer dereference in in-place update

### DIFF
--- a/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate.go
+++ b/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate.go
@@ -162,6 +162,9 @@ func (c *realControl) groupComponentControllerRevision(ctx context.Context, oldR
 }
 
 func (c *realControl) splitComponentControllerRevision(revision *apps.ControllerRevision) (map[string]*componentRevision, error) {
+	if revision == nil {
+		return nil, fmt.Errorf("cannot split nil ControllerRevision")
+	}
 	var raw map[string]interface{}
 	if err := json.Unmarshal(revision.Data.Raw, &raw); err != nil {
 		return nil, err

--- a/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate.go
+++ b/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate.go
@@ -19,6 +19,7 @@ package inplaceupdate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -38,6 +39,9 @@ import (
 	podinplaceupdate "sigs.k8s.io/rbgs/pkg/inplace/pod/inplaceupdate"
 	instanceutil "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/utils"
 )
+
+// ErrNilControllerRevision is returned when a nil revision is split.
+var ErrNilControllerRevision = errors.New("cannot split nil ControllerRevision")
 
 // Interface for managing pods in-place update.
 type Interface interface {
@@ -163,7 +167,7 @@ func (c *realControl) groupComponentControllerRevision(ctx context.Context, oldR
 
 func (c *realControl) splitComponentControllerRevision(revision *apps.ControllerRevision) (map[string]*componentRevision, error) {
 	if revision == nil {
-		return nil, fmt.Errorf("cannot split nil ControllerRevision")
+		return nil, ErrNilControllerRevision
 	}
 	var raw map[string]interface{}
 	if err := json.Unmarshal(revision.Data.Raw, &raw); err != nil {

--- a/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate_test.go
+++ b/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inplaceupdate
+
+import (
+	"testing"
+)
+
+func TestSplitComponentControllerRevisionNilInput(t *testing.T) {
+	c := &realControl{}
+	_, err := c.splitComponentControllerRevision(nil)
+	if err == nil {
+		t.Fatal("expected error for nil revision, got nil")
+	}
+	if err.Error() != "cannot split nil ControllerRevision" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}

--- a/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate_test.go
+++ b/pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package inplaceupdate
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -26,7 +27,7 @@ func TestSplitComponentControllerRevisionNilInput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil revision, got nil")
 	}
-	if err.Error() != "cannot split nil ControllerRevision" {
-		t.Fatalf("unexpected error message: %s", err.Error())
+	if !errors.Is(err, ErrNilControllerRevision) {
+		t.Fatalf("expected ErrNilControllerRevision, got %v", err)
 	}
 }

--- a/pkg/reconciler/roleinstance/sync/instance_update.go
+++ b/pkg/reconciler/roleinstance/sync/instance_update.go
@@ -72,6 +72,18 @@ func (c *realControl) updatePod(ctx context.Context, instance *workloadsv1alpha2
 			break
 		}
 	}
+	if oldRevision == nil {
+		logger.Info("Pod references a ControllerRevision that no longer exists, falling back to ReCreate",
+			"pod", klog.KObj(pod))
+		c.recorder.Eventf(instance, v1.EventTypeWarning, "RevisionNotFound",
+			"pod %s references a garbage-collected revision, falling back to recreate", pod.Name)
+		if err := c.Delete(ctx, pod); err != nil {
+			c.recorder.Eventf(instance, v1.EventTypeWarning, "FailedUpdatePodReCreate",
+				"failed to delete pod %s for update: %v", pod.Name, err)
+			return 0, err
+		}
+		return 0, nil
+	}
 	coreControl := instancecore.New(instance)
 	res := c.inplaceControl.Update(ctx, pod, oldRevision, updateRevision, coreControl.GetUpdateOptions())
 	if res.InPlaceUpdate {
@@ -84,7 +96,7 @@ func (c *realControl) updatePod(ctx context.Context, instance *workloadsv1alpha2
 		return res.DelayDuration, res.UpdateErr
 	}
 	logger.Info("Instance can not update Pod in-place, so it will back off to ReCreate", "pod", klog.KObj(pod))
-	if err := c.Delete(context.TODO(), pod); err != nil {
+	if err := c.Delete(ctx, pod); err != nil {
 		c.recorder.Eventf(instance, v1.EventTypeWarning, "FailedUpdatePodReCreate", "failed to delete pod %s for update: %v", pod.Name, err)
 		return 0, err
 	}

--- a/pkg/reconciler/roleinstance/sync/instance_update.go
+++ b/pkg/reconciler/roleinstance/sync/instance_update.go
@@ -73,10 +73,11 @@ func (c *realControl) updatePod(ctx context.Context, instance *workloadsv1alpha2
 		}
 	}
 	if oldRevision == nil {
-		logger.Info("Pod references a ControllerRevision that no longer exists, falling back to ReCreate",
-			"pod", klog.KObj(pod))
+		logger.Info("No matching ControllerRevision found for pod, falling back to ReCreate",
+			"pod", klog.KObj(pod),
+			"revisionHash", pod.Labels[apps.ControllerRevisionHashLabelKey])
 		c.recorder.Eventf(instance, v1.EventTypeWarning, "RevisionNotFound",
-			"pod %s references a garbage-collected revision, falling back to recreate", pod.Name)
+			"no matching revision found for pod %s, falling back to recreate", pod.Name)
 		if err := c.Delete(ctx, pod); err != nil {
 			c.recorder.Eventf(instance, v1.EventTypeWarning, "FailedUpdatePodReCreate",
 				"failed to delete pod %s for update: %v", pod.Name, err)

--- a/pkg/reconciler/roleinstance/sync/instance_update_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_update_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	podinplaceupdate "sigs.k8s.io/rbgs/pkg/inplace/pod/inplaceupdate"
+)
+
+// fakeInplaceControl implements inplaceupdate.Interface for testing.
+type fakeInplaceControl struct {
+	updateFn func(ctx context.Context, pod *v1.Pod, oldRevision, newRevision *apps.ControllerRevision, opts *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult
+}
+
+func (f *fakeInplaceControl) CanUpdateInPlace(_ context.Context, _, _ *apps.ControllerRevision, _ *podinplaceupdate.UpdateOptions) bool {
+	return false
+}
+
+func (f *fakeInplaceControl) Refresh(_ context.Context, _ *v1.Pod, _ *podinplaceupdate.UpdateOptions) podinplaceupdate.RefreshResult {
+	return podinplaceupdate.RefreshResult{}
+}
+
+func (f *fakeInplaceControl) Update(ctx context.Context, pod *v1.Pod, oldRevision, newRevision *apps.ControllerRevision, opts *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult {
+	if f.updateFn != nil {
+		return f.updateFn(ctx, pod, oldRevision, newRevision, opts)
+	}
+	return podinplaceupdate.UpdateResult{}
+}
+
+// fakeLifecycleControl implements lifecycle.Interface for testing.
+type fakeLifecycleControl struct{}
+
+func (f *fakeLifecycleControl) UpdatePodLifecycle(_ *workloadsv1alpha2.RoleInstance, _ *v1.Pod, _ bool) (bool, *v1.Pod, error) {
+	return false, nil, nil
+}
+
+func TestUpdatePod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = apps.AddToScheme(scheme)
+	_ = workloadsv1alpha2.AddToScheme(scheme)
+
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-instance",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+
+	tests := []struct {
+		name             string
+		podRevisionHash  string
+		revisionNames    []string
+		updateFn         func(ctx context.Context, pod *v1.Pod, oldRevision, newRevision *apps.ControllerRevision, opts *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult
+		expectPodDeleted bool
+	}{
+		{
+			name:            "nil oldRevision falls back to recreate",
+			podRevisionHash: "nonexistent-revision",
+			revisionNames:   []string{"rev-abc123", "rev-def456"},
+			updateFn: func(_ context.Context, _ *v1.Pod, _, _ *apps.ControllerRevision, _ *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult {
+				t.Fatal("inplaceControl.Update should not be called when oldRevision is nil")
+				return podinplaceupdate.UpdateResult{}
+			},
+			expectPodDeleted: true,
+		},
+		{
+			name:            "matching revision, in-place update succeeds",
+			podRevisionHash: "rev-abc123",
+			revisionNames:   []string{"rev-abc123", "rev-def456"},
+			updateFn: func(_ context.Context, _ *v1.Pod, oldRevision, _ *apps.ControllerRevision, _ *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult {
+				if oldRevision == nil {
+					t.Fatal("oldRevision should not be nil when a matching revision exists")
+				}
+				return podinplaceupdate.UpdateResult{InPlaceUpdate: true, NewResourceVersion: "999"}
+			},
+			expectPodDeleted: false,
+		},
+		{
+			name:            "matching revision, in-place not possible falls back to recreate",
+			podRevisionHash: "rev-abc123",
+			revisionNames:   []string{"rev-abc123", "rev-def456"},
+			updateFn: func(_ context.Context, _ *v1.Pod, _ *apps.ControllerRevision, _ *apps.ControllerRevision, _ *podinplaceupdate.UpdateOptions) podinplaceupdate.UpdateResult {
+				return podinplaceupdate.UpdateResult{InPlaceUpdate: false}
+			},
+			expectPodDeleted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						apps.ControllerRevisionHashLabelKey: tt.podRevisionHash,
+					},
+				},
+			}
+			updateRevision := &apps.ControllerRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rev-def456",
+					Namespace: "default",
+				},
+			}
+			var revisions []*apps.ControllerRevision
+			for _, name := range tt.revisionNames {
+				revisions = append(revisions, &apps.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: "default",
+					},
+				})
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(pod).
+				Build()
+
+			recorder := record.NewFakeRecorder(10)
+
+			ctrl := &realControl{
+				Client:           fakeClient,
+				inplaceControl:   &fakeInplaceControl{updateFn: tt.updateFn},
+				recorder:         recorder,
+				lifecycleControl: &fakeLifecycleControl{},
+			}
+
+			_, err := ctrl.updatePod(context.Background(), instance, updateRevision, revisions, pod)
+			if err != nil {
+				t.Fatalf("updatePod returned unexpected error: %v", err)
+			}
+
+			// Check if pod was deleted
+			gotPod := &v1.Pod{}
+			getErr := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), gotPod)
+			podDeleted := getErr != nil
+			if podDeleted != tt.expectPodDeleted {
+				t.Errorf("expected pod deleted=%v, got deleted=%v (err=%v)", tt.expectPodDeleted, podDeleted, getErr)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/roleinstance/sync/instance_update_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_update_test.go
@@ -22,14 +22,17 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	podinplaceupdate "sigs.k8s.io/rbgs/pkg/inplace/pod/inplaceupdate"
+	instanceutil "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/utils"
 )
 
 // fakeInplaceControl implements inplaceupdate.Interface for testing.
@@ -117,13 +120,18 @@ func TestUpdatePod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
+					Name:            "test-pod",
+					Namespace:       "default",
+					UID:             types.UID(tt.name),
+					ResourceVersion: "1",
 					Labels: map[string]string{
 						apps.ControllerRevisionHashLabelKey: tt.podRevisionHash,
 					},
 				},
 			}
+			t.Cleanup(func() {
+				instanceutil.ResourceVersionExpectations.Delete(pod)
+			})
 			updateRevision := &apps.ControllerRevision{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rev-def456",
@@ -162,7 +170,10 @@ func TestUpdatePod(t *testing.T) {
 			// Check if pod was deleted
 			gotPod := &v1.Pod{}
 			getErr := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), gotPod)
-			podDeleted := getErr != nil
+			podDeleted := apierrors.IsNotFound(getErr)
+			if getErr != nil && !podDeleted {
+				t.Fatalf("unexpected error getting pod: %v", getErr)
+			}
 			if podDeleted != tt.expectPodDeleted {
 				t.Errorf("expected pod deleted=%v, got deleted=%v (err=%v)", tt.expectPodDeleted, podDeleted, getErr)
 			}


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference in `updatePod` when a pod's referenced ControllerRevision is missing
- Fall back to recreate when no matching revision is found for the pod
- Add a sentinel `ErrNilControllerRevision` guard in `splitComponentControllerRevision`
- Use `ctx` for the recreate delete path and make the `RevisionNotFound` log and event wording accurate
- Harden unit tests with `errors.Is`, non-empty pod metadata, expectation cleanup, and precise `NotFound` assertions

Upstream: mslsrc/supercomputing#418

## Test plan
- [x] `go test ./pkg/reconciler/roleinstance/inplaceupdate`
- [x] `go test ./pkg/reconciler/roleinstance/sync`
