### PR TITLE
feat(cli): add command 'llm svc model-configs' to list builtin/custom…

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -147,6 +147,32 @@ kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --model-path /models/my-custom
 kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --test-api=false
 ```
 
+### llm svc model-configs
+
+List available model configurations (built-in and user-defined).
+
+This command helps you discover which models and run modes are available before deploying with `kubectl rbg llm svc run`. Each model config includes the model ID, supported modes, inference engine, and resource requirements.
+
+```bash
+kubectl rbg llm svc model-configs [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--output` | `-o` | Output format: `-o wide` for full details | |
+
+**Examples:**
+
+```bash
+# List all available model configurations
+kubectl rbg llm svc model-configs
+
+# Show full details with engine and source
+kubectl rbg llm svc model-configs -o wide
+```
+
 ### llm svc list
 
 List all running LLM inference services.

--- a/cmd/cli/cmd/llm/svc/model_configs.go
+++ b/cmd/cli/cmd/llm/svc/model_configs.go
@@ -19,6 +19,7 @@ package svc
 import (
 	"fmt"
 	"os"
+	"sort"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -46,6 +47,10 @@ Examples:
   kubectl rbg llm svc model-configs -o wide
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if output != "" && output != "wide" {
+				return fmt.Errorf("unsupported output format %q, supported values: wide", output)
+			}
+
 			models, err := runpkg.LoadAllModels()
 			if err != nil {
 				return fmt.Errorf("failed to load model configurations: %w", err)
@@ -56,21 +61,40 @@ Examples:
 				return nil
 			}
 
+			for i := range models {
+				sort.Slice(models[i].Modes, func(a, b int) bool {
+					return models[i].Modes[a].Name < models[i].Modes[b].Name
+				})
+			}
+
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			write := func(format string, a ...any) error {
+				_, err := fmt.Fprintf(w, format, a...)
+				return err
+			}
+
 			if output == "wide" {
-				fmt.Fprintln(w, "MODEL ID\tMODE\tENGINE\tSOURCE\tDESCRIPTION")
+				if err := write("MODEL ID\tMODE\tENGINE\tSOURCE\tDESCRIPTION\n"); err != nil {
+					return err
+				}
 				for _, m := range models {
 					for _, mode := range m.Modes {
-						fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-							m.ID, mode.Name, mode.Engine, mode.Source, mode.Description)
+						if err := write("%s\t%s\t%s\t%s\t%s\n",
+							m.ID, mode.Name, mode.Engine, mode.Source, mode.Description); err != nil {
+							return err
+						}
 					}
 				}
 			} else {
-				fmt.Fprintln(w, "MODEL ID\tMODE\tDESCRIPTION")
+				if err := write("MODEL ID\tMODE\tDESCRIPTION\n"); err != nil {
+					return err
+				}
 				for _, m := range models {
 					for _, mode := range m.Modes {
-						fmt.Fprintf(w, "%s\t%s\t%s\n",
-							m.ID, mode.Name, mode.Description)
+						if err := write("%s\t%s\t%s\n",
+							m.ID, mode.Name, mode.Description); err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/cmd/cli/cmd/llm/svc/model_configs.go
+++ b/cmd/cli/cmd/llm/svc/model_configs.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package svc
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	runpkg "sigs.k8s.io/rbgs/cmd/cli/cmd/llm/svc/run"
+)
+
+func newModelConfigsCmd() *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "model-configs",
+		Short: "List available model configurations",
+		Long: `List built-in and user-defined model configurations with their available run modes.
+
+Use this to discover which model IDs and modes are supported before running
+'kubectl rbg llm svc run'.
+
+Use -o wide to show additional columns (source, engine).
+
+Examples:
+  # List all available model configurations
+  kubectl rbg llm svc model-configs
+
+  # Show full details
+  kubectl rbg llm svc model-configs -o wide
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			models, err := runpkg.LoadAllModels()
+			if err != nil {
+				return fmt.Errorf("failed to load model configurations: %w", err)
+			}
+
+			if len(models) == 0 {
+				fmt.Println("No model configurations found.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			if output == "wide" {
+				fmt.Fprintln(w, "MODEL ID\tMODE\tENGINE\tSOURCE\tDESCRIPTION")
+				for _, m := range models {
+					for _, mode := range m.Modes {
+						fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+							m.ID, mode.Name, mode.Engine, mode.Source, mode.Description)
+					}
+				}
+			} else {
+				fmt.Fprintln(w, "MODEL ID\tMODE\tDESCRIPTION")
+				for _, m := range models {
+					for _, mode := range m.Modes {
+						fmt.Fprintf(w, "%s\t%s\t%s\n",
+							m.ID, mode.Name, mode.Description)
+					}
+				}
+			}
+
+			return w.Flush()
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output format. Supported: wide")
+
+	return cmd
+}

