### PR TITLE
feat(cli): enhance llm svc run with two new override flags

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -87,6 +87,7 @@ kubectl rbg llm svc run NAME MODEL_ID [flags]
 | `--replicas` | | Number of replicas | 1 |
 | `--mode` | | Run mode (from model config) | (first mode in model config) |
 | `--engine` | | Inference engine override (`vllm`, `sglang`) | (from mode config) |
+| `--image` | | Container image override | (from mode config) |
 | `--env` | | Environment variables (`KEY=VALUE`), can be specified multiple times | |
 | `--arg` | | Additional arguments for the engine, can be specified multiple times | |
 | `--storage` | | Storage to use (overrides default) | (current storage) |
@@ -105,6 +106,9 @@ kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --mode throughput
 
 # Override engine
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --mode custom --engine sglang
+
+# Use a custom image (e.g., mirror registry)
+kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --image registry.cn-hangzhou.aliyuncs.com/my/vllm:latest
 
 # Run with multiple replicas
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --replicas 3

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -42,7 +42,7 @@ Once the service is running, you can chat with it:
 
 ```bash
 # Interactive mode
-kubectl rbg llm svc chat my-qwen
+kubectl rbg llm svc chat my-qwen -i
 
 # Or send a single prompt
 kubectl rbg llm svc chat my-qwen --prompt "Hello, how are you?"
@@ -92,8 +92,13 @@ kubectl rbg llm svc run NAME MODEL_ID [flags]
 | `--arg` | | Additional arguments for the engine, can be specified multiple times | |
 | `--storage` | | Storage to use (overrides default) | (current storage) |
 | `--revision` | | Model revision | `main` |
+| `--model-path` | | Absolute model path inside the container. Storage is mounted at `/models`, so the default path is `/models/<model>/<revision>` | |
 | `--dry-run` | | Print the generated template without creating the workload | `false` |
-| `--namespace` | `-n` | Kubernetes namespace | default |
+| `--wait` | | Wait for the RoleBasedGroup to be ready before returning | `true` |
+| `--wait-timeout` | | Timeout for waiting for RoleBasedGroup to be ready | `20m` |
+| `--test-api` | | Test the `/v1/chat/completions` API endpoint after the service is ready | `true` |
+| `--test-api-timeout` | | Timeout for testing the API endpoint | `5m` |
+| `--local-port` | | Local port for port-forward when testing API | `32432` |
 
 **Examples:**
 
@@ -121,6 +126,12 @@ kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --env CUDA_VISIBLE_DEVICES=0,1
 
 # Pass additional engine arguments
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --arg --max-model-len=4096 --arg --dtype=half
+
+# Specify a custom model path (when models are placed manually in storage)
+kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --model-path /models/my-custom-model
+
+# Skip API readiness test
+kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --test-api=false
 ```
 
 ### llm svc list
@@ -135,7 +146,6 @@ kubectl rbg llm svc list [flags]
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--namespace` | `-n` | Kubernetes namespace | default |
 | `--all-namespaces` | `-A` | List across all namespaces | false |
 
 **Example:**
@@ -153,14 +163,8 @@ kubectl rbg llm svc list -A
 Delete an LLM inference service.
 
 ```bash
-kubectl rbg llm svc delete NAME [flags]
+kubectl rbg llm svc delete NAME... [flags]
 ```
-
-**Flags:**
-
-| Flag | Short | Description | Default |
-|------|-------|-------------|---------|
-| `--namespace` | `-n` | Kubernetes namespace | default |
 
 **Example:**
 
@@ -170,7 +174,7 @@ kubectl rbg llm svc delete my-qwen
 
 ### llm model list
 
-List available models from configured sources.
+List downloaded models in storage.
 
 ```bash
 kubectl rbg llm model list [flags]
@@ -180,16 +184,16 @@ kubectl rbg llm model list [flags]
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--source` | | Filter by source name | |
+| `--storage` | | Storage to use (overrides default) | (current storage) |
 
 **Example:**
 
 ```bash
-# List all available models
+# List models in the default storage
 kubectl rbg llm model list
 
