### PR TITLE
ci: use server-side apply for manifest E2E and remove image build

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -291,30 +291,10 @@ jobs:
           kubectl wait --for=condition=ready pod -l app=volcano-controller -n volcano-system --timeout=300s
           kubectl get pods -n volcano-system
 
-      - name: Build and load controller image
-        run: |
-          make docker-build-controller TAG=e2e-manifest
-          docker images | grep rbgs-controller || true
-          kind load docker-image docker.io/rolebasedgroup/rbgs-controller:e2e-manifest --name rbgs-manifest-e2e
-
-      - name: Build and load CRD Upgrader image
-        run: |
-          make docker-build-crd-upgrader TAG=e2e-manifest
-          docker images | grep rbgs-upgrade-crd || true
-          kind load docker-image docker.io/rolebasedgroup/rbgs-upgrade-crd:e2e-manifest --name rbgs-manifest-e2e
-
       - name: Deploy controller using manifest
         run: |
-          # Create namespace first
-          kubectl create namespace rbgs-system
-
-          # Apply manifests with image tag override
-          kubectl apply -f deploy/kubectl/manifests.yaml \
-            --namespace rbgs-system \
-            --dry-run=client -o yaml | \
-            sed 's|docker.io/rolebasedgroup/rbgs-controller:.*|docker.io/rolebasedgroup/rbgs-controller:e2e-manifest|g' | \
-            sed 's|docker.io/rolebasedgroup/rbgs-upgrade-crd:.*|docker.io/rolebasedgroup/rbgs-upgrade-crd:e2e-manifest|g' | \
-            kubectl apply -f -
+          # Apply manifests with server-side apply (required for large CRD annotations)
+          kubectl apply --server-side -f deploy/kubectl/manifests.yaml
 
           kubectl get deploy -n rbgs-system
 


### PR DESCRIPTION
- Use kubectl apply --server-side for CRD installation to avoid "metadata.annotations: Too long" error
- Remove local image build/load since manifest uses published image rolebasedgroup/rbgs-controller:v0.7.0-47b2681

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
