### PR TITLE
feat(cli): allow custom all fields without pre-build model config

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -33,7 +33,11 @@ kubectl rbg llm model pull Qwen/Qwen3.5-0.8B
 Deploy a model to your Kubernetes cluster:
 
 ```bash
+# Deploy a model with a pre-built model config
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B
+
+# Or deploy a custom model without a pre-built model config
+kubectl rbg llm svc run my-model org/new-model --engine vllm --resource nvidia.com/gpu=1
 ```
 
 ### 4. Chat with the Model
@@ -86,8 +90,11 @@ kubectl rbg llm svc run NAME MODEL_ID [flags]
 |------|-------|-------------|---------|
 | `--replicas` | | Number of replicas | 1 |
 | `--mode` | | Run mode (from model config) | (first mode in model config) |
-| `--engine` | | Inference engine override (`vllm`, `sglang`) | (from mode config) |
+| `--engine` | | Inference engine override (`vllm`, `sglang`). Required when no model config exists for MODEL_ID. | (from mode config) |
 | `--image` | | Container image override | (from mode config) |
+| `--resource` | | Resource requirements (`key=value`, e.g. `nvidia.com/gpu=1`), can be specified multiple times. Flag values override config on conflict. | |
+| `--distributed-size` | | Multi-node deployment size (<=1 means standalone) | 0 |
+| `--shm-size` | | Shared memory size (e.g. `8Gi`, `16Gi`) | |
 | `--env` | | Environment variables (`KEY=VALUE`), can be specified multiple times | |
 | `--arg` | | Additional arguments for the engine, can be specified multiple times | |
 | `--storage` | | Storage to use (overrides default) | (current storage) |
@@ -117,6 +124,12 @@ kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --image registry.cn-hangzhou.a
 
 # Run with multiple replicas
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --replicas 3
+
+# Deploy a custom model without a pre-built model config
+kubectl rbg llm svc run my-model org/new-model --engine vllm --resource nvidia.com/gpu=1
+
+# Deploy with custom resources, distributed size, and shared memory
+kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --resource nvidia.com/gpu=2 --resource memory=16Gi --distributed-size 4 --shm-size 16Gi
 
 # Dry run to preview the generated configuration
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --dry-run
@@ -699,6 +712,9 @@ kubectl rbg llm svc delete my-qwen
 kubectl rbg llm svc run qwen-small Qwen/Qwen3.5-0.8B --replicas 1
 kubectl rbg llm svc run qwen-large Qwen/Qwen3-32B --mode throughput --replicas 2
 kubectl rbg llm svc run llama-model meta-llama/Llama-3-8B --engine sglang
+
+# Deploy a custom model with no pre-built model config
+kubectl rbg llm svc run my-custom org/my-model --engine vllm --resource nvidia.com/gpu=4 --shm-size 32Gi
 
 # List all services
 kubectl rbg llm svc list

--- a/cmd/cli/cmd/llm/svc/run.go
+++ b/cmd/cli/cmd/llm/svc/run.go
@@ -137,9 +137,6 @@ func resolveModeConfig(modelID string, p RunParams, userCfg *cliconfig.Config) (
 	}
 
 	engineType := modeCfg.Engine
