### PR TITLE
chore: update CLI config API version to v1alpha2

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -649,7 +649,7 @@ kubectl rbg llm config reset-engine ENGINE_TYPE
 The configuration is stored at `~/.rbg/config.yaml`:
 
 ```yaml
-apiVersion: rbg/v1alpha1
+apiVersion: rbg/v1alpha2
 kind: Config
 currentStorage: my-pvc
 currentSource: huggingface

--- a/cmd/cli/cmd/llm/config/misc.go
+++ b/cmd/cli/cmd/llm/config/misc.go
@@ -278,7 +278,7 @@ Example:
 
 			// Create and save configuration
 			cfg := &config.Config{
-				APIVersion:     "rbg/v1alpha1",
+				APIVersion:     "rbg/v1alpha2",
 				Kind:           "Config",
 				CurrentStorage: storageType,
 				CurrentSource:  sourceType,


### PR DESCRIPTION
Update the default API version for CLI configuration from v1alpha1 to v1alpha2 to align with the current CRD version.

- cmd/cli/cmd/llm/config/misc.go: change default APIVersion to v1alpha2
- cmd/cli/README.md: update example config yaml to use v1alpha2

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
