### PR TITLE
feat(cli): get storage/source/engine details

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -520,10 +520,14 @@ kubectl rbg llm config add-storage my-pvc -i
 
 ##### config get-storages
 
-List all storage configurations.
+List all storage configurations or show details of one.
 
 ```bash
+# List all storage configurations
 kubectl rbg llm config get-storages
+
+# Show details of a specific storage
+kubectl rbg llm config get-storages my-pvc
 ```
 
 ##### config use-storage
@@ -580,10 +584,14 @@ kubectl rbg llm config add-source huggingface -i
 
 ##### config get-sources
 
-List all source configurations.
+List all source configurations or show details of one.
 
 ```bash
+# List all source configurations
 kubectl rbg llm config get-sources
+
+# Show details of a specific source
+kubectl rbg llm config get-sources huggingface
 ```
 
 ##### config use-source
@@ -614,10 +622,14 @@ kubectl rbg llm config delete-source NAME
 
 ##### config get-engines
 
-List customized engine configurations.
+List customized engine configurations or show details of one.
 
 ```bash
+# List all customized engines
 kubectl rbg llm config get-engines
+
+# Show details of a specific engine
+kubectl rbg llm config get-engines sglang
 ```
 
 ##### config set-engine
@@ -646,7 +658,7 @@ kubectl rbg llm config reset-engine ENGINE_TYPE
 
 ## Configuration File
 