-# List models from a specific source
-kubectl rbg llm model list --source huggingface
+# List models in a specific storage
+kubectl rbg llm model list --storage my-pvc
 ```
 
 ### llm model pull
@@ -197,7 +201,7 @@ kubectl rbg llm model list --source huggingface
 Pull a model from the configured source to storage.
 
 ```bash
-kubectl rbg llm model pull MODEL_NAME [flags]
+kubectl rbg llm model pull MODEL_ID [flags]
 ```
 
 **Flags:**
@@ -206,11 +210,20 @@ kubectl rbg llm model pull MODEL_NAME [flags]
 |------|-------|-------------|---------|
 | `--source` | | Source configuration name | (current source) |
 | `--storage` | | Storage configuration name | (current storage) |
+| `--revision` | | Model revision to download | `main` |
+| `--wait` | | Wait for the pull job to complete and stream logs | `true` |
 
 **Example:**
 
 ```bash
+# Pull a model with default settings
 kubectl rbg llm model pull Qwen/Qwen2.5-7B
+
+# Pull a specific revision
+kubectl rbg llm model pull Qwen/Qwen2.5-7B --revision v1.0
+
+# Pull without waiting for completion
+kubectl rbg llm model pull Qwen/Qwen2.5-7B --wait=false
 ```
 
 ### llm svc chat
@@ -225,25 +238,25 @@ kubectl rbg llm svc chat NAME [flags]
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--prompt` | `-p` | Single prompt (non-interactive) | |
-| `--interactive` | `-i` | Start interactive chat session (REPL) | false |
-| `--local-port` | | Local port for the tunnel | (random) |
+| `--prompt` | `-p` | Single prompt (non-interactive); combined with `-i` to seed the first turn | |
+| `--interactive` | `-i` | Start an interactive chat session (REPL) | false |
+| `--local-port` | | Local port for the tunnel | 0 (random) |
 | `--system` | | System prompt prepended to conversation | |
 | `--no-stream` | | Disable streaming | false |
-| `--request-timeout` | | HTTP request timeout | 5m |
+| `--request-timeout` | | HTTP request timeout for model inference | 5m |
 | `--port-forward-timeout` | | Port-forward tunnel timeout | 30s |
 
 **Examples:**
 
 ```bash
 # Interactive chat session
-kubectl rbg llm svc chat my-qwen
+kubectl rbg llm svc chat my-qwen -i
 
 # Single prompt (non-interactive)
 kubectl rbg llm svc chat my-qwen --prompt "What is the capital of France?"
 
-# With system prompt
-kubectl rbg llm svc chat my-qwen --system "You are a helpful assistant."
+# With system prompt (interactive)
+kubectl rbg llm svc chat my-qwen -i --system "You are a helpful assistant."
 ```
 
 ### llm generate
@@ -261,17 +274,17 @@ kubectl rbg llm generate [flags]
 | `--model` | Model name |
 | `--system` | GPU system type (h100_sxm, a100_sxm, b200_sxm, gb200_sxm, l40s, h200_sxm) |
 | `--total-gpus` | Total number of GPUs for deployment |
+| `--isl` | Input sequence length |
+| `--osl` | Output sequence length |
 
 **Optional Flags:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--isl` | Input sequence length | 4000 |
-| `--osl` | Output sequence length | 1000 |
+| `--configurator-tool` | Configurator tool to use | `aiconfigurator` |
 | `--ttft` | Time to first token (ms) | -1 |
 | `--tpot` | Time per output token (ms) | -1 |
 | `--request-latency` | End-to-end request latency target (ms) | -1 |
-| `--hf-id` | HuggingFace model ID | |
 | `--decode-system` | GPU system for decode workers | (same as --system) |
 | `--backend` | Inference backend (sglang, vllm, trtllm) | sglang |
 | `--backend-version` | Backend version | |
@@ -325,6 +338,7 @@ kubectl rbg llm benchmark run RBG_NAME [flags]
 | `--num-concurrency` | | Concurrency levels, can be specified multiple times or comma-separated | |
 | `--api-backend` | | API backend type (overrides auto-discovered value) | |
 | `--api-base` | | Base URL for the model serving API (overrides auto-discovered value) | |
+| `--api-port` | | Port for the model serving API (used when auto-generating api-base) | `8000` |
 | `--api-key` | | API key used to call the model serving API | `rbg` |
 | `--api-model-name` | | Model name used by the backend (overrides auto-discovered value) | |
 | `--model-tokenizer` | | Tokenizer to use (HuggingFace model name or PVC path) | (required) |
@@ -366,18 +380,24 @@ kubectl rbg llm benchmark run my-qwen \
 
 #### benchmark get
 
-Get benchmark results.
+Get benchmark configuration for a benchmark job.
 
 ```bash