--- a/cmd/cli/cmd/llm/svc/run/model_config.go
+++ b/cmd/cli/cmd/llm/svc/run/model_config.go
@@ -90,6 +90,8 @@ func LoadAllModels() ([]ModelConfig, error) {
 // mergeModelConfigs merges user and builtin model configs at the mode level.
 // Builtin models form the base; user modes override same-named modes,
 // and user-only modes are appended. User-only models are added as-is.
+// Within a single user model definition, duplicate modes are deduplicated
+// with last-one-wins semantics.
 func mergeModelConfigs(userModels []modelWithSource, builtinModels []ModelConfig) []ModelConfig {
 	modelMap := make(map[string]*ModelConfig, len(builtinModels))
 	for i := range builtinModels {
@@ -100,24 +102,26 @@ func mergeModelConfigs(userModels []modelWithSource, builtinModels []ModelConfig
 	for _, um := range userModels {
 		existing, exists := modelMap[um.model.ID]
 		if !exists {
-			modelMap[um.model.ID] = &ModelConfig{ID: um.model.ID, Name: um.model.Name, Modes: copyModes(um.model.Modes, um.source)}
-			continue
+			existing = &ModelConfig{ID: um.model.ID, Name: um.model.Name}
+			modelMap[um.model.ID] = existing
 		}
 		if um.model.Name != "" {
 			existing.Name = um.model.Name
 		}
-		modeIdx := make(map[string]int, len(existing.Modes))
-		for i := range existing.Modes {
-			modeIdx[existing.Modes[i].Name] = i
-		}
 		for _, umode := range um.model.Modes {
-			umode.Source = um.source
-			if idx, found := modeIdx[umode.Name]; found {
-				fmt.Fprintf(os.Stderr, "Warning: mode %q for model %q redefined by %s, overriding %s\n",
-					umode.Name, um.model.ID, um.source, existing.Modes[idx].Source)
-				existing.Modes[idx] = umode
-			} else {
-				existing.Modes = append(existing.Modes, umode)
+			umodeCopy := copyMode(umode, um.source)
+			found := false
+			for i := range existing.Modes {
+				if existing.Modes[i].Name == umodeCopy.Name {
+					fmt.Fprintf(os.Stderr, "Warning: mode %q for model %q redefined by %s, overriding %s\n",
+						umodeCopy.Name, um.model.ID, um.source, existing.Modes[i].Source)
+					existing.Modes[i] = umodeCopy
+					found = true
+					break
+				}
+			}
+			if !found {
+				existing.Modes = append(existing.Modes, umodeCopy)
 			}
 		}
 	}
@@ -130,22 +134,30 @@ func mergeModelConfigs(userModels []modelWithSource, builtinModels []ModelConfig
 	return result
 }
 
+// copyMode returns a deep copy of a single ModeConfig with Source set.
+func copyMode(mode ModeConfig, source string) ModeConfig {
+	mode.Source = source
+	if mode.Args != nil {
+		mode.Args = append([]string(nil), mode.Args...)
+	}
+	if mode.Env != nil {
+		mode.Env = append([]corev1.EnvVar(nil), mode.Env...)
+	}
+	if mode.Resources != nil {
+		mode.Resources = mode.Resources.DeepCopy()
+	}
+	if mode.Distributed != nil {
+		d := *mode.Distributed
+		mode.Distributed = &d
+	}
+	return mode
+}
+
 // copyModes returns a deep copy of the given modes, setting each mode's Source.
 func copyModes(modes []ModeConfig, source string) []ModeConfig {
 	out := make([]ModeConfig, len(modes))
 	for i, m := range modes {
-		m.Source = source
-		if m.Args != nil {
-			m.Args = append([]string(nil), m.Args...)
-		}
-		if m.Env != nil {
-			m.Env = append([]corev1.EnvVar(nil), m.Env...)
-		}
-		if m.Distributed != nil {
-			d := *m.Distributed
-			m.Distributed = &d
-		}
-		out[i] = m
+		out[i] = copyMode(m, source)
 	}
 	return out
 }

--- a/cmd/cli/cmd/llm/svc/run/model_config.go
+++ b/cmd/cli/cmd/llm/svc/run/model_config.go
@@ -47,6 +47,10 @@ type ModeConfig struct {
 	Env         []corev1.EnvVar     `yaml:"env"`
 	Distributed *DistributedConfig  `yaml:"distributed,omitempty"` // Multi-node deployment config
 	ShmSize     string              `yaml:"shmSize,omitempty"`     // Shared memory size (e.g., "8Gi", "16Gi")
+
+	// Source indicates where this mode was defined ("builtin" or config filename).
+	// Populated by LoadAllModels; excluded from YAML/JSON serialization.
+	Source string `yaml:"-" json:"-"`
 }
 
 // DistributedConfig describes multi-node deployment configuration.
@@ -61,111 +65,89 @@ type modelWithSource struct {
 	source string
 }
 
-// LoadAllModels loads all available model configurations by merging:
-//  1. User-defined models (from the directory returned by GetModelConfigDir(),
-//     default: ~/.rbg/models, overridable via RBG_MODEL_CONFIG env var;
-//     accepts both .yaml and .yml files)
-//  2. Built-in models (embedded models.yaml)
+// LoadAllModels loads all available model configurations and merges them at the
+// mode level: user modes override builtin modes with the same name, while
+// builtin modes with no user counterpart are preserved.
 //
-// User models are placed before built-in models, so they take precedence during lookup.
-// Duplicate detection and warnings are performed during loading.
+// Sources:
+//  1. User-defined models (from GetModelConfigDir(), default: ~/.rbg/models,
+//     overridable via RBG_MODEL_CONFIG env var; accepts .yaml and .yml files)
+//  2. Built-in models (embedded models.yaml)
 func LoadAllModels() ([]ModelConfig, error) {
-	// 1. Load user-defined models with source tracking
 	userModels, err := loadUserModels()
 	if err != nil {
-		// Log warning but don't fail - user models are optional
 		fmt.Fprintf(os.Stderr, "Warning: failed to load user models: %v\n", err)
 	}
 
-	// 2. Load built-in models (always available)
 	builtinModels, err := loadBuiltinModels()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load builtin models: %w", err)
 	}
 
-	// 3. Detect and warn about duplicates
-	detectModelConflicts(userModels, builtinModels)
-
-	// 4. Merge: user models first (higher priority), then builtin models
-	allModels := make([]ModelConfig, 0, len(userModels)+len(builtinModels))
-	for _, m := range userModels {
-		allModels = append(allModels, m.model)
-	}
-	allModels = append(allModels, builtinModels...)
-
-	return allModels, nil
+	return mergeModelConfigs(userModels, builtinModels), nil
 }
 
-// detectModelConflicts checks for duplicate model definitions and warns appropriately
-// Each model ID gets at most one warning, aggregating all definition sources
-func detectModelConflicts(userModels []modelWithSource, builtinModels []ModelConfig) {
-	// 1. Collect all definitions for each model ID
-	// Important: Record user models FIRST (they have higher priority)
-	type definition struct {
-		source string // source file name
+// mergeModelConfigs merges user and builtin model configs at the mode level.
+// Builtin models form the base; user modes override same-named modes,
+// and user-only modes are appended. User-only models are added as-is.
+func mergeModelConfigs(userModels []modelWithSource, builtinModels []ModelConfig) []ModelConfig {
+	modelMap := make(map[string]*ModelConfig, len(builtinModels))
+	for i := range builtinModels {
+		bm := &builtinModels[i]
+		modelMap[bm.ID] = &ModelConfig{ID: bm.ID, Name: bm.Name, Modes: copyModes(bm.Modes, "builtin")}
 	}
 
-	modelDefinitions := make(map[string][]definition)
-
-	// Record user models first (higher priority)
 	for _, um := range userModels {
-		modelDefinitions[um.model.ID] = append(modelDefinitions[um.model.ID], definition{
-			source: um.source,
-		})
-	}
-
-	// Then record builtin models
-	for _, m := range builtinModels {
-		modelDefinitions[m.ID] = append(modelDefinitions[m.ID], definition{
-			source: "builtin",
-		})
-	}
-
-	// 2. Emit aggregated warnings for models with multiple definitions
-	// Sort model IDs for deterministic output order
-	sortedModelIDs := make([]string, 0, len(modelDefinitions))
-	for modelID := range modelDefinitions {
-		sortedModelIDs = append(sortedModelIDs, modelID)
-	}
-	sort.Strings(sortedModelIDs)
-
-	for _, modelID := range sortedModelIDs {
-		defs := modelDefinitions[modelID]
-		if len(defs) <= 1 {
-			continue // Only one definition, no conflict
+		existing, exists := modelMap[um.model.ID]
+		if !exists {
+			modelMap[um.model.ID] = &ModelConfig{ID: um.model.ID, Name: um.model.Name, Modes: copyModes(um.model.Modes, um.source)}
+			continue
 		}
-
-		// Count definitions per source file
-		fileCount := make(map[string]int)
-		for _, d := range defs {
-			fileCount[d.source]++
+		if um.model.Name != "" {
+			existing.Name = um.model.Name
 		}
-
-		// Sort source files for deterministic output order
-		sortedFiles := make([]string, 0, len(fileCount))
-		for file := range fileCount {
-			sortedFiles = append(sortedFiles, file)
+		modeIdx := make(map[string]int, len(existing.Modes))
+		for i := range existing.Modes {
+			modeIdx[existing.Modes[i].Name] = i
 		}
-		sort.Strings(sortedFiles)
-
-		// Build warning message parts
-		parts := make([]string, 0, len(sortedFiles))
-		for _, file := range sortedFiles {
-			count := fileCount[file]
-			if count == 1 {
-				parts = append(parts, fmt.Sprintf("1 in %s", file))
+		for _, umode := range um.model.Modes {
+			umode.Source = um.source
+			if idx, found := modeIdx[umode.Name]; found {
+				fmt.Fprintf(os.Stderr, "Warning: mode %q for model %q redefined by %s, overriding %s\n",
+					umode.Name, um.model.ID, um.source, existing.Modes[idx].Source)
+				existing.Modes[idx] = umode
 			} else {
-				parts = append(parts, fmt.Sprintf("%d in %s", count, file))
+				existing.Modes = append(existing.Modes, umode)
 			}
 		}
-
-		// First definition wins (user models come first)
-		firstSource := defs[0].source
-
-		fmt.Fprintf(os.Stderr,
-			"Warning: model %q has %d definitions (%s), first definition in %s will be used\n",
-			modelID, len(defs), strings.Join(parts, ", "), firstSource)
 	}
+
+	result := make([]ModelConfig, 0, len(modelMap))
+	for _, mc := range modelMap {
+		result = append(result, *mc)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+// copyModes returns a deep copy of the given modes, setting each mode's Source.
+func copyModes(modes []ModeConfig, source string) []ModeConfig {
+	out := make([]ModeConfig, len(modes))
+	for i, m := range modes {
+		m.Source = source
+		if m.Args != nil {
+			m.Args = append([]string(nil), m.Args...)
+		}
+		if m.Env != nil {
+			m.Env = append([]corev1.EnvVar(nil), m.Env...)
+		}
+		if m.Distributed != nil {
+			d := *m.Distributed
+			m.Distributed = &d
+		}
+		out[i] = m
+	}
+	return out
 }
 
 // loadBuiltinModels loads the embedded model configurations

--- a/cmd/cli/cmd/llm/svc/run/model_config_test.go
+++ b/cmd/cli/cmd/llm/svc/run/model_config_test.go
@@ -291,13 +291,25 @@ func TestLoadAllModelsUserOverridesBuiltin(t *testing.T) {
 	if foundModel.Name != "My Override" {
 		t.Errorf("Expected user override 'My Override', got %q", foundModel.Name)
 	}
-	if foundModel.Modes[0].Image != "my-custom-image:latest" {
-		t.Errorf("Expected user image 'my-custom-image:latest', got %q", foundModel.Modes[0].Image)
+
+	// Locate the "standard" mode (modes are sorted by name)
+	var standardMode *ModeConfig
+	for i := range foundModel.Modes {
+		if foundModel.Modes[i].Name == "standard" {
+			standardMode = &foundModel.Modes[i]
+			break
+		}
+	}
+	if standardMode == nil {
+		t.Fatal("Mode 'standard' not found in merged model")
+	}
+	if standardMode.Image != "my-custom-image:latest" {
+		t.Errorf("Expected user image 'my-custom-image:latest', got %q", standardMode.Image)
 	}
 
 	// User's "standard" mode should be sourced from override.yaml
-	if foundModel.Modes[0].Source != "override.yaml" {
-		t.Errorf("Expected 'standard' mode source 'override.yaml', got %q", foundModel.Modes[0].Source)
+	if standardMode.Source != "override.yaml" {
+		t.Errorf("Expected 'standard' mode source 'override.yaml', got %q", standardMode.Source)
 	}
 
 	// Builtin modes not overridden should still be present

--- a/cmd/cli/cmd/llm/svc/run/model_config_test.go
+++ b/cmd/cli/cmd/llm/svc/run/model_config_test.go
@@ -294,6 +294,22 @@ func TestLoadAllModelsUserOverridesBuiltin(t *testing.T) {
 	if foundModel.Modes[0].Image != "my-custom-image:latest" {
 		t.Errorf("Expected user image 'my-custom-image:latest', got %q", foundModel.Modes[0].Image)
 	}
+
+	// User's "standard" mode should be sourced from override.yaml
+	if foundModel.Modes[0].Source != "override.yaml" {
+		t.Errorf("Expected 'standard' mode source 'override.yaml', got %q", foundModel.Modes[0].Source)
+	}
+
+	// Builtin modes not overridden should still be present
+	modeNames := make(map[string]bool)
+	for _, m := range foundModel.Modes {
+		modeNames[m.Name] = true
+	}
+	for _, expected := range []string{"throughput", "latency", "distributed-sglang", "distributed-vllm"} {
+		if !modeNames[expected] {
+			t.Errorf("Expected builtin mode %q to be preserved after mode-level merge", expected)
+		}
+	}
 }
 
 func TestLoadAllModelsUserDuplicate(t *testing.T) {
@@ -357,13 +373,13 @@ func TestLoadAllModelsUserDuplicate(t *testing.T) {
 		t.Fatal("Model my-org/duplicate-model not found")
 	}
 
-	// Should be from file-a.yaml (first alphabetically)
-	if foundModel.Name != "Definition A" {
-		t.Errorf("Expected first definition 'Definition A', got %q", foundModel.Name)
+	// Should be from file-b.yaml (last alphabetically wins with mode-level merge)
+	if foundModel.Name != "Definition B" {
+		t.Errorf("Expected 'Definition B' from file-b.yaml, got %q", foundModel.Name)
 	}
-	// Verify resources from first definition (file-a.yaml)
-	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "1" {
-		t.Errorf("Expected first definition GPU 1, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
+	// Verify resources from file-b.yaml
+	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "2" {
+		t.Errorf("Expected GPU 2 from file-b.yaml, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
 	}
 }
 
@@ -430,13 +446,13 @@ func TestLoadAllModelsMultipleDuplicatesAggregated(t *testing.T) {
 		t.Fatal("Model my-org/triple-model not found")
 	}
 
-	// Should be the first definition
-	if foundModel.Name != "Definition 1" {
-		t.Errorf("Expected first definition 'Definition 1', got %q", foundModel.Name)
+	// With mode-level merge, the last definition in the file wins.
+	if foundModel.Name != "Definition 3" {
+		t.Errorf("Expected last definition 'Definition 3', got %q", foundModel.Name)
 	}
-	// Verify resources from first definition
-	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "1" {
-		t.Errorf("Expected first definition GPU 1, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
+	// Verify resources from last definition
+	if gpu, ok := foundModel.Modes[0].Resources["nvidia.com/gpu"]; !ok || gpu.String() != "3" {
+		t.Errorf("Expected last definition GPU 3, got %v", foundModel.Modes[0].Resources["nvidia.com/gpu"])
 	}
 }
 

--- a/cmd/cli/cmd/llm/svc/svc.go
+++ b/cmd/cli/cmd/llm/svc/svc.go
@@ -31,14 +31,16 @@ func NewSVCCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 		Long: `Commands for managing LLM inference services (RoleBasedGroups) created by the CLI.
 
 This command group provides operations for the full lifecycle of an inference service:
-  - run:    Deploy a model as an inference service
-  - list:   List running inference services
-  - delete: Remove an inference service
-  - chat:   Interact with a running service`,
+  - run:           Deploy a model as an inference service
+  - list:          List running inference services
+  - model-configs: List available model configurations
+  - delete:        Remove an inference service
+  - chat:          Interact with a running service`,
 	}
 
 	cmd.AddCommand(newRunCmd(cf))
 	cmd.AddCommand(newListCmd(cf))
+	cmd.AddCommand(newModelConfigsCmd())
 	cmd.AddCommand(newDeleteCmd(cf))
 	cmd.AddCommand(chat.NewChatCmd(cf))
 

--- a/doc/cli/kubectl-rbg-llm-svc.md
+++ b/doc/cli/kubectl-rbg-llm-svc.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `kubectl rbg llm svc` command group manages the full lifecycle of LLM inference services on Kubernetes using RoleBasedGroup. It supports deploying models with various inference engines (vLLM, SGLang), listing and deleting services, and interactively chatting with deployed models.
+The `kubectl rbg llm svc` command group manages the full lifecycle of LLM inference services on Kubernetes using RoleBasedGroup. It supports deploying models with various inference engines (vLLM, SGLang), listing available model configurations, listing and deleting services, and interactively chatting with deployed models.
 
 ## Prerequisites
 
@@ -70,6 +70,18 @@ kubectl rbg llm svc run my-qwen Qwen/Qwen3.5-0.8B --test-api=false
 ```
 
 By default, the command waits for the service to be ready and tests the API endpoint. Use `--wait=false` to return immediately after creating the RoleBasedGroup.
+
+### List Model Configurations
+
+Before deploying a model with `kubectl rbg llm svc run`, you can list available model configurations to discover supported model IDs, run modes, inference engines, and resource presets. Model configs can be built-in or user-defined (placed in `~/.rbg/models/`).
+
+```bash
+# List all available model configurations
+kubectl rbg llm svc model-configs
+
+# Show full details including engine and source
+kubectl rbg llm svc model-configs -o wide
+```
 
 ### List Services
 
@@ -161,6 +173,12 @@ kubectl rbg llm svc run my-model org/new-model \
 ```
 
 When a model config exists, these flags act as overrides — `--resource` merges by key (flag wins on conflict), `--arg` and `--env` append to the config values.
+
+### model-configs
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o, --output` | `""` | Output format: `wide` for full details (includes engine, source) |
 
 ### list
 


### PR DESCRIPTION
## Motivation

Previously, users had no way to discover which model IDs and run modes were available before running `kubectl rbg llm svc run`. When a user-defined model config overlapped with a built-in one, the entire built-in model was silently replaced (model-level merge), causing loss of non-overridden modes. This PR addresses both issues by:

1. Introducing a discovery command so users can inspect supported models, engines, and resource presets before deployment.
2. Switching to mode-level merge so user modes override only same-named built-in modes while preserving others.

## Modifications

### New Command: `llm svc model-configs`

- Lists all available model configurations in a tabular format.
- Default view shows `MODEL ID`, `MODE`, `DESCRIPTION`.
- `-o wide` shows additional columns: `ENGINE`, `SOURCE`.

### Documentation

- Updated `cmd/cli/README.md` and `doc/cli/kubectl-rbg-llm-svc.md` with:
  - `llm svc model-configs` command description, flags, and examples.
  - Cross-reference explaining that `model-configs` helps discover deployable models before `llm svc run`.

## Tests

- Updated `model_config_test.go` assertions to reflect the new mode-level merge behavior:
  - Overridden modes carry the user file source.
  - Non-overridden built-in modes are preserved.
  - Last-file-wins semantics for duplicate user modes.
- `go test ./cmd/cli/...` passes.

## Files Changed

- `cmd/cli/cmd/llm/svc/model_configs.go` (new)
- `cmd/cli/cmd/llm/svc/run/model_config.go`
- `cmd/cli/cmd/llm/svc/run/model_config_test.go`
- `cmd/cli/cmd/llm/svc/svc.go`
- `cmd/cli/README.md`
- `doc/cli/kubectl-rbg-llm-svc.md`
