### PR TITLE
fix: deal with injectMetadataSave properly

### DIFF
--- a/cmd/cli/cmd/llm/model/pull.go
+++ b/cmd/cli/cmd/llm/model/pull.go
@@ -392,9 +392,25 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 		`downloadedAt=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) && printf '%%s\n' %s | sed "s/{{DOWNLOADED_AT}}/$downloadedAt/g" > %s`,
 		shellEscape(metadataJSON), shellEscape(modelPath+"/.rbg-metadata.json"))
 
-	// Case 1: Container already uses /bin/sh -c, directly append to the command
-	if len(container.Command) >= 2 && container.Command[0] == "/bin/sh" && container.Command[1] == "-c" {
-		if len(container.Args) > 0 {
+	// Case 1: Container already uses /bin/sh -c, directly append to the command.
+	// Handles both:
+	//   a) Command: ["/bin/sh", "-c"], Args: [...]
+	//   b) Command: ["/bin/sh"],       Args: ["-c", ...]
+	isShellC := len(container.Command) >= 2 && container.Command[0] == "/bin/sh" && container.Command[1] == "-c"
+	isShellWithCArg := len(container.Command) == 1 && container.Command[0] == "/bin/sh" && len(container.Args) >= 1 && container.Args[0] == "-c"
+
+	if isShellC || isShellWithCArg {
+		if isShellWithCArg {
+			// Normalize form (b) to form (a) so the rest of the logic is uniform.
+			container.Command = append(container.Command, "-c")
+			container.Args = container.Args[1:]
+		}
+
+		if len(container.Args) == 0 {
+			container.Args = []string{metadataCmd}
+		} else {
+			// Args should typically have exactly one element for /bin/sh -c;
+			// additional elements become $0, $1... and are not executed as commands.
 			container.Args[0] = container.Args[0] + " && " + metadataCmd
 		}
 		return
@@ -416,9 +432,8 @@ func injectMetadataSave(podTemplate *corev1.PodTemplateSpec, modelID, revision, 
 	}
 
 	// Build the wrapped command with metadata save
-	// Use printf instead of echo to prevent flag injection (e.g. echo -e, echo -n)
-	wrappedCmd := fmt.Sprintf(`%s && printf '%%s\n' %s > %s`,
-		fullCmd.String(), shellEscape(metadataJSON), shellEscape(modelPath+"/.rbg-metadata.json"))
+	// Reuse metadataCmd which includes date generation, sed replacement, and safe writing
+	wrappedCmd := fmt.Sprintf(`%s && %s`, fullCmd.String(), metadataCmd)
 
 	container.Command = []string{"/bin/sh", "-c"}
 	container.Args = []string{wrappedCmd}

--- a/cmd/cli/cmd/llm/model/pull_test.go
+++ b/cmd/cli/cmd/llm/model/pull_test.go
@@ -229,9 +229,9 @@ func extractJSONFromCommand(t *testing.T, cmd []string, args []string) string {
 
 	shellCmd := args[0]
 
-	// Both Case 1 and Case 2 now use printf '%s\n' for safety
+	// Both Case 1 and Case 2 now use printf '%s\n' and sed for safety
 	// Case 1: "original_cmd && downloadedAt=$(date ...) && printf '%s\n' {JSON} | sed ... > /path"
-	// Case 2: "binary args && printf '%s\n' {JSON} > /path"
+	// Case 2: "binary args && downloadedAt=$(date ...) && printf '%s\n' {JSON} | sed ... > /path"
 	//
 	// The JSON is passed as argument to printf (with shellEscape, may be quoted)
 	printfIdx := strings.Index(shellCmd, "printf '%s\\n' ")


### PR DESCRIPTION
## Summary

Fixes two issues in the `injectMetadataSave` helper within `rbgctl llm pull`:

1. **Incomplete `/bin/sh -c` detection** — the previous code only recognized `Command: ["/bin/sh", "-c"], Args: [...]`. It now also handles the variant `Command: ["/bin/sh"], Args: ["-c", ...]` and normalizes it to the standard form so downstream logic stays uniform.
2. **Inconsistent metadata save command between Case 1 and Case 2** — Case 2 (wrap a direct binary) was using a simplified `printf '%s\n'` without generating the `downloadedAt` timestamp via `date` and `sed`. It now reuses the same `metadataCmd` as Case 1, ensuring the `.rbg-metadata.json` file always contains the correct `downloadedAt` value.

## Changes

- `cmd/cli/cmd/llm/pull.go`
  - Expands `isShellC` detection to cover `/bin/sh` with `-c` in `Args`
  - Normalizes the split form into `Command: ["/bin/sh", "-c"]` before appending the metadata command
  - Handles the edge case where `container.Args` is empty
  - Unifies Case 2 to use the same `metadataCmd` (with `date` + `sed`) instead of a shorter variant
- `cmd/cli/cmd/llm/pull_test.go`
  - Updates test comments to reflect that both cases now use `printf '%s\n'` with `date` and `sed`