-kubectl rbg llm benchmark get JOB_NAME [flags]
+kubectl rbg llm benchmark get RBG_NAME --job JOB_NAME [flags]
 ```
+
+**Flags:**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--job` | | Name of the benchmark job to inspect (required) | |
 
 #### benchmark list
 
-List benchmark jobs.
+List benchmark jobs for a RoleBasedGroup.
 
 ```bash
-kubectl rbg llm benchmark list [RBG_NAME] [flags]
+kubectl rbg llm benchmark list RBG_NAME
 ```
 
 #### benchmark delete
@@ -385,24 +405,51 @@ kubectl rbg llm benchmark list [RBG_NAME] [flags]
 Delete a benchmark job.
 
 ```bash
-kubectl rbg llm benchmark delete JOB_NAME [flags]
+kubectl rbg llm benchmark delete RBG_NAME --job JOB_NAME [flags]
 ```
+
+**Flags:**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--job` | | Name of the benchmark job to delete (required) | |
 
 #### benchmark logs
 
 View benchmark job logs.
 
 ```bash
-kubectl rbg llm benchmark logs JOB_NAME [flags]
+kubectl rbg llm benchmark logs RBG_NAME [flags]
 ```
+
+**Flags:**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--job` | | Name of the benchmark job to view logs for (required) | |
+| `--follow` | `-f` | Follow log output in real time | `true` |
 
 #### benchmark dashboard
 
-Open benchmark dashboard.
+Start a web dashboard to browse benchmark results.
 
 ```bash
 kubectl rbg llm benchmark dashboard [flags]
 ```
+
+**Required Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--experiment-base-dir` | PVC path containing experiment results (e.g. `pvc://benchmark-output/rbg-benchmark`) |
+
+**Optional Flags:**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--port` | | Local port for port-forward | `18888` |
+| `--open-browser` | | Automatically open browser after dashboard is ready | `true` |
+| `--image` | | Container image for the benchmark dashboard | `rolebasedgroup/rbgs-benchmark-dashboard:v0.6.0` |
 
 ### llm config
 
@@ -448,11 +495,11 @@ kubectl rbg llm config add-storage NAME [flags]
 
 ```bash
 # Add PVC storage
-kubectl rbg llm config add-storage my-pvc --type pvc --config claimName=model-pvc
+kubectl rbg llm config add-storage my-pvc --type pvc --config pvcName=model-pvc
 
 # Add OSS storage
 kubectl rbg llm config add-storage my-oss --type oss \
-  --config endpoint=oss-cn-hangzhou.aliyuncs.com --config bucket=my-bucket
+  --config url=oss-cn-hangzhou.aliyuncs.com --config bucket=my-bucket
 
 # Interactive mode
 kubectl rbg llm config add-storage my-pvc -i
@@ -597,7 +644,7 @@ storages:
   - name: my-pvc
     type: pvc
     config:
-      claimName: model-pvc
+      pvcName: model-pvc
 sources:
   - name: huggingface
     type: huggingface
@@ -672,7 +719,7 @@ kubectl rbg llm svc chat my-model --port-forward-timeout 60s
 Ensure the model is pulled to storage:
 
 ```bash
-kubectl rbg llm model pull MODEL_NAME
+kubectl rbg llm model pull MODEL_ID
 ```
 
 ### GPU allocation issues

--- a/cmd/cli/cmd/llm/model/list.go
+++ b/cmd/cli/cmd/llm/model/list.go
@@ -94,7 +94,7 @@ Examples:
 			}
 
 			// Create a job to scan storage and list models
