### PR TITLE
chore: skip e2e tests for non-code file changes

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if only docs/examples/python/test changed
+      - name: Check if changes require e2e tests
         id: filter
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
@@ -36,30 +36,48 @@ jobs:
           else
             BASE_REF="HEAD^1"
           fi
-          
+
           # Get changed files
           CHANGED_FILES=$(git diff --name-only $BASE_REF HEAD)
           echo "Changed files:"
           echo "$CHANGED_FILES"
-          
-          # Check if all changes are in skip directories
-          SKIP_DIRS="^(examples|doc|python|cmd/cli)/"
-          SHOULD_RUN="true"
-          
+
+          # Define patterns for files that DO require e2e tests (code and config files)
+          # - Go source code (*.go)
+          # - Build files (Makefile, Dockerfile, go.mod, go.sum)
+          # - CRD definitions (config/crd/**/*.yaml)
+          # - RBAC config (config/rbac/**/*.yaml)
+          # - Helm charts (deploy/helm/**/*.yaml)
+          # - CI workflows (.github/workflows/*.yml)
+          # - Test files (test/**/*)
+          CODE_PATTERNS='\.go$|^Makefile|^Dockerfile|go\.mod|go\.sum|\.sh$|^config/crd/|^config/rbac/|^deploy/helm/|^\.github/workflows/|^test/'
+          SKIP_DIRS='^(examples|doc|python|cmd/cli)/'
+
+          SHOULD_RUN="false"
+
           if [ -n "$CHANGED_FILES" ]; then
             # Filter out files in skip directories
             NON_SKIP_FILES=$(echo "$CHANGED_FILES" | grep -vE "$SKIP_DIRS" || true)
-            
+
             if [ -z "$NON_SKIP_FILES" ]; then
-              echo "All changes are in examples, doc, python, or cmd/cli directories. Skipping e2e tests."
-              SHOULD_RUN="false"
+              echo "All changed files are in skip directories ($SKIP_DIRS). Skipping e2e tests."
             else
-              echo "Found changes outside skip directories. Running e2e tests."
-              echo "Files requiring e2e tests:"
-              echo "$NON_SKIP_FILES"
+              # Check if any non-skipped file matches code patterns
+              CODE_FILES=$(echo "$NON_SKIP_FILES" | grep -E "$CODE_PATTERNS" || true)
+
+              if [ -n "$CODE_FILES" ]; then
+                echo "Found code/config files that require e2e tests:"
+                echo "$CODE_FILES"
+                SHOULD_RUN="true"
+              else
+                echo "All changed files are non-code files (docs, examples, yaml configs, etc). Skipping e2e tests."
+              fi
             fi
+          else
+            # No changed files detected, run tests by default
+            SHOULD_RUN="true"
           fi
-          
+
           echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
 
   e2e-test:


### PR DESCRIPTION
## Summary

Improve the e2e test skip logic in GitHub Actions to check file patterns instead of just directories. This saves CI resources when changes only affect non-code files.

## Changes

Previously, e2e tests were only skipped when changes were in specific directories (examples, doc, python). Now the logic checks file patterns to determine if code/config files are changed.

**E2e tests are skipped when changes only affect:**
- Documentation files (.md, .rst, etc.)
- Example configurations (examples/*.yaml)
- KEPs and design docs (keps/*.md)
- Other non-program files

**E2e tests will run when changes include:**
- Go source code (*.go)
- Build files (Makefile, Dockerfile, go.mod, go.sum)
- CRD definitions (config/crd/**/*.yaml)
- RBAC config (config/rbac/**/*.yaml)
- Helm charts (deploy/helm/**/*.yaml)
- CI workflows (.github/workflows/*.yml)
- Shell scripts (*.sh)
- Test files (test/**/*)

## Test plan

This PR itself should trigger the e2e test workflow since it modifies `.github/workflows/*.yml`.

🤖 Generated with [Claude Code](https://code.alibaba-inc.com/claude-code/ali-claude-code)