-	if p.Engine != "" {
-		engineType = p.Engine
-	}
 	engineCfg, err := resolveEngine(engineType, userCfg)
 	if err != nil {
 		return nil, err
@@ -224,6 +221,9 @@ func parseResources(resourceFlags []string) (corev1.ResourceList, error) {
 // For Resources: flag values are merged by key (flag wins on conflict).
 // For Env: flag values are appended. For Args: flag values are appended.
 func applyFlagOverrides(modeCfg *runpkg.ModeConfig, p RunParams) error {
+	if p.Engine != "" {
+		modeCfg.Engine = p.Engine
+	}
 	if p.Image != "" {
 		modeCfg.Image = p.Image
 	}
@@ -253,7 +253,17 @@ func applyFlagOverrides(modeCfg *runpkg.ModeConfig, p RunParams) error {
 		if len(parts) != 2 {
 			return fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
 		}
-		modeCfg.Env = append(modeCfg.Env, corev1.EnvVar{Name: parts[0], Value: parts[1]})
+		found := false
+		for i, existing := range modeCfg.Env {
+			if existing.Name == parts[0] {
+				modeCfg.Env[i].Value = parts[1]
+				found = true
+				break
+			}
+		}
+		if !found {
+			modeCfg.Env = append(modeCfg.Env, corev1.EnvVar{Name: parts[0], Value: parts[1]})
+		}
 	}
 	modeCfg.Args = append(modeCfg.Args, p.ArgsList...)
 	return nil

--- a/cmd/cli/cmd/llm/svc/run.go
+++ b/cmd/cli/cmd/llm/svc/run.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -73,16 +74,19 @@ func resolveEngine(engineType string, cfg *cliconfig.Config) (*cliconfig.EngineC
 
 // RunParams holds all flag values supplied to the run command.
 type RunParams struct {
-	Mode      string
-	Engine    string
-	Image     string
-	Storage   string
-	Revision  string
-	ModelPath string
-	EnvVars   []string
-	ArgsList  []string
-	DryRun    bool
-	Replicas  int32
+	Mode            string
+	Engine          string
+	Image           string
+	Storage         string
+	Revision        string
+	ModelPath       string
+	EnvVars         []string
+	ArgsList        []string
+	DryRun          bool
+	Replicas        int32
+	Resources       []string // key=value pairs, e.g. "nvidia.com/gpu=1"
+	DistributedSize int32
+	ShmSize         string
 }
 
 // modeConfigResult holds the result of mode config resolution.
@@ -94,17 +98,41 @@ type modeConfigResult struct {
 }
 
 // resolveModeConfig resolves model, mode, and engine configuration.
+// If no model config is found but --engine is specified, a minimal config is constructed from flags.
 func resolveModeConfig(modelID string, p RunParams, userCfg *cliconfig.Config) (*modeConfigResult, error) {
+	var modelCfg *runpkg.ModelConfig
+	var modeCfg *runpkg.ModeConfig
+
 	models, err := runpkg.LoadAllModels()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load model configs: %w", err)
+		klog.V(1).Infof("Warning: failed to load model configs: %v", err)
 	}
-	modelCfg, err := runpkg.FindModelConfig(models, modelID)
-	if err != nil {
-		return nil, err
+	if models != nil {
+		modelCfg, err = runpkg.FindModelConfig(models, modelID)
 	}
-	modeCfg, err := runpkg.FindModeConfig(modelCfg, p.Mode)
-	if err != nil {
+
+	if modelCfg != nil && err == nil {
+		// Model config found — use it
+		modeCfg, err = runpkg.FindModeConfig(modelCfg, p.Mode)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// No model config found — fall back to flags
+		if p.Engine == "" {
+			return nil, fmt.Errorf("no model config found for %q and --engine not specified; "+
+				"either add a model config or specify --engine to deploy without a pre-built model config", modelID)
+		}
+		fmt.Fprintf(os.Stderr, "Warning: no model config found for %q, proceeding with flag-only configuration\n", modelID)
+		modelCfg = &runpkg.ModelConfig{ID: modelID, Name: modelID}
+		modeCfg = &runpkg.ModeConfig{
+			Name:   "custom",
+			Engine: p.Engine,
+		}
+	}
+
+	// Apply flag overrides (works for both config-based and flag-only paths)
+	if err := applyFlagOverrides(modeCfg, p); err != nil {
 		return nil, err
 	}
 
@@ -174,21 +202,69 @@ func resolveStorageAndModelPath(modelID string, p RunParams, userCfg *cliconfig.
 	}
 }
 
-// buildGenerateOptions builds GenerateOptions from mode config and run params.
-func buildGenerateOptions(name, modelID, modelPath string, modeCfg *runpkg.ModeConfig, p RunParams) (engineplugin.GenerateOptions, error) {
-	distributedSize := int32(0)
-	if modeCfg.Distributed != nil && modeCfg.Distributed.Size > 1 {
-		distributedSize = modeCfg.Distributed.Size
+// parseResources parses a slice of "key=value" strings into a corev1.ResourceList.
+func parseResources(resourceFlags []string) (corev1.ResourceList, error) {
+	result := corev1.ResourceList{}
+	for _, r := range resourceFlags {
+		parts := strings.SplitN(r, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid resource format: %q, expected key=value (e.g. nvidia.com/gpu=1)", r)
+		}
+		qty, err := resource.ParseQuantity(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid resource quantity %q for %q: %w", parts[1], parts[0], err)
+		}
+		result[corev1.ResourceName(parts[0])] = qty
 	}
+	return result, nil
+}
 
-	envVars := make([]corev1.EnvVar, len(modeCfg.Env))
-	copy(envVars, modeCfg.Env)
+// applyFlagOverrides applies flag values onto a ModeConfig.
+// For Image, DistributedSize, ShmSize: flag value overrides config when non-zero.
+// For Resources: flag values are merged by key (flag wins on conflict).
+// For Env: flag values are appended. For Args: flag values are appended.
+func applyFlagOverrides(modeCfg *runpkg.ModeConfig, p RunParams) error {
+	if p.Image != "" {
+		modeCfg.Image = p.Image
+	}
+	if p.DistributedSize > 0 {
+		if modeCfg.Distributed == nil {
+			modeCfg.Distributed = &runpkg.DistributedConfig{}
+		}
+		modeCfg.Distributed.Size = p.DistributedSize
+	}
+	if p.ShmSize != "" {
+		modeCfg.ShmSize = p.ShmSize
+	}
+	if len(p.Resources) > 0 {
+		flagRes, err := parseResources(p.Resources)
+		if err != nil {
+			return err
+		}
+		if modeCfg.Resources == nil {
+			modeCfg.Resources = corev1.ResourceList{}
+		}
+		for k, v := range flagRes {
+			modeCfg.Resources[k] = v
+		}
+	}
 	for _, ev := range p.EnvVars {
 		parts := strings.SplitN(ev, "=", 2)
 		if len(parts) != 2 {
-			return engineplugin.GenerateOptions{}, fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
+			return fmt.Errorf("invalid environment variable format: %q, expected KEY=VALUE", ev)
 		}
-		envVars = append(envVars, corev1.EnvVar{Name: parts[0], Value: parts[1]})
+		modeCfg.Env = append(modeCfg.Env, corev1.EnvVar{Name: parts[0], Value: parts[1]})
+	}
+	modeCfg.Args = append(modeCfg.Args, p.ArgsList...)
+	return nil
+}
+
+// buildGenerateOptions builds GenerateOptions from mode config.
+// All flag overrides should already be applied to modeCfg via applyFlagOverrides.
+func buildGenerateOptions(name, modelID, modelPath string, modeCfg *runpkg.ModeConfig) engineplugin.GenerateOptions {
+	distributedSize := int32(0)
+	if modeCfg.Distributed != nil && modeCfg.Distributed.Size > 1 {
+		distributedSize = modeCfg.Distributed.Size
 	}
 
 	var resources corev1.ResourceRequirements
@@ -203,22 +279,17 @@ func buildGenerateOptions(name, modelID, modelPath string, modeCfg *runpkg.ModeC
 		resources.Limits = limits
 	}
 
-	image := modeCfg.Image
-	if p.Image != "" {
-		image = p.Image
-	}
-
 	return engineplugin.GenerateOptions{
 		Name:            name,
 		ModelID:         modelID,
 		ModelPath:       modelPath,
-		Image:           image,
-		Args:            append(modeCfg.Args, p.ArgsList...),
-		Env:             envVars,
+		Image:           modeCfg.Image,
+		Args:            modeCfg.Args,
+		Env:             modeCfg.Env,
 		Resources:       resources,
 		DistributedSize: distributedSize,
 		ShmSize:         modeCfg.ShmSize,
-	}, nil
+	}
 }
 
 // assembleRBG assembles a RoleBasedGroup from pattern and metadata.
@@ -275,10 +346,7 @@ func generateRBG(name, modelID, namespace string, p RunParams, userCfg *cliconfi
 	storageRes := resolveStorageAndModelPath(modelID, p, userCfg)
 
 	// 3. Build GenerateOptions
-	opts, err := buildGenerateOptions(name, modelID, storageRes.modelPath, modeRes.modeCfg, p)
-	if err != nil {
-		return nil, llmmeta.RunMetadata{}, err
-	}
+	opts := buildGenerateOptions(name, modelID, storageRes.modelPath, modeRes.modeCfg)
 
 	// 4. Generate pattern
 	pattern, err := modeRes.enginePlugin.GeneratePattern(opts)
@@ -567,21 +635,24 @@ func testChatCompletionsWithReconnect(
 
 func newRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 	var (
-		replicas       int32
-		mode           string
-		engine         string
-		image          string
-		envVars        []string
-		argsList       []string
-		storage        string
-		revision       string
-		modelPath      string
-		dryRun         bool
-		waitReady      bool
-		waitTimeout    time.Duration
-		testAPI        bool
-		testAPITimeout time.Duration
-		localPort      int32
+		replicas        int32
+		mode            string
+		engine          string
+		image           string
+		envVars         []string
+		argsList        []string
+		storage         string
+		revision        string
+		modelPath       string
+		dryRun          bool
+		waitReady       bool
+		waitTimeout     time.Duration
+		testAPI         bool
+		testAPITimeout  time.Duration
+		localPort       int32
+		resources       []string
+		distributedSize int32
+		shmSize         string
 	)
 
 	cmd := &cobra.Command{
@@ -594,9 +665,12 @@ It supports various inference engines (vLLM, SGLang) and deployment modes optimi
 for different use cases (latency, throughput, etc.).
 
 The command will:
-  1. Load the model configuration from the built-in models database
+  1. Load the model configuration from the built-in models database (if available)
   2. Generate a pod template using the specified inference engine
   3. Create a RoleBasedGroup resource in the cluster
+
+If no model configuration is found, you can still deploy by specifying --engine
+(and optionally --image, --resource, etc.) to provide configuration via flags.
 
 Prerequisites:
   - The model should be available in storage (use 'kubectl rbg llm model pull' first)
@@ -614,6 +688,9 @@ Examples:
 
   # Run with multiple replicas
   kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --replicas 3
+
+  # Deploy a custom model without any model config
+  kubectl rbg llm svc run my-model org/new-model --engine vllm --resource nvidia.com/gpu=1
 
   # Dry run to preview the generated configuration
   kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --dry-run`,
@@ -639,16 +716,19 @@ Examples:
 
 			// Generate RBG (includes config resolution, pattern generation, storage mounting)
 			params := RunParams{
-				Mode:      mode,
-				Engine:    engine,
-				Image:     image,
-				Storage:   storage,
-				Revision:  revision,
-				ModelPath: modelPath,
-				EnvVars:   envVars,
-				ArgsList:  argsList,
-				DryRun:    dryRun,
-				Replicas:  replicas,
+				Mode:            mode,
+				Engine:          engine,
+				Image:           image,
+				Storage:         storage,
+				Revision:        revision,
+				ModelPath:       modelPath,
+				EnvVars:         envVars,
+				ArgsList:        argsList,
+				DryRun:          dryRun,
+				Replicas:        replicas,
+				Resources:       resources,
+				DistributedSize: distributedSize,
+				ShmSize:         shmSize,
 			}
 			rbg, metadata, err := generateRBG(name, modelID, namespace, params, userCfg, cf)
 			if err != nil {
@@ -726,6 +806,9 @@ Examples:
 	cmd.Flags().StringVar(&image, "image", "", "Container image override (default: from mode config)")
 	cmd.Flags().StringArrayVar(&envVars, "env", nil, "Environment variables (KEY=VALUE)")
 	cmd.Flags().StringArrayVar(&argsList, "arg", nil, "Additional arguments for the engine")
+	cmd.Flags().StringArrayVar(&resources, "resource", nil, "Resource requirements (key=value, e.g. nvidia.com/gpu=1)")
+	cmd.Flags().Int32Var(&distributedSize, "distributed-size", 0, "Multi-node deployment size (<=1 means standalone)")
+	cmd.Flags().StringVar(&shmSize, "shm-size", "", "Shared memory size (e.g. 8Gi, 16Gi)")
 	cmd.Flags().StringVar(&storage, "storage", "", "Storage to use (overrides default)")
 	cmd.Flags().StringVar(&revision, "revision", "main", "Model revision")
 	cmd.Flags().StringVar(&modelPath, "model-path", "", "Absolute model path inside the container. Storage is mounted at /models, so the default path is /models/<model>/<revision>")

--- a/cmd/cli/cmd/llm/svc/run_test.go
+++ b/cmd/cli/cmd/llm/svc/run_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	llmmeta "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/svc/metadata"
@@ -259,7 +260,7 @@ func TestGenerateRBG_UnknownModel(t *testing.T) {
 		DryRun:   true,
 	}, nil, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no configuration found for model")
+	assert.Contains(t, err.Error(), "no model config found for")
 }
 
 func TestGenerateRBG_UnknownEngine_Errors(t *testing.T) {
@@ -307,4 +308,165 @@ func TestGenerateRBG_FallbackModelPath(t *testing.T) {
 		}
 	}
 	assert.True(t, strings.HasPrefix(modelPathArg, "/model/"), "expected fallback model path, got: %s", modelPathArg)
+}
+
+// --- parseResources ---
+
+func TestParseResources_Valid(t *testing.T) {
+	res, err := parseResources([]string{"nvidia.com/gpu=1", "memory=16Gi", "cpu=4"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(res))
+	assert.True(t, res["nvidia.com/gpu"].Equal(resource.MustParse("1")))
+	assert.True(t, res["memory"].Equal(resource.MustParse("16Gi")))
+	assert.True(t, res["cpu"].Equal(resource.MustParse("4")))
+}
+
+func TestParseResources_InvalidFormat(t *testing.T) {
+	_, err := parseResources([]string{"nvidia.com/gpu"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid resource format")
+}
+
+func TestParseResources_InvalidQuantity(t *testing.T) {
+	_, err := parseResources([]string{"memory=notaquantity"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid resource quantity")
+}
+
+func TestParseResources_Empty(t *testing.T) {
+	res, err := parseResources(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(res))
+}
+
+// --- flag-only deployment (no model config) ---
+
+func TestGenerateRBG_FlagOnly_WithEngine(t *testing.T) {
+	// Unknown model + --engine specified should succeed
+	rbg, metadata, err := generateRBG("my-custom", "custom/new-model", "default", RunParams{
+		Engine:   "vllm",
+		Revision: "main",
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "my-custom", rbg.Name)
+	assert.Equal(t, "vllm", metadata.Engine)
+	assert.Equal(t, "custom", metadata.Mode)
+	assert.Equal(t, "custom/new-model", metadata.ModelID)
+}
+
+func TestGenerateRBG_FlagOnly_WithImageOverride(t *testing.T) {
+	rbg, _, err := generateRBG("my-custom", "custom/new-model", "default", RunParams{
+		Engine:   "vllm",
+		Image:    "my-registry/vllm:custom",
+		Revision: "main",
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	assert.Equal(t, "my-registry/vllm:custom", podTemplate.Spec.Containers[0].Image)
+}
+
+func TestGenerateRBG_FlagOnly_WithResources(t *testing.T) {
+	rbg, _, err := generateRBG("my-custom", "custom/new-model", "default", RunParams{
+		Engine:    "vllm",
+		Resources: []string{"nvidia.com/gpu=2", "memory=16Gi"},
+		Revision:  "main",
+		Replicas:  1,
+		DryRun:    true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	container := podTemplate.Spec.Containers[0]
+	assert.True(t, container.Resources.Limits["nvidia.com/gpu"].Equal(resource.MustParse("2")))
+	assert.True(t, container.Resources.Limits["memory"].Equal(resource.MustParse("16Gi")))
+	assert.True(t, container.Resources.Requests["nvidia.com/gpu"].Equal(resource.MustParse("2")))
+}
+
+func TestGenerateRBG_FlagOnly_NoEngine_Errors(t *testing.T) {
+	// Unknown model without --engine should fail
+	_, _, err := generateRBG("my-custom", "custom/new-model", "default", RunParams{
+		Revision: "main",
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--engine not specified")
+}
+
+// --- flag override on existing model config ---
+
+func TestGenerateRBG_ImageOverride_ExistingModel(t *testing.T) {
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+		Image:    "custom-image:v2",
+		Revision: "main",
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	assert.Equal(t, "custom-image:v2", podTemplate.Spec.Containers[0].Image)
+}
+
+func TestGenerateRBG_ResourceOverride_ExistingModel(t *testing.T) {
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+		Resources: []string{"nvidia.com/gpu=4"},
+		Revision:  "main",
+		Replicas:  1,
+		DryRun:    true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	container := podTemplate.Spec.Containers[0]
+	assert.True(t, container.Resources.Limits["nvidia.com/gpu"].Equal(resource.MustParse("4")))
+}
+
+func TestGenerateRBG_ShmSizeOverride(t *testing.T) {
+	rbg, _, err := generateRBG("my-svc", "Qwen/Qwen3.5-0.8B", "default", RunParams{
+		ShmSize:  "32Gi",
+		Revision: "main",
+		Replicas: 1,
+		DryRun:   true,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	podTemplate := getPodTemplateFromPattern(&rbg.Spec.Roles[0].Pattern)
+	// ShmSize should result in an emptyDir volume with sizeLimit
+	foundShm := false
+	for _, v := range podTemplate.Spec.Volumes {
+		if v.Name == "shm" && v.EmptyDir != nil {
+			foundShm = true
+			expected := resource.MustParse("32Gi")
+			assert.True(t, v.EmptyDir.SizeLimit.Equal(expected), "expected sizeLimit=32Gi")
+		}
+	}
+	assert.True(t, foundShm, "expected shm volume with sizeLimit=32Gi")
+}
+
+// --- newRunCmd: new flags exist ---
+
+func TestNewRunCmd_NewFlagDefaults(t *testing.T) {
+	cf := genericclioptions.NewConfigFlags(true)
+	cmd := newRunCmd(cf)
+
+	imageFlag := cmd.Flags().Lookup("image")
+	require.NotNil(t, imageFlag)
+	assert.Equal(t, "", imageFlag.DefValue)
+
+	resourceFlag := cmd.Flags().Lookup("resource")
+	require.NotNil(t, resourceFlag)
+
+	distFlag := cmd.Flags().Lookup("distributed-size")
+	require.NotNil(t, distFlag)
+	assert.Equal(t, "0", distFlag.DefValue)
+
+	shmFlag := cmd.Flags().Lookup("shm-size")
+	require.NotNil(t, shmFlag)
+	assert.Equal(t, "", shmFlag.DefValue)
 }


### PR DESCRIPTION
### Ⅰ. Motivation

Previously, `kubectl rbg llm svc run` required a pre-built model config for every model ID. Users deploying custom/private models without a built-in config entry would get an error and could not proceed, even if they knew all the deployment parameters. This PR enables deploying any model via CLI flags alone, without depending on a pre-built model config.

### Ⅱ. Modifications

**`cmd/cli/cmd/llm/svc/run.go`** (+145/-65)

- **Flag-only deployment**: When no model config is found but `--engine` is specified, a minimal config is constructed from flags (`custom` mode) instead of returning an error.
- **New CLI flags**:
  - `--resource` (stringArray, `key=value` e.g. `nvidia.com/gpu=1`) — specify resource requirements directly
  - `--distributed-size` (int32) — multi-node deployment size
  - `--shm-size` (string, e.g. `8Gi`) — shared memory size
- **Unified flag override layer** (`applyFlagOverrides`): All flag values (image, resources, distributed-size, shm-size, env, args) are applied onto `ModeConfig` via a single function, replacing scattered ad-hoc overrides in `buildGenerateOptions`. Flag values always win over config on conflict.

**`cmd/cli/cmd/llm/svc/run_test.go`** (+164/-1)