-The configuration is stored at `~/.rbg/config.yaml`:
+The configuration is stored at `~/.rbg/config`:
 
 ```yaml
 apiVersion: rbg/v1alpha1

--- a/cmd/cli/cmd/llm/config/config_test.go
+++ b/cmd/cli/cmd/llm/config/config_test.go
@@ -73,8 +73,8 @@ func TestNewConfigCmd_SubcommandProperties(t *testing.T) {
 	}{
 		{"add-storage", "add-storage NAME", "Add a storage configuration"},
 		{"add-source", "add-source NAME", "Add a source configuration"},
-		{"get-storages", "get-storages", "List all storage configurations"},
-		{"get-sources", "get-sources", "List all source configurations"},
+		{"get-storages", "get-storages", "List all storage configurations or show details of one"},
+		{"get-sources", "get-sources", "List all source configurations or show details of one"},
 		{"use-storage", "use-storage NAME", "Set the current storage"},
 		{"use-source", "use-source NAME", "Set the current source"},
 		{"set-storage", "set-storage NAME", "Update a storage configuration"},

--- a/cmd/cli/cmd/llm/config/engine.go
+++ b/cmd/cli/cmd/llm/config/engine.go
@@ -88,21 +88,46 @@ Example:
 
 func newGetEnginesCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get-engines",
-		Short: "List customized engine configurations",
-		Long: `List all engines with custom configurations.
+		Use:   "get-engines [ENGINE_TYPE]",
+		Short: "List customized engine configurations or show details of one",
+		Long: `List all engines with custom configurations, or show detailed information for a specific one.
 
-This shows only engines that have been explicitly configured via 'set-engine'.
-Engines not listed here use their default settings.
+Without ENGINE_TYPE: displays a table showing all customized engines.
+With ENGINE_TYPE: displays the detailed configuration for the named engine.
+If the engine has no custom configuration, it indicates that defaults are being used.
 
-Example:
-  kubectl rbg llm config get-engines`,
+Examples:
+  # List all customized engines
+  kubectl rbg llm config get-engines
+
+  # Show details of a specific engine
+  kubectl rbg llm config get-engines sglang`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
 
+			// Show details of a single engine
+			if len(args) == 1 {
+				engineType := args[0]
+				if !engineplugin.IsRegistered(engineType) {
+					return fmt.Errorf("unknown engine type '%s'", engineType)
+				}
+				fmt.Printf("Engine: %s\n", engineType)
+				e, err := cfg.GetEngine(engineType)
+				if err == nil && e != nil {
+					fmt.Println("  Configuration (customized):")
+					printConfigItems(e.Config, engineplugin.GetFields(engineType))
+				} else {
+					fmt.Println("  Configuration: (using defaults)")
+					fmt.Println("  No custom configuration found. Run 'kubectl rbg llm config set-engine' to customize.")
+				}
+				return nil
+			}
+
+			// List all customized engines
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "TYPE")
 			for _, e := range cfg.Engines {

--- a/cmd/cli/cmd/llm/config/engine.go
+++ b/cmd/cli/cmd/llm/config/engine.go
@@ -57,7 +57,7 @@ Example:
 			}
 
 			if !engineplugin.IsRegistered(engineType) {
-				return fmt.Errorf("unknown engine type '%s'", engineType)
+				return fmt.Errorf("unknown engine type '%s'. Supported types: %v", engineType, engineplugin.RegisteredNames())
 			}
 
 			configMap := make(map[string]interface{})
@@ -113,7 +113,7 @@ Examples:
 			if len(args) == 1 {
 				engineType := args[0]
 				if !engineplugin.IsRegistered(engineType) {
-					return fmt.Errorf("unknown engine type '%s'", engineType)
+					return fmt.Errorf("unknown engine type '%s'. Supported types: %v", engineType, engineplugin.RegisteredNames())
 				}
 				fmt.Printf("Engine: %s\n", engineType)
 				e, err := cfg.GetEngine(engineType)

--- a/cmd/cli/cmd/llm/config/engine.go
+++ b/cmd/cli/cmd/llm/config/engine.go
@@ -128,6 +128,10 @@ Examples:
 			}
 
 			// List all customized engines
+			if len(cfg.Engines) == 0 {
+				fmt.Println("No engine configuration found in rbg config")
+				return nil
+			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "TYPE")
 			for _, e := range cfg.Engines {

--- a/cmd/cli/cmd/llm/config/engine_test.go
+++ b/cmd/cli/cmd/llm/config/engine_test.go
@@ -41,7 +41,7 @@ func TestNewGetEnginesCmd(t *testing.T) {
 	cmd := newGetEnginesCmd()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "get-engines", cmd.Use)
+	assert.Equal(t, "get-engines [ENGINE_TYPE]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 }
 

--- a/cmd/cli/cmd/llm/config/source.go
+++ b/cmd/cli/cmd/llm/config/source.go
@@ -143,6 +143,10 @@ Examples:
 			}
 
 			// List all sources
+			if len(cfg.Sources) == 0 {
+				fmt.Println("No source found in rbg config")
+				return nil
+			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "NAME\tTYPE\tCURRENT")
 			for _, s := range cfg.Sources {

--- a/cmd/cli/cmd/llm/config/source.go
+++ b/cmd/cli/cmd/llm/config/source.go
@@ -105,23 +105,44 @@ Examples:
 
 func newGetSourcesCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get-sources",
-		Short: "List all source configurations",
-		Long: `List all configured model sources.
+		Use:   "get-sources [NAME]",
+		Short: "List all source configurations or show details of one",
+		Long: `List all configured model sources, or show detailed information for a specific one.
 
-Displays a table showing:
-  - NAME: The name of the source configuration
-  - TYPE: The source type (e.g., huggingface, modelscope)
-  - CURRENT: Indicates the currently active source with "*"
+Without NAME: displays a table showing all sources.
+With NAME: displays the detailed configuration for the named source.
 
-Example:
-  kubectl rbg llm config get-sources`,
+Examples:
+  # List all sources
+  kubectl rbg llm config get-sources
+
+  # Show details of a specific source
+  kubectl rbg llm config get-sources huggingface`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
 
+			// Show details of a single source
+			if len(args) == 1 {
+				name := args[0]
+				s, err := cfg.GetSource(name)
+				if err != nil {
+					return err
+				}
+				if s.Name == cfg.CurrentSource {
+					fmt.Printf("Source: %s (active)\n", s.Name)
+				} else {
+					fmt.Printf("Source: %s\n", s.Name)
+				}
+				fmt.Printf("  Type: %s\n", s.Type)
+				printConfigItems(s.Config, sourceplugin.GetFields(s.Type))
+				return nil
+			}
+
+			// List all sources
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "NAME\tTYPE\tCURRENT")
 			for _, s := range cfg.Sources {

--- a/cmd/cli/cmd/llm/config/source_test.go
+++ b/cmd/cli/cmd/llm/config/source_test.go
@@ -46,8 +46,8 @@ func TestNewGetSourcesCmd(t *testing.T) {
 	cmd := newGetSourcesCmd()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "get-sources", cmd.Use)
-	assert.Equal(t, "List all source configurations", cmd.Short)
+	assert.Equal(t, "get-sources [NAME]", cmd.Use)
+	assert.Equal(t, "List all source configurations or show details of one", cmd.Short)
 }
 
 func TestNewUseSourceCmd(t *testing.T) {

--- a/cmd/cli/cmd/llm/config/storage.go
+++ b/cmd/cli/cmd/llm/config/storage.go
@@ -178,6 +178,10 @@ Examples:
 			}
 
 			// List all storages
+			if len(cfg.Storages) == 0 {
+				fmt.Println("No storage found in rbg config")
+				return nil
+			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "NAME\tTYPE\tCURRENT")
 			for _, s := range cfg.Storages {

--- a/cmd/cli/cmd/llm/config/storage.go
+++ b/cmd/cli/cmd/llm/config/storage.go
@@ -140,23 +140,44 @@ Examples:
 
 func newGetStoragesCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get-storages",
-		Short: "List all storage configurations",
-		Long: `List all configured storage backends.
+		Use:   "get-storages [NAME]",
+		Short: "List all storage configurations or show details of one",
+		Long: `List all configured storage backends, or show detailed information for a specific one.
 
-Displays a table showing:
-  - NAME: The name of the storage configuration
-  - TYPE: The storage type (e.g., pvc)
-  - CURRENT: Indicates the currently active storage with "*"
+Without NAME: displays a table showing all storages.
+With NAME: displays the detailed configuration for the named storage.
 
-Example:
-  kubectl rbg llm config get-storages`,
+Examples:
+  # List all storages
+  kubectl rbg llm config get-storages
+
+  # Show details of a specific storage
+  kubectl rbg llm config get-storages my-pvc`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
 
+			// Show details of a single storage
+			if len(args) == 1 {
+				name := args[0]
+				s, err := cfg.GetStorage(name)
+				if err != nil {
+					return err
+				}
+				if s.Name == cfg.CurrentStorage {
+					fmt.Printf("Storage: %s (active)\n", s.Name)
+				} else {
+					fmt.Printf("Storage: %s\n", s.Name)
+				}
+				fmt.Printf("  Type: %s\n", s.Type)
+				printConfigItems(s.Config, storageplugin.GetFields(s.Type))
+				return nil
+			}
+
+			// List all storages
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "NAME\tTYPE\tCURRENT")
 			for _, s := range cfg.Storages {

--- a/cmd/cli/cmd/llm/config/storage_test.go
+++ b/cmd/cli/cmd/llm/config/storage_test.go
@@ -48,8 +48,8 @@ func TestNewGetStoragesCmd(t *testing.T) {
 	cmd := newGetStoragesCmd()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "get-storages", cmd.Use)
-	assert.Equal(t, "List all storage configurations", cmd.Short)
+	assert.Equal(t, "get-storages [NAME]", cmd.Use)
+	assert.Equal(t, "List all storage configurations or show details of one", cmd.Short)
 }
 
 func TestNewUseStorageCmd(t *testing.T) {

--- a/cmd/cli/cmd/llm/model/list.go
+++ b/cmd/cli/cmd/llm/model/list.go
@@ -187,14 +187,6 @@ if [ -d "$MODELS_DIR" ]; then
 
             # Add path info to metadata (use | as sed delimiter to avoid issues with / in paths)
             cat "$metadata_file" >> "$OUTPUT_FILE"
-          else
-            # No metadata file, create basic entry
-            if [ "$first" = true ]; then
-              first=false
-            else
-              echo "," >> "$OUTPUT_FILE"
-            fi
-            echo "{\"modelID\":\"$model_name\",\"revision\":\"$revision\",\"downloadedAt\":\"unknown\"}" >> "$OUTPUT_FILE"
           fi
         fi
       done

--- a/cmd/cli/plugin/source/interface.go
+++ b/cmd/cli/plugin/source/interface.go
@@ -66,7 +66,7 @@ func Get(pluginType string, config map[string]interface{}) (Plugin, error) {
 func ValidateConfig(pluginType string, config map[string]interface{}) error {
 	factory, ok := registry[pluginType]
 	if !ok {
-		return fmt.Errorf("unknown source type %q", pluginType)
+		return fmt.Errorf("unknown source type %q. . Supported types: %v", pluginType, RegisteredNames())
 	}
 	return util.ValidateConfig(factory().ConfigFields(), config)
 }

--- a/cmd/cli/plugin/storage/interface.go
+++ b/cmd/cli/plugin/storage/interface.go
@@ -129,7 +129,7 @@ func Get(pluginType string, config map[string]interface{}) (Plugin, error) {
 func ValidateConfig(pluginType string, config map[string]interface{}) error {
 	factory, ok := registry[pluginType]
 	if !ok {
-		return fmt.Errorf("unknown storage type %q", pluginType)
+		return fmt.Errorf("unknown storage type %q. . Supported types: %v", pluginType, RegisteredNames())
 	}
 	return util.ValidateConfig(factory().ConfigFields(), config)
 }

--- a/doc/cli/kubectl-rbg-llm-config.md
+++ b/doc/cli/kubectl-rbg-llm-config.md
@@ -74,6 +74,9 @@ kubectl rbg llm config add-storage NAME -i
 # List all storage configurations
 kubectl rbg llm config get-storages
 
+# Show details of a specific storage
+kubectl rbg llm config get-storages my-pvc
+
 # Set the active storage
 kubectl rbg llm config use-storage NAME
 
@@ -129,6 +132,9 @@ kubectl rbg llm config add-source NAME -i
 # List all source configurations
 kubectl rbg llm config get-sources
 
+# Show details of a specific source
+kubectl rbg llm config get-sources huggingface
+
 # Set the active source
 kubectl rbg llm config use-source NAME
 
@@ -171,6 +177,9 @@ kubectl rbg llm config set-engine ENGINE_TYPE --config key=value
 
 # List customized engine configurations
 kubectl rbg llm config get-engines
+
+# Show details of a specific engine
+kubectl rbg llm config get-engines sglang
 
 # Remove custom configuration, revert to defaults
 kubectl rbg llm config reset-engine ENGINE_TYPE
@@ -245,9 +254,23 @@ kubectl rbg llm config get-storages
 > oss-pvc    pvc   
 > oss-name   oss   *
 
+kubectl rbg llm config get-storages oss-name
+> Storage: oss-name (active)
+>   Type: oss
+>   Config:
+>     bucket: demo
+>     secretName: oss-name-oss-secret
+>     secretNamespace: default
+>     subpath: /test-cli/
+>     url: oss-cn-hongkong-internal.aliyuncs.com
+
 kubectl rbg llm config get-sources
 > NAME         TYPE         CURRENT
 > huggingface  huggingface  *
+
+kubectl rbg llm config get-sources huggingface
+> Source: huggingface (active)
+>   Type: huggingface
 
 # 7. Update a configuration
 kubectl rbg llm config set-storage my-pvc --config pvcName=new-model-pvc


### PR DESCRIPTION

## PR Description

This PR improves the CLI `llm config` commands and `list model` behavior:

### Changes

1. **Support viewing single config details for `get-storages`, `get-sources`, and `get-engines`**
   - All three commands now accept an optional `[NAME]` argument.
   - Without argument: lists all configurations (existing behavior).
   - With argument: displays detailed configuration for the named storage, source, or engine.
   - Example: `kubectl rbg llm config get-storages my-pvc`

2. **Add friendly empty-state messages**
   - When no configurations exist, print a clear note (e.g., `No storage found in rbg config`) instead of showing an empty table.

3. **Filter model directories without metadata in `list model`**
   - The `list model` command now skips directories that do not contain `.rbg-metadata.json`, avoiding incomplete entries.

4. **Synchronize documentation**
   - Updated `cmd/cli/README.md` and `doc/cli/kubectl-rbg-llm-config.md` to reflect the new command signatures and examples.

### Files Changed
- `cmd/cli/cmd/llm/config/storage.go`
- `cmd/cli/cmd/llm/config/source.go`
- `cmd/cli/cmd/llm/config/engine.go`
- `cmd/cli/cmd/llm/model/list.go`
- `cmd/cli/README.md`
- `doc/cli/kubectl-rbg-llm-config.md`