-			job := buildListModelsJob(storagePlugin.MountPath())
+			job := buildListModelsJob(storageplugin.DefaultMountPath)
 
 			// Mount storage (provisions resources for OSS and adds volumes/mounts)
 			ctrlClient, err := util.GetControllerRuntimeClient(cf)
@@ -106,6 +106,7 @@ Examples:
 				Client:      ctrlClient,
 				StorageName: storageName,
 				Namespace:   ns,
+				MountPath:   storageplugin.DefaultMountPath,
 			}); err != nil {
 				return fmt.Errorf("failed to mount storage: %w", err)
 			}

--- a/cmd/cli/cmd/llm/model/pull.go
+++ b/cmd/cli/cmd/llm/model/pull.go
@@ -128,7 +128,7 @@ Examples:
 
 			// Get mount path and construct model path
 			mountPath := storageplugin.DefaultMountPath
-			modelPath := filepath.Join(mountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(revision))
+			modelPath := filepath.ToSlash(filepath.Join(mountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(revision)))
 
 			// Get namespace
 			ns := util.GetNamespace(cf)

--- a/cmd/cli/cmd/llm/model/pull.go
+++ b/cmd/cli/cmd/llm/model/pull.go
@@ -127,7 +127,7 @@ Examples:
 			}
 
 			// Get mount path and construct model path
-			mountPath := storagePlugin.MountPath()
+			mountPath := storageplugin.DefaultMountPath
 			modelPath := filepath.Join(mountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(revision))
 
 			// Get namespace
@@ -151,6 +151,7 @@ Examples:
 				Client:      ctrlClient,
 				StorageName: storageName,
 				Namespace:   ns,
+				MountPath:   mountPath,
 			}); err != nil {
 				return fmt.Errorf("failed to mount storage: %w", err)
 			}

--- a/cmd/cli/cmd/llm/svc/list_test.go
+++ b/cmd/cli/cmd/llm/svc/list_test.go
@@ -168,11 +168,22 @@ func TestExtractRBGStatus_NoConditions(t *testing.T) {
 	assert.Equal(t, "Pending", extractRBGStatus(rbg))
 }
 
-func TestExtractRBGStatus_WithCondition(t *testing.T) {
+func TestExtractRBGStatus_WithFalseCondition(t *testing.T) {
 	rbg := &workloadsv1alpha2.RoleBasedGroup{
 		Status: workloadsv1alpha2.RoleBasedGroupStatus{
 			Conditions: []metav1.Condition{
-				{Type: "Ready"},
+				{Type: "Ready", Status: "False"},
+			},
+		},
+	}
+	assert.Equal(t, "NotReady", extractRBGStatus(rbg))
+}
+
+func TestExtractRBGStatus_WithTrueCondition(t *testing.T) {
+	rbg := &workloadsv1alpha2.RoleBasedGroup{
+		Status: workloadsv1alpha2.RoleBasedGroupStatus{
+			Conditions: []metav1.Condition{
+				{Type: "Ready", Status: "True"},
 			},
 		},
 	}

--- a/cmd/cli/cmd/llm/svc/run.go
+++ b/cmd/cli/cmd/llm/svc/run.go
@@ -144,7 +144,7 @@ func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.
 
 	// If the user explicitly specifies a model path, use it directly.
 	if p.ModelPath != "" {
-		modelPath = p.ModelPath
+		modelPath = filepath.ToSlash(p.ModelPath)
 	}
 
 	if userCfg != nil {
@@ -157,7 +157,7 @@ func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.
 				if sp, err := storageplugin.Get(storageCfg.Type, storageCfg.Config); err == nil {
 					storagePlugin = sp
 					if modelPath == "" {
-						modelPath = filepath.Join(storageplugin.DefaultMountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(p.Revision))
+						modelPath = filepath.ToSlash(filepath.Join(storageplugin.DefaultMountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(p.Revision)))
 					}
 				}
 			}

--- a/cmd/cli/cmd/llm/svc/run.go
+++ b/cmd/cli/cmd/llm/svc/run.go
@@ -73,14 +73,15 @@ func resolveEngine(engineType string, cfg *cliconfig.Config) (*cliconfig.EngineC
 
 // RunParams holds all flag values supplied to the run command.
 type RunParams struct {
-	Mode     string
-	Engine   string
-	Storage  string
-	Revision string
-	EnvVars  []string
-	ArgsList []string
-	DryRun   bool
-	Replicas int32
+	Mode      string
+	Engine    string
+	Storage   string
+	Revision  string
+	ModelPath string
+	EnvVars   []string
+	ArgsList  []string
+	DryRun    bool
+	Replicas  int32
 }
 
 // modeConfigResult holds the result of mode config resolution.
@@ -140,6 +141,11 @@ func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.
 	var storagePlugin storageplugin.Plugin
 	var storageName string
 
+	// If the user explicitly specifies a model path, use it directly.
+	if p.ModelPath != "" {
+		modelPath = p.ModelPath
+	}
+
 	if userCfg != nil {
 		storageName = userCfg.CurrentStorage
 		if p.Storage != "" {
@@ -149,7 +155,9 @@ func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.
 			if storageCfg, err := userCfg.GetStorage(storageName); err == nil {
 				if sp, err := storageplugin.Get(storageCfg.Type, storageCfg.Config); err == nil {
 					storagePlugin = sp
-					modelPath = filepath.Join(sp.MountPath(), shared.SanitizeModelID(modelID), shared.SanitizeModelID(p.Revision))
+					if modelPath == "" {
+						modelPath = filepath.Join(storageplugin.DefaultMountPath, shared.SanitizeModelID(modelID), shared.SanitizeModelID(p.Revision))
+					}
 				}
 			}
 		}
@@ -282,6 +290,7 @@ func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfi
 			StorageName: storageRes.storageName,
 			Namespace:   namespace,
 			DryRun:      p.DryRun,
+			MountPath:   storageplugin.DefaultMountPath,
 		}
 		if !p.DryRun {
 			c, err := util.GetControllerRuntimeClient(cf)
@@ -559,6 +568,7 @@ func newRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 		argsList       []string
 		storage        string
 		revision       string
+		modelPath      string
 		dryRun         bool
 		waitReady      bool
 		waitTimeout    time.Duration
@@ -622,14 +632,15 @@ Examples:
 
 			// Generate RBG (includes config resolution, pattern generation, storage mounting)
 			params := RunParams{
-				Mode:     mode,
-				Engine:   engine,
-				Storage:  storage,
-				Revision: revision,
-				EnvVars:  envVars,
-				ArgsList: argsList,
-				DryRun:   dryRun,
-				Replicas: replicas,
+				Mode:      mode,
+				Engine:    engine,
+				Storage:   storage,
+				Revision:  revision,
+				ModelPath: modelPath,
+				EnvVars:   envVars,
+				ArgsList:  argsList,
+				DryRun:    dryRun,
+				Replicas:  replicas,
 			}
 			rbg, metadata, err := generateRBG(name, modelID, namespace, params, userCfg, cf)
 			if err != nil {
@@ -708,6 +719,7 @@ Examples:
 	cmd.Flags().StringArrayVar(&argsList, "arg", nil, "Additional arguments for the engine")
 	cmd.Flags().StringVar(&storage, "storage", "", "Storage to use (overrides default)")
 	cmd.Flags().StringVar(&revision, "revision", "main", "Model revision")
+	cmd.Flags().StringVar(&modelPath, "model-path", "", "Absolute model path inside the container. Storage is mounted at /models, so the default path is /models/<model>/<revision>")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the generated template without creating the workload")
 	cmd.Flags().BoolVar(&waitReady, "wait", true, "Wait for the RoleBasedGroup to be ready before returning")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 20*time.Minute, "Timeout for waiting for RoleBasedGroup to be ready")

--- a/cmd/cli/cmd/llm/svc/run.go
+++ b/cmd/cli/cmd/llm/svc/run.go
@@ -75,6 +75,7 @@ func resolveEngine(engineType string, cfg *cliconfig.Config) (*cliconfig.EngineC
 type RunParams struct {
 	Mode      string
 	Engine    string
+	Image     string
 	Storage   string
 	Revision  string
 	ModelPath string
@@ -202,11 +203,16 @@ func buildGenerateOptions(name, modelID, modelPath string, modeCfg *runpkg.ModeC
 		resources.Limits = limits
 	}
 
+	image := modeCfg.Image
+	if p.Image != "" {
+		image = p.Image
+	}
+
 	return engineplugin.GenerateOptions{
 		Name:            name,
 		ModelID:         modelID,
 		ModelPath:       modelPath,
-		Image:           modeCfg.Image,
+		Image:           image,
 		Args:            append(modeCfg.Args, p.ArgsList...),
 		Env:             envVars,
 		Resources:       resources,
@@ -564,6 +570,7 @@ func newRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 		replicas       int32
 		mode           string
 		engine         string
+		image          string
 		envVars        []string
 		argsList       []string
 		storage        string
@@ -634,6 +641,7 @@ Examples:
 			params := RunParams{
 				Mode:      mode,
 				Engine:    engine,
+				Image:     image,
 				Storage:   storage,
 				Revision:  revision,
 				ModelPath: modelPath,
@@ -715,6 +723,7 @@ Examples:
 	cmd.Flags().Int32Var(&replicas, "replicas", 1, "Number of replicas")
 	cmd.Flags().StringVar(&mode, "mode", "", "Run mode (default: first mode in model config)")
 	cmd.Flags().StringVar(&engine, "engine", "", "Inference engine override: vllm, sglang (default: from mode config)")
+	cmd.Flags().StringVar(&image, "image", "", "Container image override (default: from mode config)")
 	cmd.Flags().StringArrayVar(&envVars, "env", nil, "Environment variables (KEY=VALUE)")
 	cmd.Flags().StringArrayVar(&argsList, "arg", nil, "Additional arguments for the engine")
 	cmd.Flags().StringVar(&storage, "storage", "", "Storage to use (overrides default)")

--- a/cmd/cli/plugin/storage/interface.go
+++ b/cmd/cli/plugin/storage/interface.go
@@ -25,6 +25,9 @@ import (
 	"sigs.k8s.io/rbgs/cmd/cli/plugin/util"
 )
 
+// DefaultMountPath is the default path where model storage is mounted in containers.
+const DefaultMountPath = "/models"
+
 // MountOptions contains options passed to MountStorage, including both
 // mount configuration and pre-mount resource provisioning parameters.
 type MountOptions struct {
@@ -38,6 +41,10 @@ type MountOptions struct {
 	// DryRun skips Kubernetes resource provisioning (Secret, PV, PVC creation) while
 	// still adding volumes and mounts to the pod template for preview purposes.
 	DryRun bool
+	// MountPath is the path where storage is mounted in the container.
+	// Typically set to DefaultMountPath ("/models"). The caller is responsible for
+	// specifying this value to ensure consistent mount behavior across plugins.
+	MountPath string
 }
 
 // PreAddOptions contains options passed to PreAdd, used for preparing
@@ -79,12 +86,8 @@ type Plugin interface {
 
 	// MountStorage provisions any required Kubernetes resources (e.g., Secret, PV, PVC)
 	// and modifies the PodTemplateSpec to add volumes and mounts.
-	// The volume is mounted at the path returned by MountPath().
+	// The volume is mounted at the path specified by opts.MountPath.
 	MountStorage(podTemplate *corev1.PodTemplateSpec, opts MountOptions) error
-
-	// MountPath returns the base path where storage is mounted in the container.
-	// The full model path is constructed by the caller as: MountPath() + "/" + sanitized(modelID)
-	MountPath() string
 
 	// PreAdd is called before adding a new storage configuration.
 	// It allows plugins to perform preparatory work such as creating Kubernetes Secrets

--- a/cmd/cli/plugin/storage/oss.go
+++ b/cmd/cli/plugin/storage/oss.go
@@ -346,7 +346,7 @@ func (o *OSSStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, opts Moun
 	}
 
 	pvcName := opts.StorageName
-	mountPath := o.MountPath()
+	mountPath := opts.MountPath
 
 	// Add volume
 	volume := corev1.Volume{
@@ -381,11 +381,6 @@ func (o *OSSStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, opts Moun
 	}
 
 	return nil
-}
-
-// MountPath returns the base mount path for the storage
-func (o *OSSStorage) MountPath() string {
-	return "/models"
 }
 
 // PreAdd creates a Kubernetes Secret for OSS credentials and returns a modified config

--- a/cmd/cli/plugin/storage/oss_test.go
+++ b/cmd/cli/plugin/storage/oss_test.go
@@ -165,11 +165,6 @@ func TestOSSStorage_Init_StorageSizeFixed(t *testing.T) {
 	assert.Equal(t, "1Ti", p.storageSize, "storageSize should always be 1Ti")
 }
 
-func TestOSSStorage_MountPath(t *testing.T) {
-	p := &OSSStorage{}
-	assert.Equal(t, "/models", p.MountPath())
-}
-
 func TestOSSStorage_Exists(t *testing.T) {
 	p := &OSSStorage{}
 	exists, err := p.Exists("any-model")
@@ -221,6 +216,7 @@ func TestOSSStorage_MountStorage_AddsVolumeAndMount(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.NoError(t, err)
 
@@ -264,7 +260,7 @@ func TestOSSStorage_MountStorage_MultipleContainers(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, p.MountStorage(tpl, MountOptions{Client: fakeClient, StorageName: "test-oss", Namespace: "default"}))
+	require.NoError(t, p.MountStorage(tpl, MountOptions{Client: fakeClient, StorageName: "test-oss", Namespace: "default", MountPath: DefaultMountPath}))
 	for _, c := range tpl.Spec.Containers {
 		require.Len(t, c.VolumeMounts, 1)
 		assert.Equal(t, "model-storage", c.VolumeMounts[0].Name)
@@ -301,7 +297,7 @@ func TestOSSStorage_MountStorage_InitContainers(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, p.MountStorage(tpl, MountOptions{Client: fakeClient, StorageName: "test-oss", Namespace: "default"}))
+	require.NoError(t, p.MountStorage(tpl, MountOptions{Client: fakeClient, StorageName: "test-oss", Namespace: "default", MountPath: DefaultMountPath}))
 	require.Len(t, tpl.Spec.InitContainers[0].VolumeMounts, 1)
 	assert.Equal(t, "/models", tpl.Spec.InitContainers[0].VolumeMounts[0].MountPath)
 }
@@ -333,6 +329,7 @@ func TestOSSStorage_MountStorage_CreatesResources(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.NoError(t, err)
 
@@ -387,6 +384,7 @@ func TestOSSStorage_MountStorage_VerifiesExistingSecret(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.NoError(t, err)
 }
@@ -407,6 +405,7 @@ func TestOSSStorage_MountStorage_FailsOnMissingSecret(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -478,6 +477,7 @@ func TestOSSStorage_MountStorage_VerifiesExistingPV(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.NoError(t, err)
 }
@@ -558,6 +558,7 @@ func TestOSSStorage_MountStorage_VerifiesExistingPVC(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.NoError(t, err)
 }
@@ -635,6 +636,7 @@ func TestOSSStorage_MountStorage_FailsOnDifferentPVC(t *testing.T) {
 		Client:      fakeClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "different PV")
@@ -711,6 +713,7 @@ func TestOSSStorage_MountStorage_ClientError(t *testing.T) {
 		Client:      mockClient,
 		StorageName: "test-oss",
 		Namespace:   "default",
+		MountPath:   DefaultMountPath,
 	})
 	require.Error(t, err)
 }

--- a/cmd/cli/plugin/storage/pvc.go
+++ b/cmd/cli/plugin/storage/pvc.go
@@ -65,9 +65,9 @@ func (p *PVCStorage) Exists(modelID string) (bool, error) {
 
 // MountStorage mounts the pre-existing PVC to the pod template.
 // PVC must be created separately before running the workload; this plugin does not provision it.
-func (p *PVCStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, _ MountOptions) error {
+func (p *PVCStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, opts MountOptions) error {
 	pvcName := p.pvcName
-	mountPath := p.MountPath()
+	mountPath := opts.MountPath
 
 	// Add volume
 	volume := corev1.Volume{
@@ -102,11 +102,6 @@ func (p *PVCStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, _ MountOp
 	}
 
 	return nil
-}
-
-// MountPath returns the base mount path for the storage.
-func (p *PVCStorage) MountPath() string {
-	return "/models"
 }
 
 // PreAdd is a no-op for PVC storage as it doesn't need to create any resources.

--- a/cmd/cli/plugin/storage/pvc_test.go
+++ b/cmd/cli/plugin/storage/pvc_test.go
@@ -58,11 +58,6 @@ func TestPVCStorage_Init_OK(t *testing.T) {
 	assert.Equal(t, "my-pvc", p.pvcName)
 }
 
-func TestPVCStorage_MountPath(t *testing.T) {
-	p := &PVCStorage{}
-	assert.Equal(t, "/models", p.MountPath())
-}
-
 func TestPVCStorage_Exists(t *testing.T) {
 	p := &PVCStorage{pvcName: "my-pvc"}
 	exists, err := p.Exists("any-model")
@@ -81,7 +76,7 @@ func TestPVCStorage_MountStorage_AddsVolumeAndMount(t *testing.T) {
 		},
 	}
 
-	err := p.MountStorage(tpl, MountOptions{})
+	err := p.MountStorage(tpl, MountOptions{MountPath: DefaultMountPath})
 	require.NoError(t, err)
 
 	require.Len(t, tpl.Spec.Volumes, 1)
@@ -108,7 +103,7 @@ func TestPVCStorage_MountStorage_MultipleContainers(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, p.MountStorage(tpl, MountOptions{}))
+	require.NoError(t, p.MountStorage(tpl, MountOptions{MountPath: DefaultMountPath}))
 	for _, c := range tpl.Spec.Containers {
 		require.Len(t, c.VolumeMounts, 1)
 		assert.Equal(t, "model-storage", c.VolumeMounts[0].Name)
@@ -129,7 +124,7 @@ func TestPVCStorage_MountStorage_InitContainers(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, p.MountStorage(tpl, MountOptions{}))
+	require.NoError(t, p.MountStorage(tpl, MountOptions{MountPath: DefaultMountPath}))
 	require.Len(t, tpl.Spec.InitContainers[0].VolumeMounts, 1)
 	assert.Equal(t, "/models", tpl.Spec.InitContainers[0].VolumeMounts[0].MountPath)
 }


### PR DESCRIPTION
## Summary

Enhance `llm svc run` with two new override flags and move `MountPath` from the storage plugin interface into `MountOptions`, plus a comprehensive README audit.

## Changes

### 1. New `--model-path` flag in `llm svc run`

Users who place models directly into storage (bypassing `llm model pull`) can now specify the exact container path. Without this flag the default `/models/<model>/<revision>` path is used.

### 2. New `--image` flag in `llm svc run`

Allows overriding the container image from the mode config. Useful when the default image registry is inaccessible (e.g. DockerHub in China) and a mirror registry is needed.

### 3. Move `MountPath` from `Plugin.MountPath()` to `MountOptions.MountPath`

- `Plugin.MountPath()` method removed from the interface — mount path is no longer a plugin-level concern.
- `DefaultMountPath = "/models"` constant added to `interface.go`.
- `MountOptions.MountPath` field introduced; all callers pass `storageplugin.DefaultMountPath`.
- Both `OSSStorage` and `PVCStorage` implementations updated to read `opts.MountPath`.
- Tests updated: `MountPath()` test cases removed; `MountStorage` calls updated to include `MountPath: DefaultMountPath`.

### 4. README.md audit and fixes

- **`svc run`**: Added `--image`, `--model-path`, `--wait`, `--wait-timeout`, `--test-api`, `--test-api-timeout`, `--local-port` flags.
- **`svc list`**: Removed global `--namespace` (inherited from root).
- **`svc delete`**: Changed usage to `NAME...` (supports multiple args); removed global-only Flags table.
- **`svc chat`**: Fixed interactive example (`-i` required); fixed `--system` example.
- **`model pull`**: Added `--revision`, `--wait` flags.
- **`model list`**: Corrected `--storage` (was `--source`).
- **`benchmark get/delete/logs`**: Added `--job` flag; `benchmark logs` usage fixed from `JOB_NAME` to `RBG_NAME` with `--job` and `--follow` flags.
- **`config add-storage`**: Added `--config` flag; fixed example keys.
- Troubleshooting: `MODEL_NAME` → `MODEL_ID`.