### PR TITLE
feat(cli): new command - auto-benchmark

### DIFF
--- a/cmd/autobenchmark/Dockerfile
+++ b/cmd/autobenchmark/Dockerfile
@@ -1,0 +1,43 @@
+# Build the auto-benchmark controller binary
+FROM registry-cn-hangzhou.ack.aliyuncs.com/dev/golang:1.24.1 AS builder
+
+ARG GOPROXY
+ARG GOPRIVATE
+ARG GOSUMDB
+
+ENV GOPROXY=${GOPROXY} \
+    GOPRIVATE=${GOPRIVATE} \
+    GOSUMDB=${GOSUMDB}
+
+WORKDIR /workspace
+ADD . /workspace
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o autobenchmark ./cmd/autobenchmark/
+
+# Final image: Python base with genai-bench + controller binary
+FROM python:3.12.12-slim
+
+# Use Chinese mirror for apt
+RUN sed -i 's|deb.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list.d/debian.sources
+
+# Install runtime libraries required by numerical Python wheels (numpy, scipy, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure pip to use Aliyun mirror
+RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/ && \
+    pip config set global.trusted-host mirrors.aliyun.com
+
+# Install genai-bench and optuna from PyPI
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir genai-bench optuna
+
+# Copy optuna bridge script
+COPY tools/optuna_bridge.py /tools/optuna_bridge.py
+
+# Copy controller binary
+WORKDIR /
+COPY --from=builder --chmod=755 /workspace/autobenchmark .
+
+ENTRYPOINT ["/autobenchmark"]

--- a/cmd/autobenchmark/main.go
+++ b/cmd/autobenchmark/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	rawzap "go.uber.org/zap"
@@ -90,7 +91,7 @@ func main() {
 			setupLog.Error(fmt.Errorf("--namespace is required or must run in-cluster"), "Namespace resolution failed")
 			os.Exit(1)
 		}
-		namespace = string(data)
+		namespace = strings.TrimSpace(string(data))
 	}
 
 	if err := run(configPath, namespace, dataDir); err != nil {

--- a/cmd/autobenchmark/main.go
+++ b/cmd/autobenchmark/main.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	rawzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	batchv1 "k8s.io/api/batch/v1"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abcontroller "sigs.k8s.io/rbgs/pkg/autobenchmark/controller"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(workloadsv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		configPath string
+		namespace  string
+		dataDir    string
+	)
+
+	flag.StringVar(&configPath, "config", "/etc/autobenchmark/config.yaml", "Path to auto-benchmark config file")
+	flag.StringVar(&namespace, "namespace", "", "Namespace for RBG and benchmark resources")
+	flag.StringVar(&dataDir, "data-dir", "/data", "Base directory for experiment data (PVC mount)")
+
+	opts := zap.Options{
+		Development: false,
+		EncoderConfigOptions: []zap.EncoderConfigOption{
+			func(ec *zapcore.EncoderConfig) {
+				ec.MessageKey = "message"
+				ec.LevelKey = "level"
+				ec.TimeKey = "time"
+				ec.CallerKey = "caller"
+				ec.EncodeLevel = zapcore.CapitalLevelEncoder
+				ec.EncodeCaller = zapcore.ShortCallerEncoder
+				ec.EncodeTime = zapcore.ISO8601TimeEncoder
+			},
+		},
+		ZapOpts: []rawzap.Option{rawzap.AddCaller()},
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	zapLogger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(zapLogger)
+
+	if namespace == "" {
+		data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			setupLog.Error(fmt.Errorf("--namespace is required or must run in-cluster"), "Namespace resolution failed")
+			os.Exit(1)
+		}
+		namespace = string(data)
+	}
+
+	if err := run(configPath, namespace, dataDir); err != nil {
+		setupLog.Error(err, "Auto-benchmark failed")
+		os.Exit(1)
+	}
+}
+
+func run(configPath, namespace, dataDir string) error {
+	cfg, err := config.ParseFile(configPath)
+	if err != nil {
+		return fmt.Errorf("parsing config %q: %w", configPath, err)
+	}
+
+	if err := config.Validate(cfg, false); err != nil {
+		return fmt.Errorf("validating config: %w", err)
+	}
+
+	expDir := filepath.Join(dataDir, cfg.Name)
+	stateDir := filepath.Join(expDir, "state")
+	reportDir := expDir
+
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("getting kubeconfig: %w", err)
+	}
+
+	k8sClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client: %w", err)
+	}
+
+	controller, err := abcontroller.NewController(cfg, k8sClient, namespace, stateDir, reportDir)
+	if err != nil {
+		return fmt.Errorf("creating controller: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := ctrl.Log.WithName("autobenchmark")
+	ctx = log.IntoContext(ctx, logger)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig := <-sigCh
+		setupLog.Info("Received signal, initiating graceful shutdown", "signal", sig.String())
+		cancel()
+	}()
+
+	setupLog.Info("Starting auto-benchmark controller", "namespace", namespace)
+	return controller.Run(ctx)
+}

--- a/cmd/cli/cmd/llm/autobenchmark/autobenchmark.go
+++ b/cmd/cli/cmd/llm/autobenchmark/autobenchmark.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	controllerImage = "rolebasedgroup/rbgs-auto-benchmark:latest"
+)
+
+// NewAutoBenchmarkCmd creates the "llm auto-benchmark" command.
+func NewAutoBenchmarkCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "auto-benchmark",
+		Aliases: []string{"ab"},
+		Short:   "Automated LLM inference parameter tuning",
+		Long: `Automated parameter tuning for LLM inference engines.
+
+Iterates through RBG template configurations and engine parameter search spaces
+to find the optimal configuration that maximizes throughput while meeting SLA constraints.`,
+	}
+
+	cmd.AddCommand(newRunCmd(cf))
+	cmd.AddCommand(newDashboardCmd(cf))
+	cmd.AddCommand(newStatusCmd(cf))
+	cmd.AddCommand(newListCmd(cf))
+	cmd.AddCommand(newStopCmd(cf))
+	cmd.AddCommand(newLogsCmd(cf))
+
+	return cmd
+}
+
+// experimentToJobName converts an experiment name to the conventional Job name.
+func experimentToJobName(expName string) string {
+	jobName := fmt.Sprintf("ab-%s", strings.ToLower(expName))
+	if len(jobName) > 63 {
+		jobName = jobName[:63]
+	}
+	return strings.TrimRight(jobName, "-")
+}

--- a/cmd/cli/cmd/llm/autobenchmark/autobenchmark.go
+++ b/cmd/cli/cmd/llm/autobenchmark/autobenchmark.go
@@ -51,8 +51,10 @@ to find the optimal configuration that maximizes throughput while meeting SLA co
 }
 
 // experimentToJobName converts an experiment name to the conventional Job name.
+// Uses sanitizeResourceName to ensure DNS-1123 compliance.
 func experimentToJobName(expName string) string {
-	jobName := fmt.Sprintf("ab-%s", strings.ToLower(expName))
+	safeName := sanitizeResourceName(expName)
+	jobName := fmt.Sprintf("ab-%s", safeName)
 	if len(jobName) > 63 {
 		jobName = jobName[:63]
 	}

--- a/cmd/cli/cmd/llm/autobenchmark/dashboard.go
+++ b/cmd/cli/cmd/llm/autobenchmark/dashboard.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+)
+
+const (
+	dashboardImage   = "rolebasedgroup/rbgs-auto-benchmark-dashboard:latest"
+	dashboardPort    = 80
+	defaultLocalPort = 18888
+)
+
+type dashboardOptions struct {
+	cf         *genericclioptions.ConfigFlags
+	configFile string
+	name       string
+	image      string
+	localPort  int
+}
+
+func newDashboardCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	opts := &dashboardOptions{
+		cf:        cf,
+		image:     dashboardImage,
+		localPort: defaultLocalPort,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "dashboard [name]",
+		Short: "Launch a web dashboard for experiment results",
+		Long: `Create a Deployment serving the auto-benchmark results UI,
+mount the experiment's output PVC, and port-forward to localhost.
+
+The dashboard is available while this command is running. Press Ctrl+C to stop and clean up.
+
+If [name] is provided, it overrides the experiment name from the config file.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.name = args[0]
+			}
+			return opts.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.configFile, "config", "f", "", "Path to auto-benchmark config file (required)")
+	cmd.Flags().StringVar(&opts.image, "image", dashboardImage, "Dashboard container image")
+	cmd.Flags().IntVarP(&opts.localPort, "port", "p", defaultLocalPort, "Local port for port-forward")
+	_ = cmd.MarkFlagRequired("config")
+
+	return cmd
+}
+
+func (o *dashboardOptions) run(ctx context.Context) error {
+	// Parse config
+	cfg, err := config.ParseFile(o.configFile)
+	if err != nil {
+		return fmt.Errorf("parsing config: %w", err)
+	}
+
+	expName := cfg.Name
+	if o.name != "" {
+		expName = o.name
+	}
+
+	// Kubernetes client
+	clientset, err := util.GetK8SClientSet(o.cf)
+	if err != nil {
+		return fmt.Errorf("getting kubernetes client: %w", err)
+	}
+	namespace := util.GetNamespace(o.cf)
+
+	// Compute PVC subPath: {results.subPath}/{experiment-name}
+	fullSubPath := filepath.Join(cfg.Results.SubPath, expName)
+
+	// Sanitize experiment name to comply with DNS-1035 label requirements.
+	// Use "abd-{name}" prefix to ensure the result always starts with a letter.
+	safeName := sanitizeResourceName(expName)
+	deployName := fmt.Sprintf("abd-%s", safeName)
+	svcName := deployName
+
+	labels := map[string]string{
+		"app":        "auto-benchmark-dashboard",
+		"experiment": expName,
+	}
+
+	// --- Create Deployment ---
+	fmt.Printf("Creating Deployment %s... ", deployName)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "dashboard",
+							Image: o.image,
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: dashboardPort},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "data",
+									MountPath: "/usr/share/nginx/html/data",
+									SubPath:   fullSubPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: cfg.Results.PVC,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Delete existing if present, then create
+	deployClient := clientset.AppsV1().Deployments(namespace)
+	_, err = deployClient.Get(ctx, deployName, metav1.GetOptions{})
+	if err == nil {
+		fmt.Printf("replacing existing... ")
+		if err := deployClient.Delete(ctx, deployName, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("deleting existing Deployment: %w", err)
+		}
+	}
+
+	_, err = deployClient.Create(ctx, deploy, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating Deployment: %w", err)
+	}
+	fmt.Println("done")
+
+	// --- Create Service ---
+	fmt.Printf("Creating Service %s... ", svcName)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       dashboardPort,
+					TargetPort: intstr.FromInt(dashboardPort),
+				},
+			},
+		},
+	}
+
+	svcClient := clientset.CoreV1().Services(namespace)
+	_, err = svcClient.Get(ctx, svcName, metav1.GetOptions{})
+	if err == nil {
+		fmt.Printf("replacing existing... ")
+		if err := svcClient.Delete(ctx, svcName, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("deleting existing Service: %w", err)
+		}
+	}
+
+	_, err = svcClient.Create(ctx, svc, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating Service: %w", err)
+	}
+	fmt.Println("done")
+
+	// --- Port-forward ---
+	fmt.Printf("Waiting for Deployment %s to be ready... ", deployName)
+	if err := o.waitForDeploymentReady(ctx, namespace, deployName); err != nil {
+		return fmt.Errorf("waiting for deployment: %w", err)
+	}
+
+	fmt.Printf("Starting port-forward svc/%s :%d -> :%d...\n", svcName, o.localPort, dashboardPort)
+
+	return o.runPortForward(ctx, namespace, svcName, deployName)
+}
+
+func (o *dashboardOptions) runPortForward(ctx context.Context, namespace, svcName, deployName string) error {
+	// Build kubectl command
+	kubeconfig := ""
+	if o.cf.KubeConfig != nil {
+		kubeconfig = *o.cf.KubeConfig
+	}
+
+	args := []string{
+		"port-forward",
+		"-n", namespace,
+		fmt.Sprintf("svc/%s", svcName),
+		fmt.Sprintf("%d:%d", o.localPort, dashboardPort),
+	}
+	if kubeconfig != "" {
+		args = append([]string{"--kubeconfig", kubeconfig}, args...)
+	}
+
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting port-forward: %w", err)
+	}
+
+	// Monitor stdout for ready signal
+	readyCh := make(chan struct{})
+	var readyOnce sync.Once
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "Forwarding from") {
+				readyOnce.Do(func() { close(readyCh) })
+			}
+			fmt.Printf("kubectl: %s\n", line)
+		}
+	}()
+
+	// Monitor stderr in background
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "kubectl: %s\n", scanner.Text())
+		}
+	}()
+
+	// Cleanup on interrupt
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-readyCh:
+		dashboardURL := fmt.Sprintf("http://localhost:%d", o.localPort)
+		fmt.Printf("\nDashboard available at: %s\n", dashboardURL)
+		fmt.Println("Press Ctrl+C to stop")
+		openBrowser(dashboardURL)
+	case <-sigCh:
+		_ = cmd.Process.Kill()
+		_ = o.cleanup(ctx, namespace, deployName, svcName)
+		return fmt.Errorf("interrupted")
+	}
+
+	// Block until signal
+	<-sigCh
+	fmt.Println("\nCleaning up...")
+
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	return o.cleanup(ctx, namespace, deployName, svcName)
+}
+
+func (o *dashboardOptions) cleanup(ctx context.Context, namespace, deployName, svcName string) error {
+	clientset, err := util.GetK8SClientSet(o.cf)
+	if err != nil {
+		return fmt.Errorf("cleanup: getting client: %w", err)
+	}
+
+	// Delete Deployment
+	if err := clientset.AppsV1().Deployments(namespace).Delete(ctx, deployName, metav1.DeleteOptions{}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to delete Deployment %s: %v\n", deployName, err)
+	} else {
+		fmt.Printf("Deleted Deployment %s\n", deployName)
+	}
+
+	// Delete Service
+	if err := clientset.CoreV1().Services(namespace).Delete(ctx, svcName, metav1.DeleteOptions{}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to delete Service %s: %v\n", svcName, err)
+	} else {
+		fmt.Printf("Deleted Service %s\n", svcName)
+	}
+
+	return nil
+}
+
+func (o *dashboardOptions) waitForDeploymentReady(ctx context.Context, namespace, deployName string) error {
+	clientset, err := util.GetK8SClientSet(o.cf)
+	if err != nil {
+		return fmt.Errorf("getting client: %w", err)
+	}
+
+	const (
+		pollInterval = 5 * time.Second
+		pollTimeout  = 5 * time.Minute
+	)
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	timeoutCh := time.After(pollTimeout)
+	dotCount := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeoutCh:
+			fmt.Println()
+			return fmt.Errorf("deployment %s did not become ready within %v", deployName, pollTimeout)
+		case <-ticker.C:
+			deploy, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deployName, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("getting deployment: %w", err)
+			}
+
+			if deploy.Status.ReadyReplicas > 0 {
+				fmt.Println()
+				return nil
+			}
+
+			// Print dots to show progress
+			if dotCount%20 == 0 && dotCount > 0 {
+				fmt.Println()
+			}
+			fmt.Print(".")
+			dotCount++
+		}
+	}
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return
+	}
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	_ = cmd.Start()
+}
+
+var invalidNameChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// sanitizeResourceName ensures a name complies with Kubernetes DNS-1035 label requirements:
+// lowercase alphanumeric characters or '-', starting with an alphabetic character.
+func sanitizeResourceName(name string) string {
+	name = strings.ToLower(name)
+	name = invalidNameChars.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	// If the name starts with a digit, prefix with 'n'
+	if len(name) > 0 && name[0] >= '0' && name[0] <= '9' {
+		name = "n" + name
+	}
+	// If empty after sanitizing, use a fallback
+	if name == "" {
+		name = "default"
+	}
+	if len(name) > 50 {
+		name = name[:50]
+		name = strings.TrimRight(name, "-")
+	}
+	return name
+}

--- a/cmd/cli/cmd/llm/autobenchmark/dashboard.go
+++ b/cmd/cli/cmd/llm/autobenchmark/dashboard.go
@@ -40,6 +40,7 @@ import (
 
 	"sigs.k8s.io/rbgs/cmd/cli/util"
 	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/constant"
 )
 
 const (
@@ -100,6 +101,11 @@ func (o *dashboardOptions) run(ctx context.Context) error {
 		expName = o.name
 	}
 
+	// Validate experiment name for use as Kubernetes label value
+	if err := validateExpName(expName); err != nil {
+		return err
+	}
+
 	// Kubernetes client
 	clientset, err := util.GetK8SClientSet(o.cf)
 	if err != nil {
@@ -116,9 +122,14 @@ func (o *dashboardOptions) run(ctx context.Context) error {
 	deployName := fmt.Sprintf("abd-%s", safeName)
 	svcName := deployName
 
-	labels := map[string]string{
-		"app":        "auto-benchmark-dashboard",
-		"experiment": expName,
+	// Use sanitized name for selector labels to ensure DNS-1123 compliance
+	selectorLabels := map[string]string{
+		"app":                          "auto-benchmark-dashboard",
+		constant.AutoBenchmarkLabelKey: safeName,
+	}
+	// Store original name in annotations for display
+	annotations := map[string]string{
+		constant.AutoBenchmarkOriginalNameAnnotationKey: expName,
 	}
 
 	// --- Create Deployment ---
@@ -126,15 +137,16 @@ func (o *dashboardOptions) run(ctx context.Context) error {
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deployName,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        deployName,
+			Namespace:   namespace,
+			Labels:      selectorLabels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(1),
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -189,12 +201,13 @@ func (o *dashboardOptions) run(ctx context.Context) error {
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      svcName,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        svcName,
+			Namespace:   namespace,
+			Labels:      selectorLabels,
+			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: labels,
+			Selector: selectorLabels,
 			Ports: []corev1.ServicePort{
 				{
 					Port:       dashboardPort,

--- a/cmd/cli/cmd/llm/autobenchmark/list.go
+++ b/cmd/cli/cmd/llm/autobenchmark/list.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/constant"
+)
+
+func newListCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List auto-benchmark experiments",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(cmd.Context(), cf)
+		},
+	}
+	return cmd
+}
+
+func runList(ctx context.Context, cf *genericclioptions.ConfigFlags) error {
+	clientset, err := util.GetK8SClientSet(cf)
+	if err != nil {
+		return err
+	}
+
+	namespace := util.GetNamespace(cf)
+
+	jobs, err := clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: constant.AutoBenchmarkLabelKey,
+	})
+	if err != nil {
+		return fmt.Errorf("listing jobs: %w", err)
+	}
+
+	if len(jobs.Items) == 0 {
+		fmt.Printf("No auto-benchmark experiments found in namespace %q\n", namespace)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tSTATUS\tAGE")
+
+	for _, job := range jobs.Items {
+		status := "Running"
+		for _, c := range job.Status.Conditions {
+			if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+				status = "Completed"
+			} else if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+				status = "Failed"
+			}
+		}
+
+		age := metav1.Now().Sub(job.CreationTimestamp.Time)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", job.Name, status, formatDuration(age))
+	}
+
+	return w.Flush()
+}
+
+func formatDuration(d interface {
+	Hours() float64
+	Minutes() float64
+}) string {
+	h := int(d.Hours())
+	if h >= 24 {
+		return fmt.Sprintf("%dd", h/24)
+	}
+	if h > 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	m := int(d.Minutes())
+	if m > 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return "<1m"
+}

--- a/cmd/cli/cmd/llm/autobenchmark/logs.go
+++ b/cmd/cli/cmd/llm/autobenchmark/logs.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+)
+
+func newLogsCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	var follow bool
+
+	cmd := &cobra.Command{
+		Use:   "logs <experiment-name>",
+		Short: "Stream logs from an auto-benchmark controller",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogs(cmd.Context(), cf, args[0], follow)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
+
+	return cmd
+}
+
+func runLogs(ctx context.Context, cf *genericclioptions.ConfigFlags, expName string, follow bool) error {
+	clientset, err := util.GetK8SClientSet(cf)
+	if err != nil {
+		return err
+	}
+
+	namespace := util.GetNamespace(cf)
+
+	jobName := experimentToJobName(expName)
+
+	// Find the controller pod for this job
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "job-name=" + jobName,
+	})
+	if err != nil {
+		return fmt.Errorf("listing pods for job %q: %w", jobName, err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found for job %q", jobName)
+	}
+
+	podName := pods.Items[0].Name
+
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Follow: follow,
+	})
+
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("streaming logs from pod %q: %w", podName, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return fmt.Errorf("reading logs: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/cli/cmd/llm/autobenchmark/run.go
+++ b/cmd/cli/cmd/llm/autobenchmark/run.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/constant"
+)
+
+type runOptions struct {
+	cf             *genericclioptions.ConfigFlags
+	configFile     string
+	name           string
+	image          string
+	serviceAccount string
+}
+
+func newRunCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	opts := &runOptions{
+		cf:    cf,
+		image: controllerImage,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Start an auto-benchmark experiment",
+		Long: `Parse the auto-benchmark config, create a ConfigMap with all templates,
+and submit a controller Job that runs the experiment autonomously in the cluster.
+
+The controller Job requires a ServiceAccount with permissions to manage RoleBasedGroup resources.
+See the guide for RBAC setup instructions.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.configFile, "config", "f", "", "Path to auto-benchmark config file (required)")
+	cmd.Flags().StringVar(&opts.name, "name", "", "Experiment name (defaults to auto-generated name from config)")
+	cmd.Flags().StringVar(&opts.image, "image", controllerImage, "Controller image")
+	cmd.Flags().StringVar(&opts.serviceAccount, "service-account", "", "ServiceAccount for the controller Job (required)")
+	_ = cmd.MarkFlagRequired("config")
+	_ = cmd.MarkFlagRequired("service-account")
+
+	return cmd
+}
+
+func (o *runOptions) run(ctx context.Context) error {
+	// Parse and validate config
+	cfg, err := config.ParseFile(o.configFile)
+	if err != nil {
+		return fmt.Errorf("parsing config: %w", err)
+	}
+
+	// Override name from CLI flag if provided
+	if o.name != "" {
+		cfg.Name = o.name
+	}
+
+	// Resolve template paths relative to config file directory so that
+	// Validate's file-existence check and the subsequent ReadFile use
+	// the same absolute paths.
+	configDir := filepath.Dir(o.configFile)
+	for i, tmpl := range cfg.Templates {
+		if !filepath.IsAbs(tmpl.Template) {
+			cfg.Templates[i].Template = filepath.Join(configDir, tmpl.Template)
+		}
+	}
+
+	if err := config.Validate(cfg, true); err != nil {
+		return fmt.Errorf("validating config: %w", err)
+	}
+
+	expName := cfg.Name
+
+	clientset, err := util.GetK8SClientSet(o.cf)
+	if err != nil {
+		return fmt.Errorf("getting kubernetes client: %w", err)
+	}
+
+	namespace := util.GetNamespace(o.cf)
+
+	// Build ConfigMap data: config YAML + each template file
+	cmData := make(map[string]string)
+
+	for i, tmpl := range cfg.Templates {
+		data, err := os.ReadFile(tmpl.Template)
+		if err != nil {
+			return fmt.Errorf("reading template %q: %w", tmpl.Template, err)
+		}
+		// Use sanitized name as key
+		key := sanitizeCMKey(tmpl.Name + ".yaml")
+		cmData[key] = string(data)
+
+		// Rewrite template path to match ConfigMap mount location inside container
+		cfg.Templates[i].Template = "/etc/autobenchmark/" + key
+	}
+
+	// Marshal the modified config (with rewritten template paths) into ConfigMap
+	configYAML, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	cmData["config.yaml"] = string(configYAML)
+
+	// Create ConfigMap
+	cmName := fmt.Sprintf("ab-%s-config", strings.ToLower(expName))
+	if len(cmName) > 63 {
+		cmName = cmName[:63]
+	}
+	cmName = strings.TrimRight(cmName, "-")
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+			Labels:    map[string]string{constant.AutoBenchmarkLabelKey: expName},
+		},
+		Data: cmData,
+	}
+
+	if _, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("creating ConfigMap: %w", err)
+	}
+	fmt.Printf("Created ConfigMap %q\n", cmName)
+
+	// Create controller Job
+	jobName := fmt.Sprintf("ab-%s", strings.ToLower(expName))
+	if len(jobName) > 63 {
+		jobName = jobName[:63]
+	}
+	jobName = strings.TrimRight(jobName, "-")
+
+	backoffLimit := int32(0)
+	ttl := int32(86400 * 7) // 7 days
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constant.AutoBenchmarkLabelKey: expName,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttl,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: o.serviceAccount,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:  "controller",
+							Image: o.image,
+							// TODO: switch to ifnotpresent
+							ImagePullPolicy: corev1.PullAlways,
+							Command:         []string{"/autobenchmark"},
+							Args: []string{
+								"--config", "/etc/autobenchmark/config.yaml",
+								"--namespace", namespace,
+								"--data-dir", "/data",
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/etc/autobenchmark",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "data",
+									MountPath: "/data",
+									SubPath:   cfg.Results.SubPath,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+								},
+							},
+						},
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: cfg.Results.PVC,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("creating controller Job: %w", err)
+	}
+
+	fmt.Printf("Created auto-benchmark Job %q in namespace %q\n", jobName, namespace)
+	fmt.Printf("Monitor with: kubectl rbg llm auto-benchmark status %s\n", expName)
+	fmt.Printf("View logs with: kubectl rbg llm auto-benchmark logs %s\n", expName)
+	return nil
+}
+
+var invalidCMKeyChars = regexp.MustCompile(`[^-._a-zA-Z0-9]+`)
+
+func sanitizeCMKey(name string) string {
+	name = strings.ToLower(name)
+	name = invalidCMKeyChars.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	return name
+}

--- a/cmd/cli/cmd/llm/autobenchmark/run.go
+++ b/cmd/cli/cmd/llm/autobenchmark/run.go
@@ -100,6 +100,11 @@ func (o *runOptions) run(ctx context.Context) error {
 	}
 
 	expName := cfg.Name
+	if err := validateExpName(expName); err != nil {
+		return err
+	}
+	// Sanitize the experiment name for Kubernetes resource naming (DNS-1123)
+	safeName := sanitizeResourceName(expName)
 
 	clientset, err := util.GetK8SClientSet(o.cf)
 	if err != nil {
@@ -132,7 +137,7 @@ func (o *runOptions) run(ctx context.Context) error {
 	cmData["config.yaml"] = string(configYAML)
 
 	// Create ConfigMap
-	cmName := fmt.Sprintf("ab-%s-config", strings.ToLower(expName))
+	cmName := fmt.Sprintf("ab-%s-config", safeName)
 	if len(cmName) > 63 {
 		cmName = cmName[:63]
 	}
@@ -142,7 +147,10 @@ func (o *runOptions) run(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: namespace,
-			Labels:    map[string]string{constant.AutoBenchmarkLabelKey: expName},
+			Labels:    map[string]string{constant.AutoBenchmarkLabelKey: safeName},
+			Annotations: map[string]string{
+				constant.AutoBenchmarkOriginalNameAnnotationKey: expName,
+			},
 		},
 		Data: cmData,
 	}
@@ -153,7 +161,7 @@ func (o *runOptions) run(ctx context.Context) error {
 	fmt.Printf("Created ConfigMap %q\n", cmName)
 
 	// Create controller Job
-	jobName := fmt.Sprintf("ab-%s", strings.ToLower(expName))
+	jobName := fmt.Sprintf("ab-%s", safeName)
 	if len(jobName) > 63 {
 		jobName = jobName[:63]
 	}
@@ -167,7 +175,10 @@ func (o *runOptions) run(ctx context.Context) error {
 			Name:      jobName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				constant.AutoBenchmarkLabelKey: expName,
+				constant.AutoBenchmarkLabelKey: safeName,
+			},
+			Annotations: map[string]string{
+				constant.AutoBenchmarkOriginalNameAnnotationKey: expName,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -236,6 +247,24 @@ func (o *runOptions) run(ctx context.Context) error {
 }
 
 var invalidCMKeyChars = regexp.MustCompile(`[^-._a-zA-Z0-9]+`)
+
+// validateExpName validates the experiment name for use as a Kubernetes label value.
+// Label values must be 63 characters or less and contain only alphanumeric characters,
+// '-', '_', or '.'.
+func validateExpName(name string) error {
+	if name == "" {
+		return fmt.Errorf("experiment name cannot be empty")
+	}
+	if len(name) > 63 {
+		return fmt.Errorf("experiment name %q exceeds 63 character limit (length: %d)", name, len(name))
+	}
+	// Kubernetes label values: alphanumeric, '-', '_', '.'
+	validLabelValueChars := regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	if !validLabelValueChars.MatchString(name) {
+		return fmt.Errorf("experiment name %q contains invalid characters; only alphanumeric, '-', '_', '.' are allowed", name)
+	}
+	return nil
+}
 
 func sanitizeCMKey(name string) string {
 	name = strings.ToLower(name)

--- a/cmd/cli/cmd/llm/autobenchmark/run.go
+++ b/cmd/cli/cmd/llm/autobenchmark/run.go
@@ -179,10 +179,9 @@ func (o *runOptions) run(ctx context.Context) error {
 					RestartPolicy:      corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{
-							Name:  "controller",
-							Image: o.image,
-							// TODO: switch to ifnotpresent
-							ImagePullPolicy: corev1.PullAlways,
+							Name:            "controller",
+							Image:           o.image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/autobenchmark"},
 							Args: []string{
 								"--config", "/etc/autobenchmark/config.yaml",

--- a/cmd/cli/cmd/llm/autobenchmark/status.go
+++ b/cmd/cli/cmd/llm/autobenchmark/status.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+)
+
+func newStatusCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <experiment-name>",
+		Short: "Show status of an auto-benchmark experiment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(cmd.Context(), cf, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runStatus(ctx context.Context, cf *genericclioptions.ConfigFlags, expName string) error {
+	clientset, err := util.GetK8SClientSet(cf)
+	if err != nil {
+		return err
+	}
+
+	namespace := util.GetNamespace(cf)
+
+	jobName := experimentToJobName(expName)
+	job, err := clientset.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting job %q: %w", jobName, err)
+	}
+
+	// Print basic job info
+	fmt.Printf("Name:      %s\n", job.Name)
+	fmt.Printf("Namespace: %s\n", job.Namespace)
+	fmt.Printf("Created:   %s\n", job.CreationTimestamp.Format("2006-01-02 15:04:05"))
+
+	// Print status
+	status := "Running"
+	for _, c := range job.Status.Conditions {
+		if c.Type == "Complete" && c.Status == "True" {
+			status = "Completed"
+		} else if c.Type == "Failed" && c.Status == "True" {
+			status = fmt.Sprintf("Failed: %s", c.Message)
+		}
+	}
+	fmt.Printf("Status:    %s\n", status)
+
+	return nil
+}

--- a/cmd/cli/cmd/llm/autobenchmark/stop.go
+++ b/cmd/cli/cmd/llm/autobenchmark/stop.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autobenchmark
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"sigs.k8s.io/rbgs/cmd/cli/util"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/constant"
+)
+
+func newStopCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop <experiment-name>",
+		Short: "Stop an auto-benchmark experiment",
+		Long:  `Deletes the controller Job and cleans up any active trial RBGs.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStop(cmd.Context(), cf, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runStop(ctx context.Context, cf *genericclioptions.ConfigFlags, expName string) error {
+	clientset, err := util.GetK8SClientSet(cf)
+	if err != nil {
+		return err
+	}
+
+	namespace := util.GetNamespace(cf)
+	labelSelector := fmt.Sprintf("%s=%s", constant.AutoBenchmarkLabelKey, expName)
+
+	// Delete controller Job(s) by experiment label
+	jobList, err := clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("listing jobs: %w", err)
+	}
+	propagation := metav1.DeletePropagationForeground
+	for _, job := range jobList.Items {
+		if err := clientset.BatchV1().Jobs(namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+			PropagationPolicy: &propagation,
+		}); err != nil {
+			fmt.Printf("Warning: failed to delete Job %q: %v\n", job.Name, err)
+		} else {
+			fmt.Printf("Deleted Job %q\n", job.Name)
+		}
+	}
+	if len(jobList.Items) == 0 {
+		// Fallback: try the conventional name directly.
+		jobName := experimentToJobName(expName)
+		if err := clientset.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{
+			PropagationPolicy: &propagation,
+		}); err != nil {
+			fmt.Printf("Warning: Job %q not found: %v\n", jobName, err)
+		} else {
+			fmt.Printf("Deleted Job %q\n", jobName)
+		}
+	}
+
+	// Clean up ConfigMap(s) by experiment label
+	cmList, err := clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		fmt.Printf("Warning: could not list ConfigMaps: %v\n", err)
+	} else {
+		for _, cm := range cmList.Items {
+			if err := clientset.CoreV1().ConfigMaps(namespace).Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil {
+				fmt.Printf("Warning: failed to delete ConfigMap %q: %v\n", cm.Name, err)
+			} else {
+				fmt.Printf("Deleted ConfigMap %q\n", cm.Name)
+			}
+		}
+	}
+
+	// Clean up trial RBGs by label
+	rbgClient, err := util.GetRBGClient(cf)
+	if err != nil {
+		fmt.Printf("Warning: could not get RBG client for cleanup: %v\n", err)
+		return nil
+	}
+
+	rbgs, err := rbgClient.WorkloadsV1alpha2().RoleBasedGroups(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		fmt.Printf("Warning: could not list trial RBGs: %v\n", err)
+		return nil
+	}
+
+	for _, rbg := range rbgs.Items {
+		if err := rbgClient.WorkloadsV1alpha2().RoleBasedGroups(namespace).Delete(ctx, rbg.Name, metav1.DeleteOptions{}); err != nil {
+			fmt.Printf("Warning: failed to delete trial RBG %q: %v\n", rbg.Name, err)
+		} else {
+			fmt.Printf("Deleted trial RBG %q\n", rbg.Name)
+		}
+	}
+
+	return nil
+}

--- a/cmd/cli/cmd/llm/llm.go
+++ b/cmd/cli/cmd/llm/llm.go
@@ -19,6 +19,7 @@ package llm
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/rbgs/cmd/cli/cmd/llm/autobenchmark"
 	"sigs.k8s.io/rbgs/cmd/cli/cmd/llm/benchmark"
 	"sigs.k8s.io/rbgs/cmd/cli/cmd/llm/config"
 	"sigs.k8s.io/rbgs/cmd/cli/cmd/llm/generate"
@@ -45,6 +46,7 @@ func NewLLMCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 	cmd.AddCommand(config.NewConfigCmd(cf))
 	cmd.AddCommand(generate.NewGenerateCmd())
 	cmd.AddCommand(benchmark.NewBenchmarkCmd(cf))
+	cmd.AddCommand(autobenchmark.NewAutoBenchmarkCmd(cf))
 
 	return cmd
 }

--- a/cmd/cli/cmd/llm/llm_test.go
+++ b/cmd/cli/cmd/llm/llm_test.go
@@ -50,7 +50,7 @@ func TestNewLLMCmd_HasExpectedSubcommands(t *testing.T) {
 func TestNewLLMCmd_SubcommandCount(t *testing.T) {
 	cf := genericclioptions.NewConfigFlags(true)
 	cmd := NewLLMCmd(cf)
-	assert.Equal(t, 5, len(cmd.Commands()))
+	assert.Equal(t, 6, len(cmd.Commands()))
 }
 
 func TestNewLLMCmd_SVCSubcommand_Exists(t *testing.T) {

--- a/cmd/cli/cmd/llm/svc/chat/chat_test.go
+++ b/cmd/cli/cmd/llm/svc/chat/chat_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The RBG Authors.
+Copyright 2026 The RBG Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/cli/plugin/storage/interface.go
+++ b/cmd/cli/plugin/storage/interface.go
@@ -81,9 +81,6 @@ type Plugin interface {
 	// Init initializes storage with config.
 	Init(config map[string]interface{}) error
 
-	// Exists checks if the model already exists in storage.
-	Exists(modelID string) (bool, error)
-
 	// MountStorage provisions any required Kubernetes resources (e.g., Secret, PV, PVC)
 	// and modifies the PodTemplateSpec to add volumes and mounts.
 	// The volume is mounted at the path specified by opts.MountPath.

--- a/cmd/cli/plugin/storage/oss.go
+++ b/cmd/cli/plugin/storage/oss.go
@@ -107,12 +107,6 @@ func (o *OSSStorage) Init(config map[string]interface{}) error {
 	return nil
 }
 
-// Exists checks if the model exists in storage
-func (o *OSSStorage) Exists(modelID string) (bool, error) {
-	// TODO: Implement actual check via OSS API
-	return false, nil
-}
-
 // PreMount verifies PV and PVC resources exist. Secret is expected to already exist
 // (created by PreAdd) and is referenced via secretName/secretNamespace.
 func (o *OSSStorage) preMount(c client.Client, storageName, namespace string) error {

--- a/cmd/cli/plugin/storage/oss_test.go
+++ b/cmd/cli/plugin/storage/oss_test.go
@@ -165,13 +165,6 @@ func TestOSSStorage_Init_StorageSizeFixed(t *testing.T) {
 	assert.Equal(t, "1Ti", p.storageSize, "storageSize should always be 1Ti")
 }
 
-func TestOSSStorage_Exists(t *testing.T) {
-	p := &OSSStorage{}
-	exists, err := p.Exists("any-model")
-	require.NoError(t, err)
-	assert.False(t, exists)
-}
-
 // testOSSWithSecretRef creates an OSSStorage with secretName/secretNamespace for testing
 func testOSSWithSecretRef() *OSSStorage {
 	return &OSSStorage{

--- a/cmd/cli/plugin/storage/pvc.go
+++ b/cmd/cli/plugin/storage/pvc.go
@@ -57,12 +57,6 @@ func (p *PVCStorage) Init(config map[string]interface{}) error {
 	return nil
 }
 
-// Exists checks if the model exists in storage
-func (p *PVCStorage) Exists(modelID string) (bool, error) {
-	// TODO: Implement actual check
-	return false, nil
-}
-
 // MountStorage mounts the pre-existing PVC to the pod template.
 // PVC must be created separately before running the workload; this plugin does not provision it.
 func (p *PVCStorage) MountStorage(podTemplate *corev1.PodTemplateSpec, opts MountOptions) error {

--- a/cmd/cli/plugin/storage/pvc_test.go
+++ b/cmd/cli/plugin/storage/pvc_test.go
@@ -58,13 +58,6 @@ func TestPVCStorage_Init_OK(t *testing.T) {
 	assert.Equal(t, "my-pvc", p.pvcName)
 }
 
-func TestPVCStorage_Exists(t *testing.T) {
-	p := &PVCStorage{pvcName: "my-pvc"}
-	exists, err := p.Exists("any-model")
-	require.NoError(t, err)
-	assert.False(t, exists)
-}
-
 func TestPVCStorage_MountStorage_AddsVolumeAndMount(t *testing.T) {
 	p := &PVCStorage{pvcName: "my-pvc"}
 

--- a/examples/cli/auto-benchmark/README.md
+++ b/examples/cli/auto-benchmark/README.md
@@ -1,0 +1,211 @@
+# Auto Benchmark Example
+
+This example demonstrates how to use RBG's auto-benchmark feature to automatically tune LLM serving parameters for optimal performance.
+
+## Overview
+
+Auto-benchmark uses Bayesian optimization (TPE algorithm) to search through parameter combinations, benchmark each configuration, and find the optimal settings that maximize throughput while meeting SLA constraints (TTFT, TPOT, error rate).
+
+## Files in This Directory
+
+| File | Description |
+|------|-------------|
+| `README.md` | This documentation |
+| `config.yaml` | Auto-benchmark configuration (search space, workloads, objectives) |
+| `template.yaml` | RBG template defining the model serving deployment |
+
+## Prerequisites
+
+- RBG CLI installed (`kubectl rbg`)
+- Kubernetes cluster with GPU nodes
+- PVC for storing benchmark results
+- Docker/Buildah for building images (or use pre-built images)
+
+## Build Images
+
+Two images need to be built: the auto-benchmark controller and the dashboard UI.
+
+### Auto-Benchmark Controller Image
+
+```bash
+docker build -f cmd/autobenchmark/Dockerfile \
+  -t <your-registry>/rbgs-auto-benchmark:<tag> \
+  .
+```
+
+This image includes:
+- Auto-benchmark Go controller binary
+- Python runtime with genai-bench and optuna
+- Optuna bridge script for Bayesian optimization
+
+Push to your registry:
+
+```bash
+docker push <your-registry>/rbgs-auto-benchmark:<tag>
+```
+
+### Dashboard UI Image
+
+```bash
+cd ui/benchmark-viewer
+docker build -t <your-registry>/rbgs-ab-dashboard:<tag> .
+docker push <your-registry>/rbgs-ab-dashboard:<tag>
+```
+
+This is a multi-stage build (Node.js → Nginx) serving the React dashboard.
+
+## Quick Start
+
+### Step 1: Prepare RBAC
+
+```bash
+kubectl create -f - << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: auto-benchmark-role
+rules:
+- apiGroups:
+  - workloads.x-k8s.io
+  resources:
+  - rolebasedgroups
+  verbs:
+  - get
+  - create
+  - delete
+EOF
+
+kubectl create -f - << EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: auto-benchmark-controller
+EOF
+
+kubectl create -f - << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: auto-benchmark-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: auto-benchmark-role
+subjects:
+- kind: ServiceAccount
+  name: auto-benchmark-controller
+EOF
+```
+
+### Step 2: Customize Configuration
+
+Edit `config.yaml` to match your environment:
+
+- **templates**: Reference your RBG template file
+- **backend**: Set to `sglang` or `vllm`
+- **searchSpace**: Define parameter ranges to explore
+- **scenarios**: Configure workload patterns and concurrency levels
+- **objectives**: Set SLA constraints and optimization target
+- **evaluator**: Configure tokenizer path
+- **results**: Specify PVC for storing results
+
+### Step 3: Run Auto-Benchmark
+
+```bash
+kubectl rbg llm auto-benchmark run \
+  -f config.yaml \
+  --name qwen3-8b \
+  --service-account auto-benchmark-controller \
+  --image <your-auto-benchmark-image>
+```
+
+The command will:
+1. Parse config.yaml and generate trial combinations
+2. Create RBG deployments for each trial
+3. Run benchmarks and collect metrics
+4. Use TPE algorithm to guide next trials toward better parameters
+5. Store all results in the configured PVC
+
+### Step 4: View Dashboard
+
+While the experiment is running (or after completion), view results:
+
+```bash
+kubectl rbg llm auto-benchmark dashboard <experiment-name> \
+  -f config.yaml \
+  --image <your-dashboard-image>
+```
+
+This will:
+- Create a temporary dashboard deployment
+- Port-forward to your local machine
+- Auto-open browser with results
+- Clean up on exit (Ctrl+C)
+
+### Step 5: Stop Experiment (Optional)
+
+```bash
+kubectl rbg llm auto-benchmark stop <experiment-name>
+```
+
+## Configuration Highlights
+
+### Search Space
+
+```yaml
+searchSpace:
+  default:
+    gpuMemoryUtilization: [0.70, 0.80, 0.90, 0.95]
+    maxNumSeqs: [256, 512, 1024, 2048]
+    chunkedPrefillSize: [512, 2048, 8192]
+```
+
+Parameters are mapped to the serving engine's CLI flags automatically (see `mapper.go`).
+
+### Workload Scenario
+
+```yaml
+scenario:
+  name: chat
+  workloads:
+  - "normal(512,256/2048,1024)"
+  concurrency: [64, 128, 256]
+  duration: 3m
+  maxRequests: 500
+```
+
+- **workloads**: `normal(mean, stddev/min,max/output)` - 输入长度正态分布 (均值 512, 标准差 256, 范围 256-2048)，输出固定 1024
+- **concurrency**: 在每个并发级别 (64, 128, 256) 分别运行 benchmark
+- **duration**: 每个 trial 持续 3 分钟
+- **maxRequests**: 最多发送 500 个请求
+
+### SLA Constraints
+
+```yaml
+objectives:
+  sla:
+    ttftP99MaxMs: 2000       # TTFT P99 ≤ 2000ms
+    tpotP99MaxMs: 15         # TPOT P99 ≤ 15ms
+    errorRateMax: 0.01       # Error rate ≤ 1%
+  optimize: outputThroughput # Maximize throughput within SLA
+```
+
+Trials violating SLA constraints are marked as failed regardless of throughput.
+
+## Dashboard Features
+
+- **Overview**: Experiment summary, best trial, parameter rankings
+- **Parallel Coordinates**: Visualize parameter-performance relationships
+- **Parameter Impact**: See which parameters affect scores most
+- **Raw Data**: Full trial details in JSON format
+- **Score Distribution**: Histogram of trial scores
+
+Color coding: 🟢 Green = good (low ratio), 🔴 Red = poor (high ratio), based on optimization direction.
+
+## Tips
+
+- Use **mixed-length workloads** (`normal` or `uniform`) instead of `fixed` to see parameter differences
+- Higher concurrency levels (128, 256) are needed to saturate GPU and expose bottlenecks
+- Expand parameter ranges for more pronounced performance differences
+- Longer durations (5m+) provide more stable measurements
+- The dashboard auto-opens in browser and cleans up on exit

--- a/examples/cli/auto-benchmark/README.md
+++ b/examples/cli/auto-benchmark/README.md
@@ -155,9 +155,15 @@ kubectl rbg llm auto-benchmark stop <experiment-name>
 ```yaml
 searchSpace:
   default:
-    gpuMemoryUtilization: [0.70, 0.80, 0.90, 0.95]
-    maxNumSeqs: [256, 512, 1024, 2048]
-    chunkedPrefillSize: [512, 2048, 8192]
+    gpuMemoryUtilization:
+      type: categorical
+      values: [0.70, 0.80, 0.90, 0.95]
+    maxNumSeqs:
+      type: categorical
+      values: [256, 512, 1024, 2048]
+    chunkedPrefillSize:
+      type: categorical
+      values: [512, 2048, 8192]
 ```
 
 Parameters are mapped to the serving engine's CLI flags automatically (see `mapper.go`).

--- a/examples/cli/auto-benchmark/config.yaml
+++ b/examples/cli/auto-benchmark/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: rbg.io/v1
+kind: AutoBenchmarkConfig
+
+# 实验名称（可选，不指定则自动生成 "exp-{timestamp}"）
+# 所有输出归入 PVC 上的 /data/{name}/ 目录
+name: my-experiment
+
+# 引用 RBG template 文件
+templates:
+- name: single
+  template: ./template.yaml
+
+# 推理引擎 backend
+backend: sglang   # sglang | vllm
+
+# 参数搜索空间（覆盖 template 中 container command 的对应 flag）
+searchSpace:
+  default:                           # "default" 应用于所有 role
+    gpuMemoryUtilization:
+      type: categorical
+      values: [0.70, 0.80, 0.90, 0.95]
+    maxNumSeqs:
+      type: categorical
+      values: [256, 512, 1024, 2048]
+    chunkedPrefillSize:
+      type: categorical
+      values: [512, 2048, 8192]
+    schedulePolicy:
+      type: categorical
+      values: ["lpm", "dfs-weight", "random"]
+
+# 固定的 benchmark workload 场景（单一场景）
+scenario:
+  name: chat
+  workloads:
+  - "normal(512,256/2048,1024)"
+  concurrency: [64, 128, 256]
+  duration: 3m
+  maxRequests: 500
+
+# 优化目标和 SLA 约束
+objectives:
+  sla:
+    ttftP99MaxMs: 2000       # TTFT P99 ≤ 2000ms
+    tpotP99MaxMs: 15         # TPOT P99 ≤ 15ms
+    errorRateMax: 0.01       # Error rate ≤ 1%
+  optimize: outputThroughput # 在满足 SLA 前提下最大化此指标
+                             # 可选: outputThroughput | inputThroughput | requestsPerSecond
+
+# 搜索策略
+strategy:
+  algorithm: tpe             # grid | tpe | gp | cmaes | random | qmc | nsgaii | nsgaiii
+  maxTrialsPerTemplate: 20   # 每个 template 最多试验次数
+  earlyStopPatience: 5       # 连续 N 次无改善则跳过当前 template
+  timeout: 4h                # 总超时
+# 评估工具配置
+evaluator:
+  type: genai-bench
+  config:
+    tokenizerSource: Qwen/Qwen3-8B  # genai-bench --model-tokenizer（必填，HuggingFace ID 或本地路径）
+
+# 结果存储 PVC
+results:
+  pvc: oss1-lj
+  subPath: auto-benchmark    # PVC 内子路径，数据存储到 /data/ 对应 PVC 的此子目录
+
+# 运行时参数
+execution:
+  rbgReadyTimeout: 15m       # 等待 RBG ready 超时
+  trialTimeout: 30m          # 单次 trial 超时

--- a/examples/cli/auto-benchmark/template.yaml
+++ b/examples/cli/auto-benchmark/template.yaml
@@ -1,0 +1,74 @@
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: qwen3-8b
+spec:
+  roles:
+  - minReadySeconds: 0
+    name: inference
+    podManagementPolicy: Parallel
+    replicas: 1
+    servicePorts:
+    - name: http
+      port: 30000
+      targetPort: 30000
+      protocol: TCP
+    standalonePattern:
+      template:
+        metadata:
+          labels:
+            rbg.workloads.x-k8s.io/source: rbgcli
+        spec:
+          # tolerations:
+          # - key: "node-role.alibabacloud.com/lingjun"
+          #   operator: "Exists"
+          #   effect: "NoSchedule"
+          containers:
+          - args:
+            - --model-path
+            - /models/qwen-qwen3-8b/main
+            - --served-model-name
+            - qwen3-8b
+            - --host
+            - 0.0.0.0
+            - --port
+            - "30000"
+            command:
+            - python
+            - -m
+            - sglang.launch_server
+            env:
+            - name: SGLANG_MODEL_PATH
+              value: /models/qwen-qwen3-8b/main
+            image: lmsysorg/sglang:v0.5.10.post1
+            imagePullPolicy: IfNotPresent
+            name: sglang
+            ports:
+            - containerPort: 30000
+              name: http
+              protocol: TCP
+            resources:
+              limits:
+                cpu: "2"
+                memory: 48Gi
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "2"
+                memory: 48Gi
+                nvidia.com/gpu: "1"
+            volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /models
+              name: model-storage
+          volumes:
+          - emptyDir:
+              medium: Memory
+              sizeLimit: 16Gi
+            name: shm
+          - name: model-storage
+            persistentVolumeClaim:
+              claimName: oss1-lj
+    workload:
+      apiVersion: workloads.x-k8s.io/v1alpha2
+      kind: RoleInstanceSet

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/appscode/jsonpatch v1.0.1
 	github.com/chzyer/readline v1.5.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
@@ -56,7 +57,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/autobenchmark/config/parse.go
+++ b/pkg/autobenchmark/config/parse.go
@@ -208,7 +208,7 @@ func validateSearchParam(role, name string, param SearchParam) error {
 		if param.Min == nil || param.Max == nil || param.Step == nil {
 			return fmt.Errorf("%s: range type requires min, max, and step", prefix)
 		}
-		if *param.Min >= *param.Max {
+		if *param.Min > *param.Max {
 			return fmt.Errorf("%s: min (%v) must be less than max (%v)", prefix, *param.Min, *param.Max)
 		}
 		if *param.Step <= 0 {

--- a/pkg/autobenchmark/config/parse.go
+++ b/pkg/autobenchmark/config/parse.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseFile reads and parses an AutoBenchmarkConfig from a YAML file.
+func ParseFile(path string) (*AutoBenchmarkConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+	return Parse(data)
+}
+
+// Parse parses an AutoBenchmarkConfig from YAML bytes.
+func Parse(data []byte) (*AutoBenchmarkConfig, error) {
+	var cfg AutoBenchmarkConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if err := setDefaults(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Validate validates the AutoBenchmarkConfig.
+// When validateFiles is true, it also checks that template file paths exist on disk.
+func Validate(cfg *AutoBenchmarkConfig, validateFiles bool) error {
+	var errs []string
+
+	errs = append(errs, validateRequiredFields(cfg)...)
+	errs = append(errs, validateEnumFields(cfg)...)
+	errs = append(errs, validateTemplates(cfg, validateFiles)...)
+	errs = append(errs, validateSearchSpace(cfg)...)
+	errs = append(errs, validateScenario(cfg)...)
+	errs = append(errs, validateStrategy(cfg)...)
+	errs = append(errs, validateEvaluator(cfg)...)
+	errs = append(errs, validateResults(cfg)...)
+	errs = append(errs, validateExecution(cfg)...)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("config validation errors:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+func validateRequiredFields(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if len(cfg.Templates) == 0 {
+		errs = append(errs, "templates: at least one template is required")
+	}
+	if cfg.Backend == "" {
+		errs = append(errs, "backend: is required")
+	}
+	if len(cfg.SearchSpace) == 0 {
+		errs = append(errs, "searchSpace: is required")
+	}
+	if cfg.Scenario.Name == "" {
+		errs = append(errs, "scenario.name: is required")
+	}
+	if cfg.Objectives.Optimize == "" {
+		errs = append(errs, "objectives.optimize: is required")
+	}
+	return errs
+}
+
+func validateEnumFields(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if cfg.Backend != "" && !slices.Contains(SupportedBackends, cfg.Backend) {
+		errs = append(errs, fmt.Sprintf("backend: unsupported value %q, must be one of %v", cfg.Backend, SupportedBackends))
+	}
+	if cfg.Strategy.Algorithm != "" && !slices.Contains(SupportedAlgorithms, cfg.Strategy.Algorithm) {
+		errs = append(errs, fmt.Sprintf("strategy.algorithm: unsupported value %q, must be one of %v", cfg.Strategy.Algorithm, SupportedAlgorithms))
+	}
+	if cfg.Objectives.Optimize != "" && !slices.Contains(SupportedOptimizeMetrics, cfg.Objectives.Optimize) {
+		errs = append(errs, fmt.Sprintf("objectives.optimize: unsupported value %q, must be one of %v", cfg.Objectives.Optimize, SupportedOptimizeMetrics))
+	}
+	return errs
+}
+
+func validateTemplates(cfg *AutoBenchmarkConfig, validateFiles bool) []string {
+	var errs []string
+	templateNames := make(map[string]bool)
+	for i, t := range cfg.Templates {
+		if t.Name == "" {
+			errs = append(errs, fmt.Sprintf("templates[%d].name: is required", i))
+		} else if templateNames[t.Name] {
+			errs = append(errs, fmt.Sprintf("templates[%d].name: duplicate name %q", i, t.Name))
+		} else {
+			templateNames[t.Name] = true
+		}
+		if t.Template == "" {
+			errs = append(errs, fmt.Sprintf("templates[%d].template: is required", i))
+		} else if validateFiles {
+			if _, err := os.Stat(t.Template); os.IsNotExist(err) {
+				errs = append(errs, fmt.Sprintf("templates[%d].template: file not found: %s", i, t.Template))
+			}
+		}
+	}
+	return errs
+}
+
+func validateSearchSpace(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	for role, params := range cfg.SearchSpace {
+		for name, param := range params {
+			if err := validateSearchParam(role, name, param); err != nil {
+				errs = append(errs, err.Error())
+			}
+		}
+	}
+	return errs
+}
+
+func validateScenario(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if len(cfg.Scenario.Workloads) == 0 {
+		errs = append(errs, "scenario.workloads: at least one is required")
+	}
+	for i, w := range cfg.Scenario.Workloads {
+		if err := ValidateWorkload(w); err != nil {
+			errs = append(errs, fmt.Sprintf("scenario.workloads[%d]: %v", i, err))
+		}
+	}
+	if len(cfg.Scenario.Concurrency) == 0 {
+		errs = append(errs, "scenario.concurrency: at least one is required")
+	}
+	if cfg.Scenario.Duration != "" {
+		if _, err := time.ParseDuration(cfg.Scenario.Duration); err != nil {
+			errs = append(errs, fmt.Sprintf("scenario.duration: invalid duration: %v", err))
+		}
+	}
+	return errs
+}
+
+func validateStrategy(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if cfg.Strategy.MaxTrialsPerTemplate <= 0 {
+		errs = append(errs, "strategy.maxTrialsPerTemplate: must be positive")
+	}
+	if cfg.Strategy.Timeout != "" {
+		if _, err := time.ParseDuration(cfg.Strategy.Timeout); err != nil {
+			errs = append(errs, fmt.Sprintf("strategy.timeout: invalid duration: %v", err))
+		}
+	}
+	return errs
+}
+
+func validateEvaluator(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if cfg.Evaluator.Type == "" {
+		errs = append(errs, "evaluator.type: is required")
+	}
+	return errs
+}
+
+func validateResults(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if cfg.Results.PVC == "" {
+		errs = append(errs, "results.pvc: is required")
+	}
+	return errs
+}
+
+func validateExecution(cfg *AutoBenchmarkConfig) []string {
+	var errs []string
+	if cfg.Execution.RBGReadyTimeout != "" {
+		if _, err := time.ParseDuration(cfg.Execution.RBGReadyTimeout); err != nil {
+			errs = append(errs, fmt.Sprintf("execution.rbgReadyTimeout: invalid duration: %v", err))
+		}
+	}
+	if cfg.Execution.TrialTimeout != "" {
+		if _, err := time.ParseDuration(cfg.Execution.TrialTimeout); err != nil {
+			errs = append(errs, fmt.Sprintf("execution.trialTimeout: invalid duration: %v", err))
+		}
+	}
+	return errs
+}
+
+func validateSearchParam(role, name string, param SearchParam) error {
+	prefix := fmt.Sprintf("searchSpace.%s.%s", role, name)
+	switch param.Type {
+	case "range":
+		if param.Min == nil || param.Max == nil || param.Step == nil {
+			return fmt.Errorf("%s: range type requires min, max, and step", prefix)
+		}
+		if *param.Min >= *param.Max {
+			return fmt.Errorf("%s: min (%v) must be less than max (%v)", prefix, *param.Min, *param.Max)
+		}
+		if *param.Step <= 0 {
+			return fmt.Errorf("%s: step must be positive, got %v", prefix, *param.Step)
+		}
+	case "categorical":
+		if len(param.Values) == 0 {
+			return fmt.Errorf("%s: categorical type requires at least one value", prefix)
+		}
+	default:
+		return fmt.Errorf("%s: unsupported type %q, must be \"range\" or \"categorical\"", prefix, param.Type)
+	}
+	return nil
+}
+
+func setDefaults(cfg *AutoBenchmarkConfig) error {
+	if cfg.Name == "" {
+		cfg.Name = fmt.Sprintf("exp-%d", time.Now().UnixMilli())
+	}
+	if cfg.Strategy.Algorithm == "" {
+		cfg.Strategy.Algorithm = "grid"
+	}
+	if cfg.Strategy.MaxTrialsPerTemplate == 0 {
+		cfg.Strategy.MaxTrialsPerTemplate = 20
+	}
+	if cfg.Strategy.Timeout == "" {
+		cfg.Strategy.Timeout = "4h"
+	}
+	if cfg.Execution.RBGReadyTimeout == "" {
+		cfg.Execution.RBGReadyTimeout = "15m"
+	}
+	if cfg.Execution.TrialTimeout == "" {
+		cfg.Execution.TrialTimeout = "30m"
+	}
+	return nil
+}

--- a/pkg/autobenchmark/config/parse_test.go
+++ b/pkg/autobenchmark/config/parse_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fullValidConfig() string {
+	return `
+apiVersion: rbg/v1alpha1
+kind: AutoBenchmarkConfig
+
+templates:
+  - name: "agg-tp4"
+    template: "./templates/agg-tp4.yaml"
+  - name: "disagg-pd"
+    template: "./templates/disagg-pd.yaml"
+
+backend: "sglang"
+
+searchSpace:
+  default:
+    gpuMemoryUtilization:
+      type: "categorical"
+      values: [0.85, 0.90, 0.95]
+    maxNumSeqs:
+      type: "range"
+      min: 64
+      max: 512
+      step: 64
+
+scenario:
+  name: "test-load"
+  workloads: ["fixed(512,256)"]
+  concurrency: [16, 32]
+  duration: "10m"
+
+objectives:
+  sla:
+    ttftP99MaxMs: 2000
+    tpotP99MaxMs: 50
+    errorRateMax: 0.01
+  optimize: "outputThroughput"
+
+strategy:
+  algorithm: "grid"
+  maxTrialsPerTemplate: 10
+  earlyStopPatience: 3
+  timeout: "2h"
+
+evaluator:
+  type: "genai-bench"
+
+results:
+  pvc: "pvc://auto-bench-results/"
+
+execution:
+  rbgReadyTimeout: "10m"
+  trialTimeout: "20m"
+`
+}
+
+func TestParse_FullValidConfig(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+
+	assert.Equal(t, "rbg/v1alpha1", cfg.APIVersion)
+	assert.Equal(t, "AutoBenchmarkConfig", cfg.Kind)
+	assert.Len(t, cfg.Templates, 2)
+	assert.Equal(t, "agg-tp4", cfg.Templates[0].Name)
+	assert.Equal(t, "./templates/agg-tp4.yaml", cfg.Templates[0].Template)
+	assert.Equal(t, "sglang", cfg.Backend)
+	assert.Contains(t, cfg.SearchSpace, "default")
+	assert.Contains(t, cfg.SearchSpace["default"], "gpuMemoryUtilization")
+	assert.Equal(t, "categorical", cfg.SearchSpace["default"]["gpuMemoryUtilization"].Type)
+	assert.Equal(t, "test-load", cfg.Scenario.Name)
+	assert.Equal(t, "outputThroughput", cfg.Objectives.Optimize)
+	assert.Equal(t, "grid", cfg.Strategy.Algorithm)
+	assert.Equal(t, 10, cfg.Strategy.MaxTrialsPerTemplate)
+	assert.Equal(t, "genai-bench", cfg.Evaluator.Type)
+	assert.Equal(t, "pvc://auto-bench-results/", cfg.Results.PVC)
+}
+
+func TestParse_Defaults(t *testing.T) {
+	yamlData := `
+templates:
+  - name: "t1"
+    template: "./t1.yaml"
+backend: "sglang"
+searchSpace:
+  default:
+    x:
+      type: "categorical"
+      values: [1, 2]
+scenario:
+  name: "s"
+  workloads: ["fixed(100,50)"]
+  concurrency: [1]
+objectives:
+  optimize: "outputThroughput"
+evaluator:
+  type: "genai-bench"
+results:
+  pvc: "pvc://results/"
+`
+	cfg, err := Parse([]byte(yamlData))
+	require.NoError(t, err)
+
+	assert.Equal(t, "grid", cfg.Strategy.Algorithm)
+	assert.Equal(t, 20, cfg.Strategy.MaxTrialsPerTemplate)
+	assert.Equal(t, "4h", cfg.Strategy.Timeout)
+	assert.Equal(t, "15m", cfg.Execution.RBGReadyTimeout)
+	assert.Equal(t, "30m", cfg.Execution.TrialTimeout)
+}
+
+func TestValidate_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(cfg *AutoBenchmarkConfig)
+		wantErr string
+	}{
+		{
+			name:    "missing templates",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Templates = nil },
+			wantErr: "templates: at least one template is required",
+		},
+		{
+			name:    "missing backend",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Backend = "" },
+			wantErr: "backend: is required",
+		},
+		{
+			name:    "missing searchSpace",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.SearchSpace = nil },
+			wantErr: "searchSpace: is required",
+		},
+		{
+			name:    "missing scenario name",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Scenario.Name = "" },
+			wantErr: "scenario.name: is required",
+		},
+		{
+			name:    "missing objectives.optimize",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Objectives.Optimize = "" },
+			wantErr: "objectives.optimize: is required",
+		},
+		{
+			name:    "missing evaluator.type",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Evaluator.Type = "" },
+			wantErr: "evaluator.type: is required",
+		},
+		{
+			name:    "missing results.pvc",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Results.PVC = "" },
+			wantErr: "results.pvc: is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Parse([]byte(fullValidConfig()))
+			require.NoError(t, err)
+			tt.modify(cfg)
+			err = Validate(cfg, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidate_UnsupportedBackend(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Backend = "tensorrt"
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported value \"tensorrt\"")
+}
+
+func TestValidate_UnsupportedAlgorithm(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Strategy.Algorithm = "unknown-algo"
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported value \"unknown-algo\"")
+}
+
+func TestValidate_UnsupportedOptimizeMetric(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Objectives.Optimize = "latency"
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported value \"latency\"")
+}
+
+func TestValidate_DuplicateTemplateName(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Templates[1].Name = cfg.Templates[0].Name
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate name")
+}
+
+func TestValidate_SearchParamRangeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		param   SearchParam
+		wantErr string
+	}{
+		{
+			name:    "min >= max",
+			param:   SearchParam{Type: "range", Min: ptr(100.0), Max: ptr(50.0), Step: ptr(10.0)},
+			wantErr: "min (100) must be less than max (50)",
+		},
+		{
+			name:    "step <= 0",
+			param:   SearchParam{Type: "range", Min: ptr(1.0), Max: ptr(10.0), Step: ptr(0.0)},
+			wantErr: "step must be positive",
+		},
+		{
+			name:    "missing min/max/step",
+			param:   SearchParam{Type: "range", Min: ptr(1.0)},
+			wantErr: "range type requires min, max, and step",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Parse([]byte(fullValidConfig()))
+			require.NoError(t, err)
+			cfg.SearchSpace["default"]["testParam"] = tt.param
+			err = Validate(cfg, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidate_SearchParamCategoricalEmpty(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.SearchSpace["default"]["emptyParam"] = SearchParam{Type: "categorical", Values: nil}
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one value")
+}
+
+func TestValidate_SearchParamUnknownType(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.SearchSpace["default"]["badParam"] = SearchParam{Type: "uniform"}
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type \"uniform\"")
+}
+
+func TestValidate_InvalidDurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(cfg *AutoBenchmarkConfig)
+		wantErr string
+	}{
+		{
+			name:    "invalid strategy.timeout",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Strategy.Timeout = "notaduration" },
+			wantErr: "strategy.timeout: invalid duration",
+		},
+		{
+			name:    "invalid execution.rbgReadyTimeout",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Execution.RBGReadyTimeout = "abc" },
+			wantErr: "execution.rbgReadyTimeout: invalid duration",
+		},
+		{
+			name:    "invalid execution.trialTimeout",
+			modify:  func(cfg *AutoBenchmarkConfig) { cfg.Execution.TrialTimeout = "xyz" },
+			wantErr: "execution.trialTimeout: invalid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Parse([]byte(fullValidConfig()))
+			require.NoError(t, err)
+			tt.modify(cfg)
+			err = Validate(cfg, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidate_TemplateFileNotFound(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Templates[0].Template = "/nonexistent/path/template.yaml"
+	err = Validate(cfg, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+}
+
+func TestValidate_TemplateFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	f1 := filepath.Join(tmpDir, "t1.yaml")
+	f2 := filepath.Join(tmpDir, "t2.yaml")
+	require.NoError(t, os.WriteFile(f1, []byte("apiVersion: v1"), 0644))
+	require.NoError(t, os.WriteFile(f2, []byte("apiVersion: v1"), 0644))
+
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Templates[0].Template = f1
+	cfg.Templates[1].Template = f2
+	err = Validate(cfg, true)
+	assert.NoError(t, err)
+}
+
+func TestValidate_StrategyMaxTrialsNonPositive(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Strategy.MaxTrialsPerTemplate = 0
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maxTrialsPerTemplate: must be positive")
+}
+
+func TestValidate_ScenarioMissingFields(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	cfg.Scenario.Workloads = nil
+	err = Validate(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scenario.workloads: at least one is required")
+}
+
+func TestValidate_FullValidConfig(t *testing.T) {
+	cfg, err := Parse([]byte(fullValidConfig()))
+	require.NoError(t, err)
+	err = Validate(cfg, false)
+	assert.NoError(t, err)
+}
+
+func TestParseFile_NonexistentFile(t *testing.T) {
+	_, err := ParseFile("/nonexistent/config.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading config file")
+}
+
+func TestParseFile_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "bad.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("{{invalid yaml"), 0644))
+	_, err := ParseFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing config YAML")
+}
+
+func TestParse_RoleSpecificSearchSpace(t *testing.T) {
+	yamlData := `
+templates:
+  - name: "t1"
+    template: "./t1.yaml"
+backend: "sglang"
+searchSpace:
+  default:
+    maxNumSeqs:
+      type: "categorical"
+      values: [64, 128]
+  prefill:
+    chunkedPrefillSize:
+      type: "categorical"
+      values: [2048, 4096]
+  decode:
+    maxNumSeqs:
+      type: "range"
+      min: 128
+      max: 512
+      step: 128
+scenario:
+  name: "s"
+  workloads: ["fixed(100,50)"]
+  concurrency: [1]
+objectives:
+  optimize: "outputThroughput"
+evaluator:
+  type: "genai-bench"
+results:
+  pvc: "pvc://results/"
+`
+	cfg, err := Parse([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Contains(t, cfg.SearchSpace, "default")
+	assert.Contains(t, cfg.SearchSpace, "prefill")
+	assert.Contains(t, cfg.SearchSpace, "decode")
+	assert.Contains(t, cfg.SearchSpace["prefill"], "chunkedPrefillSize")
+
+	err = Validate(cfg, false)
+	assert.NoError(t, err)
+}
+
+func ptr(v float64) *float64 { return &v }

--- a/pkg/autobenchmark/config/types.go
+++ b/pkg/autobenchmark/config/types.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// AutoBenchmarkConfig is the top-level configuration for auto-benchmark.
+type AutoBenchmarkConfig struct {
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string `yaml:"kind" json:"kind"`
+
+	// Name is the experiment name, used as the base directory on PVC for all outputs.
+	Name string `yaml:"name" json:"name"`
+
+	// Templates references complete RBG YAML files as base templates.
+	Templates []TemplateRef `yaml:"templates" json:"templates"`
+
+	// Backend is the inference engine backend (sglang | vllm).
+	Backend string `yaml:"backend" json:"backend"`
+
+	// SearchSpace defines params to overlay on base RBG container commands.
+	// Keys are role names ("default" applies to all roles).
+	SearchSpace map[string]map[string]SearchParam `yaml:"searchSpace" json:"searchSpace"`
+
+	// Scenario defines the fixed workload configuration for benchmarking.
+	Scenario ScenarioSpec `yaml:"scenario" json:"scenario"`
+
+	// Objectives defines SLA constraints and the metric to optimize.
+	Objectives ObjectivesSpec `yaml:"objectives" json:"objectives"`
+
+	// Strategy configures the search algorithm.
+	Strategy StrategySpec `yaml:"strategy" json:"strategy"`
+
+	// Evaluator configures the benchmark evaluation tool.
+	Evaluator EvaluatorSpec `yaml:"evaluator" json:"evaluator"`
+
+	// Results configures result storage.
+	Results ResultsSpec `yaml:"results" json:"results"`
+
+	// Execution configures runtime behavior.
+	Execution ExecutionSpec `yaml:"execution" json:"execution"`
+}
+
+// TemplateRef references a complete RBG YAML file as a base template.
+type TemplateRef struct {
+	// Name is a human-readable identifier for this template.
+	Name string `yaml:"name" json:"name"`
+
+	// Template is the file path to the RBG YAML template.
+	Template string `yaml:"template" json:"template"`
+}
+
+// SearchParam defines a single searchable parameter.
+type SearchParam struct {
+	// Type is the parameter type: "range" or "categorical".
+	Type string `yaml:"type" json:"type"`
+
+	// Values is used for categorical params.
+	Values []interface{} `yaml:"values,omitempty" json:"values,omitempty"`
+
+	// Min, Max, Step are used for range params.
+	Min  *float64 `yaml:"min,omitempty" json:"min,omitempty"`
+	Max  *float64 `yaml:"max,omitempty" json:"max,omitempty"`
+	Step *float64 `yaml:"step,omitempty" json:"step,omitempty"`
+}
+
+// ScenarioSpec defines a fixed workload scenario for benchmarking.
+// Fields use project-own generic syntax; each evaluator plugin translates them
+// to its own CLI format (e.g. genai-bench D/N/U notation).
+type ScenarioSpec struct {
+	Name        string   `yaml:"name" json:"name"`
+	Workloads   []string `yaml:"workloads" json:"workloads"`                         // project-own syntax: fixed(in,out), normal(μ_in,σ_in/μ_out,σ_out), uniform(min,max/min,max), dataset
+	Concurrency []int    `yaml:"concurrency" json:"concurrency"`                     // list of concurrency levels to test
+	Duration    string   `yaml:"duration,omitempty" json:"duration,omitempty"`       // Go duration string, e.g. "2m", "30s"
+	MaxRequests int      `yaml:"maxRequests,omitempty" json:"maxRequests,omitempty"` // max requests per run
+}
+
+// ObjectivesSpec defines SLA constraints and the optimization target.
+type ObjectivesSpec struct {
+	SLA      SLASpec `yaml:"sla" json:"sla"`
+	Optimize string  `yaml:"optimize" json:"optimize"`
+}
+
+// SLASpec defines performance SLA constraints.
+type SLASpec struct {
+	TTFTP99MaxMs *float64 `yaml:"ttftP99MaxMs,omitempty" json:"ttftP99MaxMs,omitempty"`
+	TPOTP99MaxMs *float64 `yaml:"tpotP99MaxMs,omitempty" json:"tpotP99MaxMs,omitempty"`
+	ErrorRateMax *float64 `yaml:"errorRateMax,omitempty" json:"errorRateMax,omitempty"`
+}
+
+// StrategySpec configures the search algorithm.
+type StrategySpec struct {
+	Algorithm            string `yaml:"algorithm" json:"algorithm"`
+	MaxTrialsPerTemplate int    `yaml:"maxTrialsPerTemplate" json:"maxTrialsPerTemplate"`
+	EarlyStopPatience    int    `yaml:"earlyStopPatience,omitempty" json:"earlyStopPatience,omitempty"`
+	Timeout              string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+
+	// Optuna-specific fields (used when algorithm is an Optuna-backed sampler).
+	Seed            *int                   `yaml:"seed,omitempty" json:"seed,omitempty"`                       // RNG seed for reproducibility
+	StoragePath     string                 `yaml:"storagePath,omitempty" json:"storagePath,omitempty"`         // SQLite DB path on PVC for persistence
+	AlgorithmConfig map[string]interface{} `yaml:"algorithmConfig,omitempty" json:"algorithmConfig,omitempty"` // Extra kwargs passed to the Optuna sampler constructor
+}
+
+// EvaluatorSpec configures the benchmark evaluation tool.
+// The evaluator runs in-process inside the controller; no container fields needed.
+type EvaluatorSpec struct {
+	Type   string                 `yaml:"type" json:"type"`
+	Config map[string]interface{} `yaml:"config,omitempty" json:"config,omitempty"` // evaluator-specific config, interpreted by the plugin's Init method
+}
+
+// ResultsSpec configures result storage.
+type ResultsSpec struct {
+	PVC     string `yaml:"pvc" json:"pvc"`
+	SubPath string `yaml:"subPath,omitempty" json:"subPath,omitempty"`
+}
+
+// ExecutionSpec configures runtime behavior.
+type ExecutionSpec struct {
+	RBGReadyTimeout string `yaml:"rbgReadyTimeout,omitempty" json:"rbgReadyTimeout,omitempty"`
+	TrialTimeout    string `yaml:"trialTimeout,omitempty" json:"trialTimeout,omitempty"`
+}
+
+// SupportedBackends lists valid backend values.
+var SupportedBackends = []string{"sglang", "vllm"}
+
+// SupportedAlgorithms lists valid search algorithm values.
+var SupportedAlgorithms = []string{"grid", "tpe", "gp", "cmaes", "random", "qmc", "nsgaii", "nsgaiii"}
+
+// SupportedOptimizeMetrics lists valid optimization target metrics.
+var SupportedOptimizeMetrics = []string{"outputThroughput", "inputThroughput", "requestsPerSecond"}

--- a/pkg/autobenchmark/config/workload.go
+++ b/pkg/autobenchmark/config/workload.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// WorkloadType enumerates the supported workload distribution types.
+type WorkloadType string
+
+const (
+	WorkloadFixed   WorkloadType = "fixed"
+	WorkloadNormal  WorkloadType = "normal"
+	WorkloadUniform WorkloadType = "uniform"
+	WorkloadDataset WorkloadType = "dataset"
+)
+
+// Workload represents a parsed workload string.
+type Workload struct {
+	Type         WorkloadType
+	InputTokens  int // fixed: exact input token count
+	OutputTokens int // fixed: exact output token count
+	InputMean    int // normal: input mean
+	InputStdDev  int // normal: input standard deviation
+	OutputMean   int // normal: output mean
+	OutputStdDev int // normal: output standard deviation
+	InputMin     int // uniform: input minimum
+	InputMax     int // uniform: input maximum
+	OutputMin    int // uniform: output minimum
+	OutputMax    int // uniform: output maximum
+}
+
+var (
+	fixedRe   = regexp.MustCompile(`^fixed\((\d+),(\d+)\)$`)
+	normalRe  = regexp.MustCompile(`^normal\((\d+),(\d+)/(\d+),(\d+)\)$`)
+	uniformRe = regexp.MustCompile(`^uniform\((\d+),(\d+)/(\d+),(\d+)\)$`)
+	datasetRe = regexp.MustCompile(`^dataset$`)
+)
+
+// ParseWorkload parses a workload string into a Workload struct.
+// Supported formats:
+//   - fixed(input,output)           e.g. fixed(100,1000)
+//   - normal(μ_in,σ_in/μ_out,σ_out) e.g. normal(480,240/300,150)
+//   - uniform(min_in,max_in/min_out,max_out) e.g. uniform(100,500/200,800)
+//   - dataset
+func ParseWorkload(s string) (*Workload, error) {
+	if datasetRe.MatchString(s) {
+		return &Workload{Type: WorkloadDataset}, nil
+	}
+
+	if m := fixedRe.FindStringSubmatch(s); m != nil {
+		input, _ := strconv.Atoi(m[1])
+		output, _ := strconv.Atoi(m[2])
+		return &Workload{
+			Type:         WorkloadFixed,
+			InputTokens:  input,
+			OutputTokens: output,
+		}, nil
+	}
+
+	if m := normalRe.FindStringSubmatch(s); m != nil {
+		inputMean, _ := strconv.Atoi(m[1])
+		inputStd, _ := strconv.Atoi(m[2])
+		outputMean, _ := strconv.Atoi(m[3])
+		outputStd, _ := strconv.Atoi(m[4])
+		return &Workload{
+			Type:         WorkloadNormal,
+			InputMean:    inputMean,
+			InputStdDev:  inputStd,
+			OutputMean:   outputMean,
+			OutputStdDev: outputStd,
+		}, nil
+	}
+
+	if m := uniformRe.FindStringSubmatch(s); m != nil {
+		inputMin, _ := strconv.Atoi(m[1])
+		inputMax, _ := strconv.Atoi(m[2])
+		outputMin, _ := strconv.Atoi(m[3])
+		outputMax, _ := strconv.Atoi(m[4])
+		return &Workload{
+			Type:      WorkloadUniform,
+			InputMin:  inputMin,
+			InputMax:  inputMax,
+			OutputMin: outputMin,
+			OutputMax: outputMax,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("invalid workload string %q: expected one of fixed(in,out), normal(μ_in,σ_in/μ_out,σ_out), uniform(min_in,max_in/min_out,max_out), dataset", s)
+}
+
+// ValidateWorkload validates that the string is a parseable workload.
+func ValidateWorkload(s string) error {
+	_, err := ParseWorkload(s)
+	return err
+}

--- a/pkg/autobenchmark/config/workload_test.go
+++ b/pkg/autobenchmark/config/workload_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWorkload_Fixed(t *testing.T) {
+	w, err := ParseWorkload("fixed(100,1000)")
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadFixed, w.Type)
+	assert.Equal(t, 100, w.InputTokens)
+	assert.Equal(t, 1000, w.OutputTokens)
+}
+
+func TestParseWorkload_Normal(t *testing.T) {
+	w, err := ParseWorkload("normal(480,240/300,150)")
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadNormal, w.Type)
+	assert.Equal(t, 480, w.InputMean)
+	assert.Equal(t, 240, w.InputStdDev)
+	assert.Equal(t, 300, w.OutputMean)
+	assert.Equal(t, 150, w.OutputStdDev)
+}
+
+func TestParseWorkload_Uniform(t *testing.T) {
+	w, err := ParseWorkload("uniform(100,500/200,800)")
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadUniform, w.Type)
+	assert.Equal(t, 100, w.InputMin)
+	assert.Equal(t, 500, w.InputMax)
+	assert.Equal(t, 200, w.OutputMin)
+	assert.Equal(t, 800, w.OutputMax)
+}
+
+func TestParseWorkload_Dataset(t *testing.T) {
+	w, err := ParseWorkload("dataset")
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadDataset, w.Type)
+}
+
+func TestParseWorkload_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"random text", "foobar"},
+		{"genai-bench format D", "D(100,1000)"},
+		{"genai-bench format N", "N(480,240)/(300,150)"},
+		{"genai-bench format E", "E(1024)"},
+		{"missing parens", "fixed100,1000"},
+		{"extra spaces", "fixed( 100, 1000)"},
+		{"negative numbers", "fixed(-100,1000)"},
+		{"float numbers", "fixed(100.5,1000)"},
+		{"incomplete normal", "normal(480,240)"},
+		{"incomplete uniform", "uniform(100,500)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseWorkload(tt.input)
+			assert.Error(t, err, "expected error for input %q", tt.input)
+		})
+	}
+}
+
+func TestValidateWorkload(t *testing.T) {
+	assert.NoError(t, ValidateWorkload("fixed(100,1000)"))
+	assert.NoError(t, ValidateWorkload("normal(480,240/300,150)"))
+	assert.NoError(t, ValidateWorkload("uniform(100,500/200,800)"))
+	assert.NoError(t, ValidateWorkload("dataset"))
+	assert.Error(t, ValidateWorkload("invalid"))
+}

--- a/pkg/autobenchmark/constant/constant.go
+++ b/pkg/autobenchmark/constant/constant.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant
+
+const (
+	// AutoBenchmarkLabelKey is the label key used to tag all auto-benchmark
+	// resources (Jobs, ConfigMaps, and trial RBGs). The value is the experiment name.
+	AutoBenchmarkLabelKey = "rbg.workloads.x-k8s.io/auto-benchmark"
+)

--- a/pkg/autobenchmark/constant/constant.go
+++ b/pkg/autobenchmark/constant/constant.go
@@ -20,4 +20,8 @@ const (
 	// AutoBenchmarkLabelKey is the label key used to tag all auto-benchmark
 	// resources (Jobs, ConfigMaps, and trial RBGs). The value is the experiment name.
 	AutoBenchmarkLabelKey = "rbg.workloads.x-k8s.io/auto-benchmark"
+
+	// AutoBenchmarkOriginalNameAnnotationKey is the annotation key used to store
+	// the original experiment name when the resource name is sanitized for DNS-1123 compliance.
+	AutoBenchmarkOriginalNameAnnotationKey = AutoBenchmarkLabelKey + "/original-name"
 )

--- a/pkg/autobenchmark/controller/controller.go
+++ b/pkg/autobenchmark/controller/controller.go
@@ -1,0 +1,581 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/constant"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/evaluator"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/lifecycle"
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/search"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// Controller orchestrates the auto-benchmark experiment loop.
+type Controller struct {
+	cfg       *config.AutoBenchmarkConfig
+	client    client.Client
+	namespace string
+
+	builder *lifecycle.Builder
+	manager *lifecycle.RBGManager
+	eval    evaluator.Evaluator
+
+	state     *StateManager
+	reportDir string
+
+	// parsed durations
+	timeout         time.Duration
+	rbgReadyTimeout time.Duration
+	trialTimeout    time.Duration
+}
+
+// NewController creates a Controller from config.
+func NewController(
+	cfg *config.AutoBenchmarkConfig,
+	c client.Client,
+	namespace string,
+	stateDir string,
+	reportDir string,
+) (*Controller, error) {
+	builder, err := lifecycle.NewBuilder(cfg.Backend)
+	if err != nil {
+		return nil, fmt.Errorf("creating builder: %w", err)
+	}
+
+	// Validate algorithm name early (don't store; Run creates per-template instances).
+	if _, err := search.Get(cfg.Strategy.Algorithm); err != nil {
+		return nil, fmt.Errorf("creating search algorithm: %w", err)
+	}
+
+	eval, err := evaluator.Get(cfg.Evaluator.Type)
+	if err != nil {
+		return nil, fmt.Errorf("creating evaluator: %w", err)
+	}
+
+	if err := eval.Init(cfg.Evaluator.Config); err != nil {
+		return nil, fmt.Errorf("initializing evaluator: %w", err)
+	}
+
+	// Duration strings are validated during config parsing (setDefaults + Validate),
+	// so errors here are effectively unreachable in normal flow.
+	timeout, _ := time.ParseDuration(cfg.Strategy.Timeout)
+	rbgReady, _ := time.ParseDuration(cfg.Execution.RBGReadyTimeout)
+	trialTO, _ := time.ParseDuration(cfg.Execution.TrialTimeout)
+
+	return &Controller{
+		cfg:             cfg,
+		client:          c,
+		namespace:       namespace,
+		builder:         builder,
+		manager:         lifecycle.NewRBGManager(c, namespace),
+		eval:            eval,
+		state:           NewStateManager(stateDir),
+		reportDir:       reportDir,
+		timeout:         timeout,
+		rbgReadyTimeout: rbgReady,
+		trialTimeout:    trialTO,
+	}, nil
+}
+
+// Run executes the main orchestration loop.
+func (ctrl *Controller) Run(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithValues("experiment", ctrl.cfg.Name)
+	ctx = log.IntoContext(ctx, logger)
+
+	// Apply overall timeout
+	if ctrl.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, ctrl.timeout)
+		defer cancel()
+	}
+
+	// Load or initialize experiment state
+	expState, err := ctrl.loadOrInitState(ctx)
+	if err != nil {
+		return fmt.Errorf("initializing state: %w", err)
+	}
+
+	// Expand search space once
+	expandedSpace := search.ExpandSearchSpace(ctrl.cfg.SearchSpace)
+
+	// Create algorithm instance once; Init will be called per template.
+	algoInstance, err := search.Get(ctrl.cfg.Strategy.Algorithm)
+	if err != nil {
+		return err
+	}
+	// Close subprocess (if any) when the experiment finishes.
+	if closer, ok := algoInstance.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	// Template iteration loop
+	iter := NewTemplateIterator(ctrl.cfg.Templates, expState.CurrentTemplateIdx)
+
+	for iter.HasNext() {
+		if err := ctx.Err(); err != nil {
+			logger.Info("Experiment timeout reached, saving state")
+			break
+		}
+
+		tmplRef := iter.Next()
+		tmplIdx := iter.CurrentIndex() - 1 // index of current template
+		logger.Info("Processing template", "index", tmplIdx, "template", tmplRef.Name)
+
+		// Ensure template state exists
+		for len(expState.Templates) <= tmplIdx {
+			expState.Templates = append(expState.Templates, abtypes.TemplateState{
+				Name: tmplRef.Name,
+			})
+		}
+		ts := &expState.Templates[tmplIdx]
+
+		if ts.Completed {
+			logger.Info("Template already completed, skipping", "template", tmplRef.Name)
+			continue
+		}
+
+		// (Re-)initialize algorithm for this template. The algorithm instance
+		// is created once before the loop; Init reuses the subprocess.
+		if err := algoInstance.Init(ctx, tmplRef.Name, expandedSpace, ctrl.cfg.Strategy); err != nil {
+			return fmt.Errorf("initializing algorithm for template %q: %w", tmplRef.Name, err)
+		}
+		if len(ts.AlgorithmState) > 0 {
+			if err := algoInstance.UnmarshalState(ts.AlgorithmState); err != nil {
+				logger.Info("Failed to restore algorithm state, continuing", "template", tmplRef.Name, "error", err.Error())
+			}
+		}
+
+		// Load base RBG template
+		baseRBG, err := lifecycle.LoadTemplate(tmplRef.Template)
+		if err != nil {
+			return fmt.Errorf("loading template %q: %w", tmplRef.Name, err)
+		}
+
+		// Trial loop for this template
+		err = ctrl.runTrials(ctx, expState, ts, tmplIdx, baseRBG, algoInstance)
+		if err != nil {
+			logger.Error(err, "Error running trials", "template", tmplRef.Name)
+		}
+
+		// Mark template completed
+		ts.Completed = true
+		ts.BestTrial = SelectBest(ts.Trials)
+
+		// Update global best
+		if ts.BestTrial != nil {
+			if expState.GlobalBest == nil || ts.BestTrial.Score > expState.GlobalBest.Score {
+				expState.GlobalBest = ts.BestTrial
+			}
+		}
+
+		expState.CurrentTemplateIdx = iter.CurrentIndex()
+		if err := ctrl.state.Save(expState); err != nil {
+			logger.Error(err, "Failed to save checkpoint")
+		}
+	}
+
+	// Generate report
+	endTime := time.Now()
+	report := BuildReport(expState)
+	if err := WriteReportJSON(ctrl.reportDir, report); err != nil {
+		logger.Error(err, "Failed to write report", "format", "json")
+	}
+	if err := WriteReportYAML(ctrl.reportDir, report); err != nil {
+		logger.Error(err, "Failed to write report", "format", "yaml")
+	}
+	// Write full result detail for UI consumption
+	result := BuildResult(expState, ctrl.cfg, endTime)
+	if err := WriteResultJSON(ctrl.reportDir, result); err != nil {
+		logger.Error(err, "Failed to write result detail", "format", "json")
+	}
+
+	logger.Info("Experiment completed", "summary", report.Summary)
+	return nil
+}
+
+// runTrials executes the trial loop for a single template.
+func (ctrl *Controller) runTrials(
+	ctx context.Context,
+	expState *abtypes.ExperimentState,
+	ts *abtypes.TemplateState,
+	tmplIdx int,
+	baseRBG *v1alpha2.RoleBasedGroup,
+	algo search.SearchAlgorithm,
+) error {
+	logger := log.FromContext(ctx).WithValues("template", ts.Name)
+
+	earlyStopCounter := 0
+	bestScore := float64(0)
+	if ts.BestTrial != nil {
+		bestScore = ts.BestTrial.Score
+	}
+
+	for !algo.IsDone(ts.Trials) {
+		if err := ctx.Err(); err != nil {
+			return nil // timeout, graceful exit
+		}
+
+		trialIdx := len(ts.Trials)
+		params, err := algo.SuggestNext(ts.Trials)
+		if err != nil {
+			logger.Error(err, "Algorithm suggest failed")
+			break
+		}
+
+		logger.Info("Starting trial", "trialIndex", trialIdx, "params", params)
+
+		result := ctrl.executeTrial(ctx, baseRBG, ts.Name, trialIdx, params)
+		ts.Trials = append(ts.Trials, result)
+
+		// Check early stop: only count SLA-passing trials that did not improve.
+		// SLA failures reset the counter so that invalid configs don't exhaust patience.
+		if ctrl.cfg.Strategy.EarlyStopPatience > 0 {
+			if result.SLAPass && result.Score > bestScore {
+				bestScore = result.Score
+				earlyStopCounter = 0
+			} else if result.SLAPass {
+				earlyStopCounter++
+			} else {
+				earlyStopCounter = 0
+			}
+			if earlyStopCounter >= ctrl.cfg.Strategy.EarlyStopPatience {
+				logger.Info("Early stop triggered", "patience", ctrl.cfg.Strategy.EarlyStopPatience)
+				break
+			}
+		}
+
+		// Save algorithm state
+		algoState, err := algo.MarshalState()
+		if err == nil {
+			ts.AlgorithmState = algoState
+		}
+
+		// Checkpoint after each trial
+		expState.CurrentTemplateIdx = tmplIdx
+		if err := ctrl.state.Save(expState); err != nil {
+			logger.Error(err, "Failed to save checkpoint")
+		}
+
+		// Write incremental result detail for mid-flight visibility
+		resultDetail := BuildResult(expState, ctrl.cfg, time.Time{})
+		if err := WriteResultJSON(ctrl.reportDir, resultDetail); err != nil {
+			logger.Error(err, "Failed to write result detail")
+		}
+	}
+
+	return nil
+}
+
+// executeTrial runs a single trial: deploy RBG -> wait ready -> run benchmark in-process -> collect results -> cleanup.
+func (ctrl *Controller) executeTrial(
+	ctx context.Context,
+	baseRBG *v1alpha2.RoleBasedGroup,
+	templateName string,
+	trialIdx int,
+	params abtypes.RoleParamSet,
+) abtypes.TrialResult {
+	logger := log.FromContext(ctx).WithValues("trialIndex", trialIdx)
+	ctx = log.IntoContext(ctx, logger)
+
+	start := time.Now()
+	result := abtypes.TrialResult{
+		TrialIndex:   trialIdx,
+		TemplateName: templateName,
+		Params:       params,
+		StartTime:    start,
+	}
+
+	// Apply trial timeout early so it governs all trial phases
+	// (creation, readiness, and benchmark execution).
+	trialCtx := ctx
+	if ctrl.trialTimeout > 0 {
+		var cancel context.CancelFunc
+		trialCtx, cancel = context.WithTimeout(ctx, ctrl.trialTimeout)
+		defer cancel()
+	}
+
+	// Build trial RBG
+	trialRBG, err := ctrl.builder.BuildTrial(baseRBG, trialIdx, params)
+	if err != nil {
+		result.Error = fmt.Sprintf("build trial: %v", err)
+		result.EndTime = time.Now()
+		result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+		return result
+	}
+
+	// Tag trial RBG with experiment label for scoped cleanup
+	if trialRBG.Labels == nil {
+		trialRBG.Labels = make(map[string]string)
+	}
+	trialRBG.Labels[constant.AutoBenchmarkLabelKey] = ctrl.cfg.Name
+
+	trialName := trialRBG.Name
+	defer func() {
+		// Cleanup: delete trial RBG
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if delErr := ctrl.manager.Delete(cleanupCtx, trialName); delErr != nil {
+			logger.Error(delErr, "Failed to cleanup trial RBG", "rbgName", trialName)
+		}
+	}()
+
+	// Create trial RBG
+	if err := ctrl.manager.Create(trialCtx, trialRBG); err != nil {
+		result.Error = fmt.Sprintf("create RBG: %v", err)
+		result.EndTime = time.Now()
+		result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+		return result
+	}
+
+	// Wait for RBG to be fully ready (Pod Ready + inference endpoint serving).
+	endpoint, err := ctrl.waitRBGFullyReady(trialCtx, trialRBG, trialName, ctrl.rbgReadyTimeout)
+	if err != nil {
+		result.Error = fmt.Sprintf("RBG not ready: %v", err)
+		result.EndTime = time.Now()
+		result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+		return result
+	}
+	modelName := extractServedModelName(baseRBG, ctrl.cfg.Backend)
+
+	// Result directory: {reportDir}/{scenario}/{templateName}/trial-{idx}
+	scenario := ctrl.cfg.Scenario
+	resultDir := filepath.Join(ctrl.reportDir, scenario.Name, templateName, fmt.Sprintf("trial-%d", trialIdx))
+
+	// Run benchmark in-process
+	evalCtx := evaluator.EvalContext{
+		Endpoint:  endpoint,
+		ModelName: modelName,
+		Backend:   ctrl.cfg.Backend,
+		Scenario:  scenario,
+		OutputDir: resultDir,
+	}
+
+	if err := ctrl.eval.Run(trialCtx, evalCtx); err != nil {
+		result.Error = fmt.Sprintf("benchmark failed: %v", err)
+		result.EndTime = time.Now()
+		result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+		return result
+	}
+
+	// Collect results from local output directory
+	metrics, err := ctrl.eval.CollectResults(resultDir)
+	if err != nil {
+		result.Error = fmt.Sprintf("collecting results: %v", err)
+		result.EndTime = time.Now()
+		result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+		return result
+	}
+
+	// Evaluate SLA
+	result.Metrics = metrics
+	result.SLAPass, result.Score = EvaluateSLA(metrics, ctrl.cfg.Objectives)
+	result.EndTime = time.Now()
+	result.Duration = abtypes.Duration(result.EndTime.Sub(start))
+
+	logger.Info("Trial completed", "slaPass", result.SLAPass, "score", result.Score)
+	return result
+}
+
+// resolveEndpoint determines the inference endpoint for a trial RBG.
+func (ctrl *Controller) resolveEndpoint(trialRBG *v1alpha2.RoleBasedGroup) string {
+	for _, role := range trialRBG.Spec.Roles {
+		port := ctrl.resolveRolePort(&role)
+		if port <= 0 {
+			continue
+		}
+		// For leader-worker pattern, route directly to the leader pod via headless service DNS.
+		// The RBG controller only creates headless services; using service-level DNS may resolve
+		// to worker pods, which do not serve inference requests.
+		if role.LeaderWorkerPattern != nil {
+			return lifecycle.GetLeaderPodEndpoint(trialRBG, &role, ctrl.namespace, port)
+		}
+		return lifecycle.GetServiceEndpoint(trialRBG, &role, ctrl.namespace, port)
+	}
+	// Last resort fallback: assume a default worker role at port 8000.
+	return lifecycle.GetServiceEndpoint(trialRBG, &v1alpha2.RoleSpec{Name: "worker"}, ctrl.namespace, 8000)
+}
+
+// resolveRolePort extracts the inference port for a role.
+// Priority: args --port > ServicePorts > container ports > engine default.
+func (ctrl *Controller) resolveRolePort(role *v1alpha2.RoleSpec) int {
+	podSpec := getRolePodSpec(role)
+	if podSpec != nil && len(podSpec.Containers) > 0 {
+		// 1. Check container args for explicit --port.
+		for _, c := range podSpec.Containers {
+			for i, arg := range c.Args {
+				if arg == "--port" && i+1 < len(c.Args) {
+					if p, err := strconv.Atoi(c.Args[i+1]); err == nil && p > 0 {
+						return p
+					}
+				}
+			}
+		}
+		// 2. Check container ports.
+		for _, c := range podSpec.Containers {
+			for _, p := range c.Ports {
+				if p.ContainerPort > 0 {
+					return int(p.ContainerPort)
+				}
+			}
+		}
+	}
+	// 3. Check ServicePorts.
+	if len(role.ServicePorts) > 0 {
+		return int(role.ServicePorts[0].Port)
+	}
+	// 4. Fall back to engine default.
+	return defaultEnginePort(ctrl.cfg.Backend)
+}
+
+func defaultEnginePort(backend string) int {
+	switch backend {
+	case "sglang":
+		return 30000
+	case "vllm":
+		return 8000
+	default:
+		return 8000
+	}
+}
+
+// extractServedModelName reads --served-model-name from the base template's container args.
+// Falls back to the RBG metadata name if the flag is not found.
+func extractServedModelName(rbg *v1alpha2.RoleBasedGroup, backend string) string {
+	flag := "--served-model-name"
+	if backend == "vllm" {
+		flag = "--served-model-name"
+	}
+	for _, role := range rbg.Spec.Roles {
+		podSpec := getRolePodSpec(&role)
+		if podSpec == nil {
+			continue
+		}
+		for _, c := range podSpec.Containers {
+			allArgs := append(c.Command, c.Args...)
+			for i, arg := range allArgs {
+				if arg == flag && i+1 < len(allArgs) {
+					return allArgs[i+1]
+				}
+			}
+		}
+	}
+	return rbg.Name
+}
+
+// getRolePodSpec extracts the PodSpec from a RoleSpec regardless of pattern type.
+func getRolePodSpec(role *v1alpha2.RoleSpec) *corev1.PodSpec {
+	if sp := role.StandalonePattern; sp != nil {
+		if sp.Template != nil {
+			return &sp.Template.Spec
+		}
+	}
+	if lw := role.LeaderWorkerPattern; lw != nil {
+		if lw.Template != nil {
+			return &lw.Template.Spec
+		}
+	}
+	return nil
+}
+
+// loadOrInitState loads checkpoint or creates new state.
+func (ctrl *Controller) loadOrInitState(ctx context.Context) (*abtypes.ExperimentState, error) {
+	existing, err := ctrl.state.Load()
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		logger := log.FromContext(ctx)
+		logger.Info("Resuming experiment from checkpoint", "templateIndex", existing.CurrentTemplateIdx)
+		return existing, nil
+	}
+
+	return &abtypes.ExperimentState{
+		ExperimentID: ctrl.cfg.Name,
+		StartTime:    time.Now(),
+	}, nil
+}
+
+// waitRBGFullyReady waits for both the RBG to report Ready=True and the
+// inference endpoint to respond with HTTP 200, sharing a single timeout.
+// A bool tracks whether the RBG ready phase is complete so that subsequent
+// polls only hit the endpoint (reducing unnecessary API calls).
+func (ctrl *Controller) waitRBGFullyReady(
+	ctx context.Context,
+	trialRBG *v1alpha2.RoleBasedGroup,
+	trialName string,
+	timeout time.Duration,
+) (endpoint string, err error) {
+	logger := log.FromContext(ctx)
+	rbgReady := false
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		if !rbgReady {
+			rbg, err := ctrl.manager.Get(ctx, trialName)
+			if err != nil {
+				logger.V(2).Info("RBG not found yet", "error", err.Error())
+				return false, nil // retry on transient errors
+			}
+			if !isRBGReady(rbg) {
+				return false, nil
+			}
+			logger.Info("RBG is ready, waiting for inference endpoint", "rbgName", trialName)
+			rbgReady = true
+		}
+
+		endpoint = ctrl.resolveEndpoint(trialRBG)
+		healthURL := endpoint + "/health"
+		resp, err := httpClient.Get(healthURL)
+		if err != nil {
+			logger.V(2).Info("Endpoint not ready yet", "error", err.Error())
+			return false, nil // retry
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode == http.StatusOK {
+			logger.Info("Inference endpoint is ready", "healthURL", healthURL)
+			return true, nil
+		}
+		logger.V(2).Info("Endpoint returned non-OK status", "statusCode", resp.StatusCode)
+		return false, nil
+	})
+	return endpoint, err
+}
+
+// isRBGReady checks if the RBG has a Ready=True condition.
+func isRBGReady(rbg *v1alpha2.RoleBasedGroup) bool {
+	for _, c := range rbg.Status.Conditions {
+		if c.Type == string(v1alpha2.RoleBasedGroupReady) && c.Status == "True" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/autobenchmark/controller/controller.go
+++ b/pkg/autobenchmark/controller/controller.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,6 +57,9 @@ type Controller struct {
 	timeout         time.Duration
 	rbgReadyTimeout time.Duration
 	trialTimeout    time.Duration
+
+	// sanitized experiment name for label values (DNS-1123 compliant)
+	expNameLabel string
 }
 
 // NewController creates a Controller from config.
@@ -90,6 +95,9 @@ func NewController(
 	rbgReady, _ := time.ParseDuration(cfg.Execution.RBGReadyTimeout)
 	trialTO, _ := time.ParseDuration(cfg.Execution.TrialTimeout)
 
+	// Sanitize experiment name for use as Kubernetes label value
+	expNameLabel := sanitizeLabelValue(cfg.Name)
+
 	return &Controller{
 		cfg:             cfg,
 		client:          c,
@@ -102,6 +110,7 @@ func NewController(
 		timeout:         timeout,
 		rbgReadyTimeout: rbgReady,
 		trialTimeout:    trialTO,
+		expNameLabel:    expNameLabel,
 	}, nil
 }
 
@@ -335,7 +344,11 @@ func (ctrl *Controller) executeTrial(
 	if trialRBG.Labels == nil {
 		trialRBG.Labels = make(map[string]string)
 	}
-	trialRBG.Labels[constant.AutoBenchmarkLabelKey] = ctrl.cfg.Name
+	trialRBG.Labels[constant.AutoBenchmarkLabelKey] = ctrl.expNameLabel
+	if trialRBG.Annotations == nil {
+		trialRBG.Annotations = make(map[string]string)
+	}
+	trialRBG.Annotations[constant.AutoBenchmarkOriginalNameAnnotationKey] = ctrl.cfg.Name
 
 	trialName := trialRBG.Name
 	defer func() {
@@ -578,4 +591,21 @@ func isRBGReady(rbg *v1alpha2.RoleBasedGroup) bool {
 		}
 	}
 	return false
+}
+
+// sanitizeLabelValue ensures a string is valid for use as a Kubernetes label value.
+// Label values must be 63 characters or less and contain only alphanumeric characters,
+// '-', '_', or '.'. This function truncates and sanitizes as needed.
+func sanitizeLabelValue(name string) string {
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	// Replace invalid characters with '-'
+	invalidChars := regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+	name = invalidChars.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if name == "" {
+		name = "default"
+	}
+	return name
 }

--- a/pkg/autobenchmark/controller/reporter.go
+++ b/pkg/autobenchmark/controller/reporter.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.yaml.in/yaml/v2"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// Report is the final output of an auto-benchmark experiment.
+type Report struct {
+	ExperimentID string               `json:"experimentId" yaml:"experimentId"`
+	GlobalBest   *abtypes.TrialResult `json:"globalBest,omitempty" yaml:"globalBest,omitempty"`
+	Templates    []TemplateReport     `json:"templates" yaml:"templates"`
+	Summary      string               `json:"summary" yaml:"summary"`
+}
+
+// TemplateReport summarizes results for a single template.
+type TemplateReport struct {
+	Name       string               `json:"name" yaml:"name"`
+	BestTrial  *abtypes.TrialResult `json:"bestTrial,omitempty" yaml:"bestTrial,omitempty"`
+	NumTrials  int                  `json:"numTrials" yaml:"numTrials"`
+	NumSLAPass int                  `json:"numSLAPass" yaml:"numSLAPass"`
+}
+
+// BuildReport creates a report from the experiment state.
+func BuildReport(state *abtypes.ExperimentState) *Report {
+	report := &Report{
+		ExperimentID: state.ExperimentID,
+		GlobalBest:   state.GlobalBest,
+	}
+
+	totalTrials := 0
+	totalPass := 0
+
+	for _, ts := range state.Templates {
+		tr := TemplateReport{
+			Name:      ts.Name,
+			BestTrial: ts.BestTrial,
+			NumTrials: len(ts.Trials),
+		}
+		for _, trial := range ts.Trials {
+			if trial.SLAPass {
+				tr.NumSLAPass++
+			}
+		}
+		totalTrials += tr.NumTrials
+		totalPass += tr.NumSLAPass
+		report.Templates = append(report.Templates, tr)
+	}
+
+	if state.GlobalBest != nil {
+		report.Summary = fmt.Sprintf(
+			"Best result: template=%q, trial=%d, score=%.2f (%d/%d trials passed SLA)",
+			state.GlobalBest.TemplateName, state.GlobalBest.TrialIndex,
+			state.GlobalBest.Score, totalPass, totalTrials,
+		)
+	} else {
+		report.Summary = fmt.Sprintf(
+			"No configuration met SLA constraints (%d trials executed across %d templates)",
+			totalTrials, len(state.Templates),
+		)
+	}
+
+	return report
+}
+
+// SelectBest finds the best SLA-passing trial from a list by highest score.
+func SelectBest(trials []abtypes.TrialResult) *abtypes.TrialResult {
+	var best *abtypes.TrialResult
+	for i := range trials {
+		t := &trials[i]
+		if !t.SLAPass {
+			continue
+		}
+		if best == nil || t.Score > best.Score {
+			best = t
+		}
+	}
+	return best
+}
+
+// WriteReportJSON writes the report as JSON to the given directory.
+func WriteReportJSON(dir string, report *Report) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "report.json"), data, 0644)
+}
+
+// WriteReportYAML writes the report as YAML to the given directory.
+func WriteReportYAML(dir string, report *Report) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(report)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "report.yaml"), data, 0644)
+}
+
+// --- ResultDetail: full experiment result for UI consumption ---
+
+// ResultDetail is the complete experiment result including all trials,
+// status metadata, and a config snapshot for UI-driven visualization.
+type ResultDetail struct {
+	ExperimentID string               `json:"experimentId"`
+	Status       ResultStatus         `json:"status"`
+	Config       ResultConfig         `json:"config"`
+	Templates    []TemplateDetail     `json:"templates"`
+	GlobalBest   *abtypes.TrialResult `json:"globalBest,omitempty"`
+}
+
+// ResultStatus holds timing and progress metadata for the experiment.
+type ResultStatus struct {
+	StartTime    time.Time        `json:"startTime"`
+	EndTime      time.Time        `json:"endTime,omitempty"`
+	Duration     abtypes.Duration `json:"duration,omitempty"`
+	NumTemplates int              `json:"numTemplates"`
+	TotalTrials  int              `json:"totalTrials"`
+	NumSLAPass   int              `json:"numSLAPass"`
+	NumSLAFail   int              `json:"numSLAFail"`
+}
+
+// ResultConfig is a snapshot of the key config fields relevant for UI display.
+type ResultConfig struct {
+	Name                string            `json:"name"`
+	Backend             string            `json:"backend"`
+	Algorithm           string            `json:"algorithm"`
+	Optimize            string            `json:"optimize"`
+	SLA                 ResultSLA         `json:"sla"`
+	ScenarioName        string            `json:"scenarioName"`
+	ScenarioWorkloads   []string          `json:"scenarioWorkloads,omitempty"`
+	ScenarioConcurrency []int             `json:"scenarioConcurrency,omitempty"`
+	MaxTrialsPerTmpl    int               `json:"maxTrialsPerTemplate"`
+	EarlyStopPatience   int               `json:"earlyStopPatience,omitempty"`
+	Timeout             string            `json:"timeout,omitempty"`
+	Templates           []string          `json:"templates"`
+	SearchSpace         ResultSearchSpace `json:"searchSpace"`
+}
+
+// ResultSLA mirrors the SLA constraints from config.
+type ResultSLA struct {
+	TTFTP99MaxMs *float64 `json:"ttftP99MaxMs,omitempty"`
+	TPOTP99MaxMs *float64 `json:"tpotP99MaxMs,omitempty"`
+	ErrorRateMax *float64 `json:"errorRateMax,omitempty"`
+}
+
+// SearchParamDetail describes a single searchable parameter with its range/categorical details.
+type SearchParamDetail struct {
+	Type   string        `json:"type"`
+	Values []interface{} `json:"values,omitempty"`
+	Min    *float64      `json:"min,omitempty"`
+	Max    *float64      `json:"max,omitempty"`
+	Step   *float64      `json:"step,omitempty"`
+}
+
+// ResultSearchSpace maps each role to its tunable parameter definitions.
+type ResultSearchSpace map[string]map[string]SearchParamDetail
+
+// TemplateDetail holds all trial results for a single template.
+type TemplateDetail struct {
+	Name      string                `json:"name"`
+	BestTrial *abtypes.TrialResult  `json:"bestTrial,omitempty"`
+	Trials    []abtypes.TrialResult `json:"trials"`
+}
+
+// BuildResult builds a full ResultDetail from experiment state and config.
+func BuildResult(state *abtypes.ExperimentState, cfg *config.AutoBenchmarkConfig, endTime time.Time) *ResultDetail {
+	result := &ResultDetail{
+		ExperimentID: state.ExperimentID,
+		GlobalBest:   state.GlobalBest,
+	}
+
+	// Status
+	result.Status.StartTime = state.StartTime
+	if !endTime.IsZero() {
+		result.Status.EndTime = endTime
+		result.Status.Duration = abtypes.Duration(endTime.Sub(state.StartTime))
+	}
+	result.Status.NumTemplates = len(state.Templates)
+
+	for _, ts := range state.Templates {
+		result.Status.TotalTrials += len(ts.Trials)
+		for _, trial := range ts.Trials {
+			if trial.SLAPass {
+				result.Status.NumSLAPass++
+			} else {
+				result.Status.NumSLAFail++
+			}
+		}
+	}
+
+	// Config snapshot
+	result.Config.Name = cfg.Name
+	result.Config.Backend = cfg.Backend
+	result.Config.Algorithm = cfg.Strategy.Algorithm
+	result.Config.Optimize = cfg.Objectives.Optimize
+	result.Config.SLA.TTFTP99MaxMs = cfg.Objectives.SLA.TTFTP99MaxMs
+	result.Config.SLA.TPOTP99MaxMs = cfg.Objectives.SLA.TPOTP99MaxMs
+	result.Config.SLA.ErrorRateMax = cfg.Objectives.SLA.ErrorRateMax
+	result.Config.ScenarioName = cfg.Scenario.Name
+	result.Config.ScenarioWorkloads = cfg.Scenario.Workloads
+	result.Config.ScenarioConcurrency = cfg.Scenario.Concurrency
+	result.Config.MaxTrialsPerTmpl = cfg.Strategy.MaxTrialsPerTemplate
+	result.Config.EarlyStopPatience = cfg.Strategy.EarlyStopPatience
+	result.Config.Timeout = cfg.Strategy.Timeout
+
+	for _, t := range cfg.Templates {
+		result.Config.Templates = append(result.Config.Templates, t.Name)
+	}
+
+	result.Config.SearchSpace = make(ResultSearchSpace, len(cfg.SearchSpace))
+	for role, params := range cfg.SearchSpace {
+		details := make(map[string]SearchParamDetail, len(params))
+		for name, sp := range params {
+			details[name] = SearchParamDetail{
+				Type:   sp.Type,
+				Values: sp.Values,
+				Min:    sp.Min,
+				Max:    sp.Max,
+				Step:   sp.Step,
+			}
+		}
+		result.Config.SearchSpace[role] = details
+	}
+
+	// Templates
+	for _, ts := range state.Templates {
+		td := TemplateDetail{
+			Name:      ts.Name,
+			BestTrial: ts.BestTrial,
+			Trials:    ts.Trials,
+		}
+		result.Templates = append(result.Templates, td)
+	}
+
+	return result
+}
+
+// WriteResultJSON writes the full result detail as JSON to the given directory.
+func WriteResultJSON(dir string, result *ResultDetail) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "result.json"), data, 0644)
+}

--- a/pkg/autobenchmark/controller/reporter_test.go
+++ b/pkg/autobenchmark/controller/reporter_test.go
@@ -1,0 +1,369 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func TestSelectBest(t *testing.T) {
+	tests := []struct {
+		name   string
+		trials []abtypes.TrialResult
+		want   *abtypes.TrialResult
+	}{
+		{
+			name:   "empty",
+			trials: nil,
+			want:   nil,
+		},
+		{
+			name: "all fail SLA",
+			trials: []abtypes.TrialResult{
+				{TrialIndex: 0, SLAPass: false, Score: 0},
+				{TrialIndex: 1, SLAPass: false, Score: 0},
+			},
+			want: nil,
+		},
+		{
+			name: "single pass",
+			trials: []abtypes.TrialResult{
+				{TrialIndex: 0, SLAPass: false, Score: 0},
+				{TrialIndex: 1, SLAPass: true, Score: 1500},
+			},
+			want: &abtypes.TrialResult{TrialIndex: 1, SLAPass: true, Score: 1500},
+		},
+		{
+			name: "multiple pass - highest score wins",
+			trials: []abtypes.TrialResult{
+				{TrialIndex: 0, SLAPass: true, Score: 1000},
+				{TrialIndex: 1, SLAPass: true, Score: 2000},
+				{TrialIndex: 2, SLAPass: true, Score: 1500},
+				{TrialIndex: 3, SLAPass: false, Score: 0},
+			},
+			want: &abtypes.TrialResult{TrialIndex: 1, SLAPass: true, Score: 2000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			best := SelectBest(tt.trials)
+			if tt.want == nil {
+				assert.Nil(t, best)
+			} else {
+				require.NotNil(t, best)
+				assert.Equal(t, tt.want.TrialIndex, best.TrialIndex)
+				assert.InDelta(t, tt.want.Score, best.Score, 0.01)
+			}
+		})
+	}
+}
+
+func TestBuildReport(t *testing.T) {
+	t.Run("with global best", func(t *testing.T) {
+		state := &abtypes.ExperimentState{
+			ExperimentID: "exp-1",
+			Templates: []abtypes.TemplateState{
+				{
+					Name: "t1",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: true, Score: 1000},
+						{TrialIndex: 1, SLAPass: false},
+					},
+					BestTrial: &abtypes.TrialResult{TrialIndex: 0, Score: 1000},
+				},
+				{
+					Name: "t2",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: true, Score: 2000},
+					},
+					BestTrial: &abtypes.TrialResult{TrialIndex: 0, Score: 2000},
+				},
+			},
+			GlobalBest: &abtypes.TrialResult{TrialIndex: 0, TemplateName: "t2", Score: 2000},
+		}
+
+		report := BuildReport(state)
+		assert.Equal(t, "exp-1", report.ExperimentID)
+		require.NotNil(t, report.GlobalBest)
+		assert.InDelta(t, 2000, report.GlobalBest.Score, 0.01)
+		require.Len(t, report.Templates, 2)
+		assert.Equal(t, 2, report.Templates[0].NumTrials)
+		assert.Equal(t, 1, report.Templates[0].NumSLAPass)
+		assert.Equal(t, 1, report.Templates[1].NumTrials)
+		assert.Equal(t, 1, report.Templates[1].NumSLAPass)
+		assert.Contains(t, report.Summary, "Best result")
+		assert.Contains(t, report.Summary, "2/3 trials passed SLA")
+	})
+
+	t.Run("no SLA pass", func(t *testing.T) {
+		state := &abtypes.ExperimentState{
+			ExperimentID: "exp-2",
+			Templates: []abtypes.TemplateState{
+				{
+					Name: "t1",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: false},
+						{TrialIndex: 1, SLAPass: false},
+					},
+				},
+			},
+		}
+
+		report := BuildReport(state)
+		assert.Nil(t, report.GlobalBest)
+		assert.Contains(t, report.Summary, "No configuration met SLA")
+		assert.Contains(t, report.Summary, "2 trials executed")
+	})
+}
+
+func TestWriteReportJSON(t *testing.T) {
+	dir := t.TempDir()
+	report := &Report{
+		ExperimentID: "exp-test",
+		Summary:      "test summary",
+	}
+
+	err := WriteReportJSON(dir, report)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "report.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "exp-test")
+	assert.Contains(t, string(data), "test summary")
+}
+
+func TestWriteReportYAML(t *testing.T) {
+	dir := t.TempDir()
+	report := &Report{
+		ExperimentID: "exp-test",
+		Summary:      "test summary",
+	}
+
+	err := WriteReportYAML(dir, report)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "report.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "exp-test")
+	assert.Contains(t, string(data), "test summary")
+}
+
+func TestBuildResult(t *testing.T) {
+	startTime := time.Now()
+	endTime := startTime.Add(30 * time.Minute)
+
+	cfg := &config.AutoBenchmarkConfig{
+		Name:    "exp-1",
+		Backend: "vllm",
+		Strategy: config.StrategySpec{
+			Algorithm:            "tpe",
+			MaxTrialsPerTemplate: 10,
+			EarlyStopPatience:    3,
+			Timeout:              "1h",
+		},
+		Objectives: config.ObjectivesSpec{
+			Optimize: "outputThroughput",
+			SLA: config.SLASpec{
+				TTFTP99MaxMs: float64Ptr(500),
+				TPOTP99MaxMs: float64Ptr(50),
+			},
+		},
+		Scenario: config.ScenarioSpec{
+			Name:        "smoke",
+			Workloads:   []string{"fixed(128,10)"},
+			Concurrency: []int{4},
+		},
+		Templates: []config.TemplateRef{
+			{Name: "tp"},
+			{Name: "pp"},
+		},
+		SearchSpace: map[string]map[string]config.SearchParam{
+			"default": {
+				"gpuMemoryUtilization": {Type: "range", Min: float64Ptr(0.7), Max: float64Ptr(0.99), Step: float64Ptr(0.05)},
+				"maxNumSeqs":           {Type: "categorical", Values: []interface{}{float64(64), float64(128), float64(256)}},
+			},
+		},
+	}
+
+	t.Run("with trials", func(t *testing.T) {
+		state := &abtypes.ExperimentState{
+			ExperimentID: "exp-1",
+			StartTime:    startTime,
+			Templates: []abtypes.TemplateState{
+				{
+					Name: "tp",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: true, Score: 1000},
+						{TrialIndex: 1, SLAPass: false, Score: 0},
+						{TrialIndex: 2, SLAPass: true, Score: 2000},
+					},
+					BestTrial: &abtypes.TrialResult{TrialIndex: 2, Score: 2000},
+				},
+				{
+					Name: "pp",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: true, Score: 1500},
+					},
+					BestTrial: &abtypes.TrialResult{TrialIndex: 0, Score: 1500},
+				},
+			},
+			GlobalBest: &abtypes.TrialResult{TrialIndex: 2, TemplateName: "tp", Score: 2000},
+		}
+
+		result := BuildResult(state, cfg, endTime)
+
+		// ExperimentID
+		assert.Equal(t, "exp-1", result.ExperimentID)
+
+		// Status — completed (endTime is set)
+		assert.Equal(t, startTime, result.Status.StartTime)
+		assert.Equal(t, endTime, result.Status.EndTime)
+		assert.InDelta(t, 30*time.Minute.Seconds(), time.Duration(result.Status.Duration).Seconds(), 1)
+		assert.Equal(t, 2, result.Status.NumTemplates)
+		assert.Equal(t, 4, result.Status.TotalTrials)
+		assert.Equal(t, 3, result.Status.NumSLAPass)
+		assert.Equal(t, 1, result.Status.NumSLAFail)
+
+		// Config
+		assert.Equal(t, "exp-1", result.Config.Name)
+		assert.Equal(t, "vllm", result.Config.Backend)
+		assert.Equal(t, "tpe", result.Config.Algorithm)
+		assert.Equal(t, "outputThroughput", result.Config.Optimize)
+		require.NotNil(t, result.Config.SLA.TTFTP99MaxMs)
+		assert.InDelta(t, 500, *result.Config.SLA.TTFTP99MaxMs, 0.01)
+		require.NotNil(t, result.Config.SLA.TPOTP99MaxMs)
+		assert.InDelta(t, 50, *result.Config.SLA.TPOTP99MaxMs, 0.01)
+		assert.Nil(t, result.Config.SLA.ErrorRateMax)
+		assert.Equal(t, "smoke", result.Config.ScenarioName)
+		assert.Equal(t, []string{"fixed(128,10)"}, result.Config.ScenarioWorkloads)
+		assert.Equal(t, []int{4}, result.Config.ScenarioConcurrency)
+		assert.Equal(t, 10, result.Config.MaxTrialsPerTmpl)
+		assert.Equal(t, 3, result.Config.EarlyStopPatience)
+		assert.Equal(t, "1h", result.Config.Timeout)
+		assert.Equal(t, []string{"tp", "pp"}, result.Config.Templates)
+		assert.Len(t, result.Config.SearchSpace, 1)
+		assert.Len(t, result.Config.SearchSpace["default"], 2)
+		gpuMem := result.Config.SearchSpace["default"]["gpuMemoryUtilization"]
+		assert.Equal(t, "range", gpuMem.Type)
+		require.NotNil(t, gpuMem.Min)
+		assert.InDelta(t, 0.7, *gpuMem.Min, 0.01)
+		require.NotNil(t, gpuMem.Max)
+		assert.InDelta(t, 0.99, *gpuMem.Max, 0.01)
+		require.NotNil(t, gpuMem.Step)
+		assert.InDelta(t, 0.05, *gpuMem.Step, 0.01)
+		maxSeqs := result.Config.SearchSpace["default"]["maxNumSeqs"]
+		assert.Equal(t, "categorical", maxSeqs.Type)
+		require.Len(t, maxSeqs.Values, 3)
+
+		// Templates
+		require.Len(t, result.Templates, 2)
+		assert.Equal(t, "tp", result.Templates[0].Name)
+		require.NotNil(t, result.Templates[0].BestTrial)
+		assert.InDelta(t, 2000, result.Templates[0].BestTrial.Score, 0.01)
+		assert.Len(t, result.Templates[0].Trials, 3)
+
+		assert.Equal(t, "pp", result.Templates[1].Name)
+		assert.Len(t, result.Templates[1].Trials, 1)
+
+		// GlobalBest
+		require.NotNil(t, result.GlobalBest)
+		assert.InDelta(t, 2000, result.GlobalBest.Score, 0.01)
+	})
+
+	t.Run("in progress - no endTime", func(t *testing.T) {
+		state := &abtypes.ExperimentState{
+			ExperimentID: "exp-1",
+			StartTime:    startTime,
+			Templates: []abtypes.TemplateState{
+				{
+					Name: "tp",
+					Trials: []abtypes.TrialResult{
+						{TrialIndex: 0, SLAPass: true, Score: 1000},
+					},
+				},
+			},
+		}
+
+		result := BuildResult(state, cfg, time.Time{})
+
+		assert.True(t, result.Status.EndTime.IsZero())
+		assert.Equal(t, abtypes.Duration(0), result.Status.Duration)
+	})
+
+	t.Run("empty state", func(t *testing.T) {
+		state := &abtypes.ExperimentState{
+			ExperimentID: "exp-empty",
+			StartTime:    startTime,
+		}
+
+		result := BuildResult(state, cfg, endTime)
+
+		assert.Equal(t, "exp-empty", result.ExperimentID)
+		assert.Equal(t, 0, result.Status.NumTemplates)
+		assert.Equal(t, 0, result.Status.TotalTrials)
+		assert.Equal(t, 0, result.Status.NumSLAPass)
+		assert.Equal(t, 0, result.Status.NumSLAFail)
+		assert.Len(t, result.Templates, 0)
+		assert.Nil(t, result.GlobalBest)
+	})
+}
+
+func TestWriteResultJSON(t *testing.T) {
+	dir := t.TempDir()
+	result := &ResultDetail{
+		ExperimentID: "exp-test",
+		Status: ResultStatus{
+			TotalTrials: 5,
+			NumSLAPass:  4,
+			NumSLAFail:  1,
+		},
+		Config: ResultConfig{
+			Name:    "exp-test",
+			Backend: "vllm",
+		},
+	}
+
+	err := WriteResultJSON(dir, result)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "result.json"))
+	require.NoError(t, err)
+
+	// Verify file exists and contains expected content
+	assert.Contains(t, string(data), "exp-test")
+
+	// Verify JSON is valid and parseable
+	var parsed ResultDetail
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "exp-test", parsed.ExperimentID)
+	assert.Equal(t, 5, parsed.Status.TotalTrials)
+	assert.Equal(t, 4, parsed.Status.NumSLAPass)
+	assert.Equal(t, 1, parsed.Status.NumSLAFail)
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/pkg/autobenchmark/controller/sla.go
+++ b/pkg/autobenchmark/controller/sla.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// EvaluateSLA checks whether metrics satisfy all SLA constraints.
+// Returns (pass, score). Score is the value of the optimize metric when SLA passes,
+// or 0 when SLA fails.
+func EvaluateSLA(metrics *abtypes.Metrics, objectives config.ObjectivesSpec) (bool, float64) {
+	if metrics == nil {
+		return false, 0
+	}
+
+	sla := objectives.SLA
+
+	// Check TTFT P99 constraint
+	if sla.TTFTP99MaxMs != nil && metrics.TTFTP99 > *sla.TTFTP99MaxMs {
+		return false, 0
+	}
+
+	// Check TPOT P99 constraint
+	if sla.TPOTP99MaxMs != nil && metrics.TPOTP99 > *sla.TPOTP99MaxMs {
+		return false, 0
+	}
+
+	// Check error rate constraint
+	if sla.ErrorRateMax != nil && metrics.ErrorRate > *sla.ErrorRateMax {
+		return false, 0
+	}
+
+	// All SLA checks passed — compute score from optimize metric
+	score := getOptimizeMetric(metrics, objectives.Optimize)
+	return true, score
+}
+
+// getOptimizeMetric extracts the metric value to maximize based on the optimize target.
+func getOptimizeMetric(metrics *abtypes.Metrics, optimize string) float64 {
+	switch optimize {
+	case "outputThroughput":
+		return metrics.OutputThroughput
+	case "inputThroughput":
+		return metrics.InputThroughput
+	case "requestsPerSecond":
+		return metrics.RequestsPerSecond
+	default:
+		return metrics.OutputThroughput // fallback
+	}
+}

--- a/pkg/autobenchmark/controller/sla_test.go
+++ b/pkg/autobenchmark/controller/sla_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func f64(v float64) *float64 { return &v }
+
+func TestEvaluateSLA(t *testing.T) {
+	tests := []struct {
+		name       string
+		metrics    *abtypes.Metrics
+		objectives config.ObjectivesSpec
+		wantPass   bool
+		wantScore  float64
+	}{
+		{
+			name: "all pass - output throughput",
+			metrics: &abtypes.Metrics{
+				TTFTP99:          1500,
+				TPOTP99:          8,
+				ErrorRate:        0.005,
+				OutputThroughput: 2000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{TTFTP99MaxMs: f64(2000), TPOTP99MaxMs: f64(10), ErrorRateMax: f64(0.01)},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  true,
+			wantScore: 2000,
+		},
+		{
+			name: "TTFT P99 exceeds SLA",
+			metrics: &abtypes.Metrics{
+				TTFTP99:          2500,
+				TPOTP99:          5,
+				ErrorRate:        0,
+				OutputThroughput: 3000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{TTFTP99MaxMs: f64(2000)},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  false,
+			wantScore: 0,
+		},
+		{
+			name: "TPOT P99 exceeds SLA",
+			metrics: &abtypes.Metrics{
+				TTFTP99:          100,
+				TPOTP99:          15,
+				ErrorRate:        0,
+				OutputThroughput: 1000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{TPOTP99MaxMs: f64(10)},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  false,
+			wantScore: 0,
+		},
+		{
+			name: "error rate exceeds SLA",
+			metrics: &abtypes.Metrics{
+				TTFTP99:          100,
+				TPOTP99:          5,
+				ErrorRate:        0.02,
+				OutputThroughput: 500,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{ErrorRateMax: f64(0.01)},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  false,
+			wantScore: 0,
+		},
+		{
+			name: "no SLA constraints - always passes",
+			metrics: &abtypes.Metrics{
+				OutputThroughput: 1500,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  true,
+			wantScore: 1500,
+		},
+		{
+			name:    "nil metrics - fails",
+			metrics: nil,
+			objectives: config.ObjectivesSpec{
+				Optimize: "outputThroughput",
+			},
+			wantPass:  false,
+			wantScore: 0,
+		},
+		{
+			name: "optimize requestsPerSecond",
+			metrics: &abtypes.Metrics{
+				RequestsPerSecond: 50.5,
+				OutputThroughput:  2000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{},
+				Optimize: "requestsPerSecond",
+			},
+			wantPass:  true,
+			wantScore: 50.5,
+		},
+		{
+			name: "optimize inputThroughput",
+			metrics: &abtypes.Metrics{
+				InputThroughput:  800,
+				OutputThroughput: 2000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{},
+				Optimize: "inputThroughput",
+			},
+			wantPass:  true,
+			wantScore: 800,
+		},
+		{
+			name: "boundary - exactly at SLA limit passes",
+			metrics: &abtypes.Metrics{
+				TTFTP99:          2000,
+				OutputThroughput: 1000,
+			},
+			objectives: config.ObjectivesSpec{
+				SLA:      config.SLASpec{TTFTP99MaxMs: f64(2000)},
+				Optimize: "outputThroughput",
+			},
+			wantPass:  true,
+			wantScore: 1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pass, score := EvaluateSLA(tt.metrics, tt.objectives)
+			assert.Equal(t, tt.wantPass, pass)
+			assert.InDelta(t, tt.wantScore, score, 0.01)
+		})
+	}
+}

--- a/pkg/autobenchmark/controller/state.go
+++ b/pkg/autobenchmark/controller/state.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+const checkpointFile = "checkpoint.json"
+
+// StateManager handles experiment state persistence (checkpoint/resume).
+type StateManager struct {
+	baseDir string
+}
+
+// NewStateManager creates a StateManager that persists to the given directory.
+func NewStateManager(baseDir string) *StateManager {
+	return &StateManager{baseDir: baseDir}
+}
+
+// Save atomically writes the experiment state to disk.
+// Uses write-to-temp + rename to avoid corruption on crashes.
+func (sm *StateManager) Save(state *abtypes.ExperimentState) error {
+	if err := os.MkdirAll(sm.baseDir, 0755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling state: %w", err)
+	}
+
+	target := filepath.Join(sm.baseDir, checkpointFile)
+	tmp := target + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("writing temp checkpoint: %w", err)
+	}
+
+	if err := os.Rename(tmp, target); err != nil {
+		return fmt.Errorf("renaming checkpoint: %w", err)
+	}
+
+	return nil
+}
+
+// Load reads the experiment state from disk. Returns nil if no checkpoint exists.
+func (sm *StateManager) Load() (*abtypes.ExperimentState, error) {
+	path := filepath.Join(sm.baseDir, checkpointFile)
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading checkpoint: %w", err)
+	}
+
+	var state abtypes.ExperimentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshaling checkpoint: %w", err)
+	}
+
+	return &state, nil
+}
+
+// Exists returns whether a checkpoint file exists.
+func (sm *StateManager) Exists() bool {
+	_, err := os.Stat(filepath.Join(sm.baseDir, checkpointFile))
+	return err == nil
+}

--- a/pkg/autobenchmark/controller/state_test.go
+++ b/pkg/autobenchmark/controller/state_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func TestStateManager_SaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStateManager(dir)
+
+	state := &abtypes.ExperimentState{
+		ExperimentID:       "exp-123",
+		StartTime:          time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CurrentTemplateIdx: 1,
+		Templates: []abtypes.TemplateState{
+			{
+				Name:      "template-a",
+				Completed: true,
+				Trials: []abtypes.TrialResult{
+					{TrialIndex: 0, TemplateName: "template-a", SLAPass: true, Score: 1500},
+					{TrialIndex: 1, TemplateName: "template-a", SLAPass: false, Score: 0},
+				},
+				BestTrial: &abtypes.TrialResult{TrialIndex: 0, Score: 1500, SLAPass: true},
+			},
+			{
+				Name:      "template-b",
+				Completed: false,
+				Trials:    nil,
+			},
+		},
+		GlobalBest: &abtypes.TrialResult{TrialIndex: 0, TemplateName: "template-a", Score: 1500, SLAPass: true},
+	}
+
+	// Save
+	err := sm.Save(state)
+	require.NoError(t, err)
+	assert.True(t, sm.Exists())
+
+	// Load
+	loaded, err := sm.Load()
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, "exp-123", loaded.ExperimentID)
+	assert.Equal(t, 1, loaded.CurrentTemplateIdx)
+	require.Len(t, loaded.Templates, 2)
+	assert.True(t, loaded.Templates[0].Completed)
+	assert.False(t, loaded.Templates[1].Completed)
+	assert.Len(t, loaded.Templates[0].Trials, 2)
+	require.NotNil(t, loaded.GlobalBest)
+	assert.InDelta(t, 1500, loaded.GlobalBest.Score, 0.01)
+}
+
+func TestStateManager_LoadNonExistent(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStateManager(filepath.Join(dir, "nodir"))
+
+	loaded, err := sm.Load()
+	require.NoError(t, err)
+	assert.Nil(t, loaded)
+	assert.False(t, sm.Exists())
+}
+
+func TestStateManager_Resume(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStateManager(dir)
+
+	// Simulate: template-0 completed 5 trials, template-1 has 0
+	state := &abtypes.ExperimentState{
+		ExperimentID:       "exp-resume",
+		CurrentTemplateIdx: 1,
+		Templates: []abtypes.TemplateState{
+			{
+				Name:      "t0",
+				Completed: true,
+				Trials: []abtypes.TrialResult{
+					{TrialIndex: 0}, {TrialIndex: 1}, {TrialIndex: 2},
+					{TrialIndex: 3}, {TrialIndex: 4},
+				},
+			},
+			{
+				Name:      "t1",
+				Completed: false,
+			},
+		},
+	}
+
+	require.NoError(t, sm.Save(state))
+
+	// Load and verify resume point
+	loaded, err := sm.Load()
+	require.NoError(t, err)
+	assert.Equal(t, 1, loaded.CurrentTemplateIdx)
+	assert.True(t, loaded.Templates[0].Completed)
+	assert.Len(t, loaded.Templates[0].Trials, 5)
+	assert.False(t, loaded.Templates[1].Completed)
+}
+
+func TestStateManager_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewStateManager(dir)
+
+	// Write initial state
+	state1 := &abtypes.ExperimentState{ExperimentID: "v1"}
+	require.NoError(t, sm.Save(state1))
+
+	// Write updated state
+	state2 := &abtypes.ExperimentState{ExperimentID: "v2"}
+	require.NoError(t, sm.Save(state2))
+
+	// Load should return v2
+	loaded, err := sm.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "v2", loaded.ExperimentID)
+}
+
+func TestStateManager_CreatesDirIfNeeded(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	sm := NewStateManager(dir)
+
+	state := &abtypes.ExperimentState{ExperimentID: "test"}
+	require.NoError(t, sm.Save(state))
+	assert.True(t, sm.Exists())
+}

--- a/pkg/autobenchmark/controller/template.go
+++ b/pkg/autobenchmark/controller/template.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+)
+
+// TemplateIterator iterates over the list of template references.
+type TemplateIterator struct {
+	templates []config.TemplateRef
+	index     int
+}
+
+// NewTemplateIterator creates a new iterator starting at the given index.
+func NewTemplateIterator(templates []config.TemplateRef, startIndex int) *TemplateIterator {
+	if startIndex < 0 {
+		startIndex = 0
+	}
+	return &TemplateIterator{
+		templates: templates,
+		index:     startIndex,
+	}
+}
+
+// HasNext returns true if there are more templates to iterate.
+func (ti *TemplateIterator) HasNext() bool {
+	return ti.index < len(ti.templates)
+}
+
+// Next returns the current template and advances the iterator.
+// Returns nil if no more templates.
+func (ti *TemplateIterator) Next() *config.TemplateRef {
+	if !ti.HasNext() {
+		return nil
+	}
+	ref := &ti.templates[ti.index]
+	ti.index++
+	return ref
+}
+
+// CurrentIndex returns the current iterator position.
+func (ti *TemplateIterator) CurrentIndex() int {
+	return ti.index
+}
+
+// Skip advances the iterator past completed templates (for resume).
+func (ti *TemplateIterator) Skip(n int) {
+	ti.index += n
+	if ti.index > len(ti.templates) {
+		ti.index = len(ti.templates)
+	}
+}

--- a/pkg/autobenchmark/controller/template_test.go
+++ b/pkg/autobenchmark/controller/template_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+)
+
+func TestTemplateIterator_Basic(t *testing.T) {
+	templates := []config.TemplateRef{
+		{Name: "t1", Template: "t1.yaml"},
+		{Name: "t2", Template: "t2.yaml"},
+		{Name: "t3", Template: "t3.yaml"},
+	}
+
+	iter := NewTemplateIterator(templates, 0)
+	assert.True(t, iter.HasNext())
+	assert.Equal(t, 0, iter.CurrentIndex())
+
+	ref := iter.Next()
+	require.NotNil(t, ref)
+	assert.Equal(t, "t1", ref.Name)
+	assert.Equal(t, 1, iter.CurrentIndex())
+
+	ref = iter.Next()
+	require.NotNil(t, ref)
+	assert.Equal(t, "t2", ref.Name)
+
+	ref = iter.Next()
+	require.NotNil(t, ref)
+	assert.Equal(t, "t3", ref.Name)
+
+	assert.False(t, iter.HasNext())
+	assert.Nil(t, iter.Next())
+}
+
+func TestTemplateIterator_Empty(t *testing.T) {
+	iter := NewTemplateIterator(nil, 0)
+	assert.False(t, iter.HasNext())
+	assert.Nil(t, iter.Next())
+}
+
+func TestTemplateIterator_StartIndex(t *testing.T) {
+	templates := []config.TemplateRef{
+		{Name: "t1"},
+		{Name: "t2"},
+		{Name: "t3"},
+	}
+
+	// Start from index 2 (resume scenario)
+	iter := NewTemplateIterator(templates, 2)
+	assert.True(t, iter.HasNext())
+
+	ref := iter.Next()
+	require.NotNil(t, ref)
+	assert.Equal(t, "t3", ref.Name)
+
+	assert.False(t, iter.HasNext())
+}
+
+func TestTemplateIterator_Skip(t *testing.T) {
+	templates := []config.TemplateRef{
+		{Name: "t1"},
+		{Name: "t2"},
+		{Name: "t3"},
+		{Name: "t4"},
+	}
+
+	iter := NewTemplateIterator(templates, 0)
+	iter.Skip(2) // Skip first 2
+
+	assert.True(t, iter.HasNext())
+	ref := iter.Next()
+	require.NotNil(t, ref)
+	assert.Equal(t, "t3", ref.Name)
+}
+
+func TestTemplateIterator_SkipBeyondEnd(t *testing.T) {
+	templates := []config.TemplateRef{
+		{Name: "t1"},
+	}
+
+	iter := NewTemplateIterator(templates, 0)
+	iter.Skip(10) // Skip more than available
+	assert.False(t, iter.HasNext())
+}
+
+func TestTemplateIterator_NegativeStartIndex(t *testing.T) {
+	templates := []config.TemplateRef{
+		{Name: "t1"},
+	}
+
+	iter := NewTemplateIterator(templates, -5)
+	assert.Equal(t, 0, iter.CurrentIndex())
+	assert.True(t, iter.HasNext())
+}

--- a/pkg/autobenchmark/evaluator/genaibench.go
+++ b/pkg/autobenchmark/evaluator/genaibench.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evaluator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func init() {
+	Register("genai-bench", func() Evaluator { return &GenAIBench{} })
+}
+
+// GenAIBench implements the Evaluator interface using the genai-bench tool.
+type GenAIBench struct {
+	tokenizerSource string
+	apiKey          string
+}
+
+// Name returns the evaluator name.
+func (g *GenAIBench) Name() string { return "genai-bench" }
+
+// Init reads plugin-specific config. Expected keys: tokenizerSource (string), apiKey (string).
+func (g *GenAIBench) Init(cfg map[string]interface{}) error {
+	if v, ok := cfg["tokenizerSource"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("genai-bench: tokenizerSource must be a string, got %T", v)
+		}
+		g.tokenizerSource = s
+	}
+	if v, ok := cfg["apiKey"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("genai-bench: apiKey must be a string, got %T", v)
+		}
+		g.apiKey = s
+	}
+	return nil
+}
+
+// Run executes genai-bench as a subprocess.
+func (g *GenAIBench) Run(ctx context.Context, evalCtx EvalContext) error {
+	args := g.buildGenAIBenchArgs(evalCtx)
+
+	logger := log.FromContext(ctx)
+	logger.Info("Running genai-bench", "command", strings.Join(append([]string{"genai-bench"}, args...), " "))
+
+	cmd := exec.CommandContext(ctx, "genai-bench", args...)
+	cmd.Env = append(os.Environ(), "ENABLE_UI=false")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("genai-bench failed: %w", err)
+	}
+	return nil
+}
+
+// CollectResults reads result JSON files from the given directory and aggregates metrics.
+// genai-bench writes one JSON file per concurrency level (e.g., D100_100_text-to-text_num_concurrency_4_time_16s.json).
+// Metrics are aggregated across all result files using worst-case semantics for SLA checking.
+func (g *GenAIBench) CollectResults(resultDir string) (*abtypes.Metrics, error) {
+	entries, err := os.ReadDir(resultDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading result directory %q: %w", resultDir, err)
+	}
+
+	results := make([]benchmarkResult, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") || name == "experiment_metadata.json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(resultDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("reading result file %q: %w", name, err)
+		}
+		var r benchmarkResult
+		if err := json.Unmarshal(data, &r); err != nil {
+			return nil, fmt.Errorf("parsing result file %q: %w", name, err)
+		}
+		results = append(results, r)
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no result JSON files found in %q", resultDir)
+	}
+
+	return aggregateResults(results), nil
+}
+
+// aggregateResults merges metrics across multiple concurrency-level results.
+// Uses worst-case for latency/error metrics (SLA-oriented) and average for throughput.
+func aggregateResults(results []benchmarkResult) *abtypes.Metrics {
+	m := &abtypes.Metrics{}
+	n := float64(len(results))
+
+	var sumOutputTP, sumInputTP, sumTotalTP, sumRPS float64
+	var maxErrorRate float64
+	var maxTTFTP50, maxTTFTP99, maxTPOTP50, maxTPOTP99 float64
+	var totalCompleted, totalErrors, totalRequests int
+
+	for _, r := range results {
+		am := r.AggregatedMetrics
+		sumOutputTP += am.MeanOutputThroughput
+		sumInputTP += am.MeanInputThroughput
+		sumTotalTP += am.MeanTotalTokensThroughput
+		sumRPS += am.RequestsPerSecond
+		maxErrorRate = math.Max(maxErrorRate, am.ErrorRate)
+		totalCompleted += am.NumCompletedRequests
+		totalErrors += am.NumErrorRequests
+		totalRequests += am.NumRequests
+
+		if ttft, ok := am.Stats["ttft"]; ok {
+			maxTTFTP50 = math.Max(maxTTFTP50, ttft.P50)
+			maxTTFTP99 = math.Max(maxTTFTP99, ttft.P99)
+		}
+		if tpot, ok := am.Stats["tpot"]; ok {
+			maxTPOTP50 = math.Max(maxTPOTP50, tpot.P50)
+			maxTPOTP99 = math.Max(maxTPOTP99, tpot.P99)
+		}
+	}
+
+	m.OutputThroughput = sumOutputTP / n
+	m.InputThroughput = sumInputTP / n
+	m.TotalThroughput = sumTotalTP / n
+	m.RequestsPerSecond = sumRPS / n
+	m.ErrorRate = maxErrorRate
+	m.NumCompletedRequests = totalCompleted
+	m.NumErrorRequests = totalErrors
+	m.NumRequests = totalRequests
+	m.TTFTP50 = maxTTFTP50
+	m.TTFTP99 = maxTTFTP99
+	m.TPOTP50 = maxTPOTP50
+	m.TPOTP99 = maxTPOTP99
+
+	return m
+}
+
+// benchmarkResult mirrors the genai-bench output structure.
+type benchmarkResult struct {
+	AggregatedMetrics aggregatedMetrics `json:"aggregated_metrics"`
+}
+
+type aggregatedMetrics struct {
+	MeanOutputThroughput      float64          `json:"mean_output_throughput_tokens_per_s"`
+	MeanInputThroughput       float64          `json:"mean_input_throughput_tokens_per_s"`
+	MeanTotalTokensThroughput float64          `json:"mean_total_tokens_throughput_tokens_per_s"`
+	RequestsPerSecond         float64          `json:"requests_per_second"`
+	ErrorRate                 float64          `json:"error_rate"`
+	NumCompletedRequests      int              `json:"num_completed_requests"`
+	NumErrorRequests          int              `json:"num_error_requests"`
+	NumRequests               int              `json:"num_requests"`
+	Stats                     map[string]stats `json:"stats"`
+}
+
+type stats struct {
+	P50 float64 `json:"p50"`
+	P99 float64 `json:"p99"`
+}
+
+// buildGenAIBenchArgs constructs the command-line arguments for genai-bench.
+// It translates the generic ScenarioSpec into genai-bench specific CLI flags.
+func (g *GenAIBench) buildGenAIBenchArgs(evalCtx EvalContext) []string {
+	scenario := evalCtx.Scenario
+	backend := evalCtx.Backend
+	if backend == "" {
+		backend = "sglang"
+	}
+	apiKey := g.apiKey
+	if apiKey == "" {
+		apiKey = "EMPTY"
+	}
+	args := []string{
+		"benchmark",
+		"--api-backend", backend,
+		"--api-base", evalCtx.Endpoint,
+		"--api-model-name", evalCtx.ModelName,
+		"--api-key", apiKey,
+		"--task", "text-to-text",
+	}
+
+	// Translate workloads to genai-bench traffic scenarios
+	for _, w := range scenario.Workloads {
+		ts := translateWorkload(w)
+		args = append(args, "--traffic-scenario", ts)
+	}
+
+	for _, c := range scenario.Concurrency {
+		args = append(args, "--num-concurrency", strconv.Itoa(c))
+	}
+
+	// Duration -> --max-time-per-run (in minutes)
+	if scenario.Duration != "" {
+		if d, err := time.ParseDuration(scenario.Duration); err == nil {
+			minutes := int(d.Minutes())
+			if minutes < 1 {
+				minutes = 1
+			}
+			args = append(args, "--max-time-per-run", strconv.Itoa(minutes))
+		}
+	}
+
+	if scenario.MaxRequests > 0 {
+		args = append(args, "--max-requests-per-run", strconv.Itoa(scenario.MaxRequests))
+	}
+
+	// Output directory: split into base dir + folder name for genai-bench convention.
+	if evalCtx.OutputDir != "" {
+		baseDir := filepath.Dir(evalCtx.OutputDir)
+		folderName := filepath.Base(evalCtx.OutputDir)
+		args = append(args, "--experiment-base-dir", baseDir, "--experiment-folder-name", folderName)
+	}
+
+	if g.tokenizerSource != "" {
+		args = append(args, "--model-tokenizer", g.tokenizerSource)
+	}
+
+	return args
+}
+
+// translateWorkload converts a project-own workload string to genai-bench traffic scenario format.
+func translateWorkload(w string) string {
+	wl, err := config.ParseWorkload(w)
+	if err != nil {
+		return w
+	}
+	switch wl.Type {
+	case config.WorkloadFixed:
+		return fmt.Sprintf("D(%d,%d)", wl.InputTokens, wl.OutputTokens)
+	case config.WorkloadNormal:
+		return fmt.Sprintf("N(%d,%d)/(%d,%d)", wl.InputMean, wl.InputStdDev, wl.OutputMean, wl.OutputStdDev)
+	case config.WorkloadUniform:
+		return fmt.Sprintf("U(%d,%d)/(%d,%d)", wl.InputMin, wl.InputMax, wl.OutputMin, wl.OutputMax)
+	case config.WorkloadDataset:
+		return "dataset"
+	default:
+		return w
+	}
+}

--- a/pkg/autobenchmark/evaluator/genaibench_test.go
+++ b/pkg/autobenchmark/evaluator/genaibench_test.go
@@ -1,0 +1,487 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evaluator
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+)
+
+func TestGenAIBench_Name(t *testing.T) {
+	g := &GenAIBench{}
+	assert.Equal(t, "genai-bench", g.Name())
+}
+
+func TestBuildGenAIBenchArgs(t *testing.T) {
+	tests := []struct {
+		name            string
+		tokenizerSource string // for Init
+		evalCtx         EvalContext
+		expected        []string // args that must all be present
+		absent          []string // args that must NOT be present
+	}{
+		{
+			name: "basic args with workload translation",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "test-scenario",
+					Workloads:   []string{"fixed(100,1000)"},
+					Concurrency: []int{4},
+				},
+			},
+			expected: []string{
+				"benchmark",
+				"--api-backend", "sglang",
+				"--api-base", "http://svc:8000",
+				"--api-model-name", "my-model",
+				"--task", "text-to-text",
+				"--traffic-scenario", "D(100,1000)",
+				"--num-concurrency", "4",
+			},
+			absent: []string{
+				"--experiment-base-dir",
+				"--experiment-folder-name",
+				"--model-tokenizer",
+			},
+		},
+		{
+			name: "with output dir",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{1},
+				},
+				OutputDir: "/data/results/scenario/trial-0",
+			},
+			expected: []string{
+				"--experiment-base-dir", "/data/results/scenario",
+				"--experiment-folder-name", "trial-0",
+			},
+		},
+		{
+			name:            "with tokenizer from Init",
+			tokenizerSource: "/models/tokenizer",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{1},
+				},
+			},
+			expected: []string{
+				"--model-tokenizer", "/models/tokenizer",
+			},
+		},
+		{
+			name: "workload translation and limits",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "multi-wl",
+					Workloads:   []string{"fixed(100,1000)", "normal(480,240/300,150)"},
+					Concurrency: []int{4, 8},
+					Duration:    "2m",
+					MaxRequests: 1000,
+				},
+			},
+			expected: []string{
+				"--traffic-scenario", "D(100,1000)",
+				"--traffic-scenario", "N(480,240)/(300,150)",
+				"--num-concurrency", "4",
+				"--num-concurrency", "8",
+				"--max-time-per-run", "2",
+				"--max-requests-per-run", "1000",
+			},
+		},
+		{
+			name: "uniform workload translation",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Workloads:   []string{"uniform(100,500/200,800)"},
+					Concurrency: []int{4},
+				},
+			},
+			expected: []string{
+				"--traffic-scenario", "U(100,500)/(200,800)",
+			},
+		},
+		{
+			name: "dataset workload translation",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Workloads:   []string{"dataset"},
+					Concurrency: []int{4},
+				},
+			},
+			expected: []string{
+				"--traffic-scenario", "dataset",
+			},
+		},
+		{
+			name: "multiple concurrency values",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{1, 2, 4, 8},
+				},
+			},
+			expected: []string{
+				"--num-concurrency", "1",
+				"--num-concurrency", "2",
+				"--num-concurrency", "4",
+				"--num-concurrency", "8",
+			},
+		},
+		{
+			name: "duration 30s rounds up to 1 minute",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{4},
+					Duration:    "30s",
+				},
+			},
+			expected: []string{
+				"--max-time-per-run", "1",
+			},
+		},
+		{
+			name: "backend from config",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Backend:   "vllm",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{4},
+				},
+			},
+			expected: []string{
+				"--api-backend", "vllm",
+			},
+			absent: []string{
+				"sglang",
+			},
+		},
+		{
+			name: "default backend when empty",
+			evalCtx: EvalContext{
+				Endpoint:  "http://svc:8000",
+				ModelName: "my-model",
+				Scenario: config.ScenarioSpec{
+					Name:        "s1",
+					Concurrency: []int{4},
+				},
+			},
+			expected: []string{
+				"--api-backend", "sglang",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GenAIBench{}
+			if tt.tokenizerSource != "" {
+				require.NoError(t, g.Init(map[string]interface{}{
+					"tokenizerSource": tt.tokenizerSource,
+				}))
+			}
+			args := g.buildGenAIBenchArgs(tt.evalCtx)
+
+			// Check all expected args are present
+			for i := 0; i < len(tt.expected); i++ {
+				assert.Contains(t, args, tt.expected[i],
+					"expected arg %q not found", tt.expected[i])
+			}
+
+			// Check absent args are not present
+			for _, a := range tt.absent {
+				assert.NotContains(t, args, a,
+					"arg %q should not be present", a)
+			}
+		})
+	}
+}
+
+func TestGenAIBench_CollectResults(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   map[string]interface{} // filename -> content to marshal as JSON
+		wantErr string
+		check   func(t *testing.T, dir string)
+	}{
+		{
+			name: "single result file",
+			files: map[string]interface{}{
+				"D100_100_text-to-text_num_concurrency_4_time_16s.json": benchmarkResult{
+					AggregatedMetrics: aggregatedMetrics{
+						MeanOutputThroughput:      1500.5,
+						MeanInputThroughput:       800.3,
+						MeanTotalTokensThroughput: 2300.8,
+						RequestsPerSecond:         25.7,
+						ErrorRate:                 0.01,
+						NumCompletedRequests:      99,
+						NumErrorRequests:          1,
+						NumRequests:               100,
+						Stats: map[string]stats{
+							"ttft": {P50: 12.5, P99: 45.0},
+							"tpot": {P50: 3.2, P99: 8.7},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, dir string) {
+				g := &GenAIBench{}
+				m, err := g.CollectResults(dir)
+				require.NoError(t, err)
+				assert.InDelta(t, 1500.5, m.OutputThroughput, 0.01)
+				assert.InDelta(t, 800.3, m.InputThroughput, 0.01)
+				assert.InDelta(t, 2300.8, m.TotalThroughput, 0.01)
+				assert.InDelta(t, 25.7, m.RequestsPerSecond, 0.01)
+				assert.InDelta(t, 0.01, m.ErrorRate, 0.001)
+				assert.Equal(t, 99, m.NumCompletedRequests)
+				assert.Equal(t, 1, m.NumErrorRequests)
+				assert.Equal(t, 100, m.NumRequests)
+				assert.InDelta(t, 12.5, m.TTFTP50, 0.01)
+				assert.InDelta(t, 45.0, m.TTFTP99, 0.01)
+				assert.InDelta(t, 3.2, m.TPOTP50, 0.01)
+				assert.InDelta(t, 8.7, m.TPOTP99, 0.01)
+			},
+		},
+		{
+			name: "multiple concurrency files aggregated",
+			files: map[string]interface{}{
+				"D100_100_text-to-text_num_concurrency_4_time_16s.json": benchmarkResult{
+					AggregatedMetrics: aggregatedMetrics{
+						MeanOutputThroughput: 1000.0,
+						RequestsPerSecond:    20.0,
+						ErrorRate:            0.01,
+						NumCompletedRequests: 99,
+						NumErrorRequests:     1,
+						NumRequests:          100,
+						Stats: map[string]stats{
+							"ttft": {P50: 10.0, P99: 40.0},
+							"tpot": {P50: 3.0, P99: 8.0},
+						},
+					},
+				},
+				"N480_240_300_150_text-to-text_num_concurrency_16_time_26s.json": benchmarkResult{
+					AggregatedMetrics: aggregatedMetrics{
+						MeanOutputThroughput: 2000.0,
+						RequestsPerSecond:    30.0,
+						ErrorRate:            0.05,
+						NumCompletedRequests: 95,
+						NumErrorRequests:     5,
+						NumRequests:          100,
+						Stats: map[string]stats{
+							"ttft": {P50: 20.0, P99: 80.0},
+							"tpot": {P50: 5.0, P99: 12.0},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, dir string) {
+				g := &GenAIBench{}
+				m, err := g.CollectResults(dir)
+				require.NoError(t, err)
+				// Throughput averaged: (1000+2000)/2 = 1500
+				assert.InDelta(t, 1500.0, m.OutputThroughput, 0.01)
+				// RPS averaged: (20+30)/2 = 25
+				assert.InDelta(t, 25.0, m.RequestsPerSecond, 0.01)
+				// Error rate worst-case: max(0.01, 0.05) = 0.05
+				assert.InDelta(t, 0.05, m.ErrorRate, 0.001)
+				// Request counts summed
+				assert.Equal(t, 194, m.NumCompletedRequests)
+				assert.Equal(t, 6, m.NumErrorRequests)
+				assert.Equal(t, 200, m.NumRequests)
+				// Latency worst-case: max across files
+				assert.InDelta(t, 20.0, m.TTFTP50, 0.01)
+				assert.InDelta(t, 80.0, m.TTFTP99, 0.01)
+				assert.InDelta(t, 5.0, m.TPOTP50, 0.01)
+				assert.InDelta(t, 12.0, m.TPOTP99, 0.01)
+			},
+		},
+		{
+			name: "skips experiment_metadata.json",
+			files: map[string]interface{}{
+				"experiment_metadata.json": map[string]string{"version": "1.0"},
+				"result_concurrency_4.json": benchmarkResult{
+					AggregatedMetrics: aggregatedMetrics{
+						MeanOutputThroughput: 500.0,
+						RequestsPerSecond:    10.0,
+						NumRequests:          50,
+					},
+				},
+			},
+			check: func(t *testing.T, dir string) {
+				g := &GenAIBench{}
+				m, err := g.CollectResults(dir)
+				require.NoError(t, err)
+				assert.InDelta(t, 500.0, m.OutputThroughput, 0.01)
+				assert.Equal(t, 50, m.NumRequests)
+			},
+		},
+		{
+			name: "missing stats map defaults to zero",
+			files: map[string]interface{}{
+				"result.json": benchmarkResult{
+					AggregatedMetrics: aggregatedMetrics{
+						MeanOutputThroughput: 100.0,
+						RequestsPerSecond:    10.0,
+						Stats:                nil,
+					},
+				},
+			},
+			check: func(t *testing.T, dir string) {
+				g := &GenAIBench{}
+				m, err := g.CollectResults(dir)
+				require.NoError(t, err)
+				assert.InDelta(t, 100.0, m.OutputThroughput, 0.01)
+				assert.Equal(t, float64(0), m.TTFTP50)
+				assert.Equal(t, float64(0), m.TPOTP99)
+			},
+		},
+		{
+			name:    "empty directory",
+			files:   map[string]interface{}{},
+			wantErr: "no result JSON files found",
+		},
+		{
+			name:    "nonexistent directory",
+			wantErr: "reading result directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "nonexistent directory" {
+				g := &GenAIBench{}
+				_, err := g.CollectResults("/nonexistent/path/that/does/not/exist")
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			dir := t.TempDir()
+			for name, content := range tt.files {
+				data, err := json.Marshal(content)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), data, 0644))
+			}
+
+			if tt.wantErr != "" {
+				g := &GenAIBench{}
+				_, err := g.CollectResults(dir)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			tt.check(t, dir)
+		})
+	}
+}
+
+func TestFactoryRegistration(t *testing.T) {
+	t.Run("genai-bench registered", func(t *testing.T) {
+		e, err := Get("genai-bench")
+		require.NoError(t, err)
+		assert.Equal(t, "genai-bench", e.Name())
+	})
+
+	t.Run("unknown evaluator", func(t *testing.T) {
+		_, err := Get("nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown evaluator")
+	})
+}
+
+func TestGenAIBench_Init(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		g := &GenAIBench{}
+		err := g.Init(map[string]interface{}{
+			"tokenizerSource": "/models/tokenizer",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "/models/tokenizer", g.tokenizerSource)
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		g := &GenAIBench{}
+		err := g.Init(map[string]interface{}{})
+		require.NoError(t, err)
+		assert.Empty(t, g.tokenizerSource)
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		g := &GenAIBench{}
+		err := g.Init(nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong type for tokenizerSource", func(t *testing.T) {
+		g := &GenAIBench{}
+		err := g.Init(map[string]interface{}{
+			"tokenizerSource": 123,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a string")
+	})
+}
+
+func TestTranslateWorkload(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"fixed(100,1000)", "D(100,1000)"},
+		{"normal(480,240/300,150)", "N(480,240)/(300,150)"},
+		{"uniform(100,500/200,800)", "U(100,500)/(200,800)"},
+		{"dataset", "dataset"},
+		{"unknown-format", "unknown-format"}, // passthrough on parse error
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := translateWorkload(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/autobenchmark/evaluator/interface.go
+++ b/pkg/autobenchmark/evaluator/interface.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evaluator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// Evaluator defines the interface for benchmark evaluation tools.
+type Evaluator interface {
+	// Name returns the evaluator name.
+	Name() string
+
+	// Init initializes the evaluator with plugin-specific configuration.
+	// Called once after factory creation, before any Run calls.
+	Init(config map[string]interface{}) error
+
+	// Run executes the benchmark tool as a subprocess.
+	Run(ctx context.Context, evalCtx EvalContext) error
+
+	// CollectResults reads result files from the given directory and extracts metrics.
+	CollectResults(resultDir string) (*abtypes.Metrics, error)
+}
+
+// EvalContext provides context for running a benchmark evaluation.
+type EvalContext struct {
+	Endpoint  string              // inference service URL (e.g., http://svc:8000)
+	ModelName string              // model name for the benchmark tool
+	Backend   string              // inference backend (sglang | vllm)
+	Scenario  config.ScenarioSpec // workload scenario (generic format)
+	OutputDir string              // local directory for result output
+}
+
+// Factory is a function that creates a new Evaluator instance.
+type Factory func() Evaluator
+
+var (
+	registry = make(map[string]Factory)
+	mu       sync.RWMutex
+)
+
+// Register registers an Evaluator factory by name.
+func Register(name string, factory Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[name] = factory
+}
+
+// Get creates a new Evaluator instance by name.
+func Get(name string) (Evaluator, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	factory, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown evaluator: %q", name)
+	}
+	return factory(), nil
+}

--- a/pkg/autobenchmark/lifecycle/builder.go
+++ b/pkg/autobenchmark/lifecycle/builder.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+	roleinstanceutils "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/utils"
+)
+
+// Builder creates trial-specific RBG specs from base templates.
+type Builder struct {
+	mapper *ParamMapper
+}
+
+// NewBuilder creates a Builder for the given backend.
+func NewBuilder(backend string) (*Builder, error) {
+	mapper, err := NewParamMapper(backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Builder{mapper: mapper}, nil
+}
+
+// LoadTemplate reads an RBG YAML file and extracts the RoleBasedGroup object.
+// Handles multi-document YAML (RBG + Service).
+func LoadTemplate(path string) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading template file %q: %w", path, err)
+	}
+	return ParseRBGFromYAML(data)
+}
+
+// ParseRBGFromYAML extracts the RoleBasedGroup from a potentially multi-document YAML.
+func ParseRBGFromYAML(data []byte) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading YAML document: %w", err)
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		// Decode YAML to JSON first (K8s objects use JSON tags)
+		jsonData, err := yaml.ToJSON(doc)
+		if err != nil {
+			continue // skip non-parseable documents
+		}
+
+		// Check if this is an RBG by looking at kind
+		var meta struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal(jsonData, &meta); err != nil {
+			continue
+		}
+		if meta.Kind != "RoleBasedGroup" {
+			continue
+		}
+
+		var rbg workloadsv1alpha2.RoleBasedGroup
+		if err := json.Unmarshal(jsonData, &rbg); err != nil {
+			return nil, fmt.Errorf("unmarshaling RoleBasedGroup: %w", err)
+		}
+		return &rbg, nil
+	}
+	return nil, fmt.Errorf("no RoleBasedGroup found in YAML")
+}
+
+// BuildTrial creates a trial-specific RBG spec by deep-copying the base and
+// overlaying the search params onto the container commands.
+//
+// Role-specific params: keys in params map to role names.
+// "default" key applies to all roles.
+func (b *Builder) BuildTrial(base *workloadsv1alpha2.RoleBasedGroup, trialIndex int, params abtypes.RoleParamSet) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	// Deep-copy via JSON round-trip
+	trial, err := deepCopyRBG(base)
+	if err != nil {
+		return nil, fmt.Errorf("deep-copying RBG: %w", err)
+	}
+
+	// Generate trial name
+	trial.Name = fmt.Sprintf("%s-trial-%d", base.Name, trialIndex)
+	// Clear resource version (new object)
+	trial.ResourceVersion = ""
+	trial.UID = ""
+
+	// Overlay params on each role
+	for i := range trial.Spec.Roles {
+		role := &trial.Spec.Roles[i]
+
+		// Collect params for this role: start with "default", then override with role-specific
+		merged := make(map[string]any)
+		if defaultParams, ok := params["default"]; ok {
+			for k, v := range defaultParams {
+				merged[k] = v
+			}
+		}
+		if roleParams, ok := params[role.Name]; ok {
+			for k, v := range roleParams {
+				merged[k] = v
+			}
+		}
+		if len(merged) == 0 {
+			continue
+		}
+
+		if err := b.overlayRoleParams(role, merged); err != nil {
+			return nil, fmt.Errorf("overlaying params on role %q: %w", role.Name, err)
+		}
+	}
+
+	return trial, nil
+}
+
+// overlayRoleParams overlays params onto the first container's command args in a role.
+func (b *Builder) overlayRoleParams(role *workloadsv1alpha2.RoleSpec, params map[string]any) error {
+	podSpec := getRolePodSpec(role)
+	if podSpec == nil {
+		return fmt.Errorf("role %q has no PodSpec", role.Name)
+	}
+
+	if len(podSpec.Containers) == 0 {
+		return fmt.Errorf("role %q has no containers", role.Name)
+	}
+
+	container := &podSpec.Containers[0]
+	newArgs, err := b.mapper.OverlayArgs(mergeCommandArgs(container), params)
+	if err != nil {
+		return err
+	}
+
+	// Write back: if original used Command, keep that pattern
+	if len(container.Command) > 0 {
+		container.Command = newArgs
+		container.Args = nil
+	} else {
+		container.Args = newArgs
+	}
+	return nil
+}
+
+// mergeCommandArgs returns the full command line (Command + Args).
+// In Kubernetes, the executed process is command[0:] + args[0:],
+// so we must merge both to get the complete argument list.
+func mergeCommandArgs(c *corev1.Container) []string {
+	result := make([]string, 0, len(c.Command)+len(c.Args))
+	result = append(result, c.Command...)
+	result = append(result, c.Args...)
+	return result
+}
+
+// getRolePodSpec extracts the PodSpec from a RoleSpec regardless of pattern type.
+func getRolePodSpec(role *workloadsv1alpha2.RoleSpec) *corev1.PodSpec {
+	if sp := role.StandalonePattern; sp != nil {
+		if sp.Template != nil {
+			return &sp.Template.Spec
+		}
+	}
+	if lw := role.LeaderWorkerPattern; lw != nil {
+		if lw.Template != nil {
+			return &lw.Template.Spec
+		}
+	}
+	return nil
+}
+
+// GetTrialName returns the trial-specific RBG name.
+func GetTrialName(baseName string, trialIndex int) string {
+	return fmt.Sprintf("%s-trial-%d", baseName, trialIndex)
+}
+
+// GetServiceEndpoint returns the inference endpoint URL for an RBG by convention.
+// Service name is resolved via the controller's GetServiceName helper.
+func GetServiceEndpoint(rbg *workloadsv1alpha2.RoleBasedGroup, role *workloadsv1alpha2.RoleSpec, namespace string, port int) string {
+	svcName := rbg.GetServiceName(role)
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", svcName, namespace, port)
+}
+
+// GetLeaderPodEndpoint returns the inference endpoint URL for a leader pod in leader-worker pattern.
+// Pod naming and service naming are delegated to the RoleInstance controller helpers so that
+// auto-benchmark and the controller share the same naming rules.
+// The endpoint uses pod DNS under the headless service:
+//
+//	{podName}.{svcName}.{namespace}.svc.cluster.local:port
+func GetLeaderPodEndpoint(rbg *workloadsv1alpha2.RoleBasedGroup, role *workloadsv1alpha2.RoleSpec, namespace string, port int) string {
+	svcName := rbg.GetServiceName(role)
+	instanceName := rbg.GetWorkloadName(role)
+	podName := roleinstanceutils.FormatComponentPodName(instanceName, "leader", 0, constants.LeaderWorkerSetTemplateType)
+	return fmt.Sprintf("http://%s.%s.%s.svc.cluster.local:%d", podName, svcName, namespace, port)
+}
+
+func deepCopyRBG(src *workloadsv1alpha2.RoleBasedGroup) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+	var dst workloadsv1alpha2.RoleBasedGroup
+	if err := json.Unmarshal(data, &dst); err != nil {
+		return nil, err
+	}
+	return &dst, nil
+}

--- a/pkg/autobenchmark/lifecycle/builder_test.go
+++ b/pkg/autobenchmark/lifecycle/builder_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func testdataPath(name string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "testdata", name)
+}
+
+func TestLoadTemplate_AggRBG(t *testing.T) {
+	rbg, err := LoadTemplate(testdataPath("agg-rbg.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "test-agg", rbg.Name)
+	require.Len(t, rbg.Spec.Roles, 1)
+	assert.Equal(t, "worker", rbg.Spec.Roles[0].Name)
+}
+
+func TestLoadTemplate_DisaggMultiDoc(t *testing.T) {
+	rbg, err := LoadTemplate(testdataPath("disagg-rbg.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "test-disagg", rbg.Name)
+	require.Len(t, rbg.Spec.Roles, 2)
+	assert.Equal(t, "prefill", rbg.Spec.Roles[0].Name)
+	assert.Equal(t, "decode", rbg.Spec.Roles[1].Name)
+}
+
+func TestLoadTemplate_FileNotFound(t *testing.T) {
+	_, err := LoadTemplate("/nonexistent/path.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading template file")
+}
+
+func TestLoadTemplate_NoRBGInYAML(t *testing.T) {
+	// Create a temp file with only a Service
+	dir := t.TempDir()
+	path := filepath.Join(dir, "service-only.yaml")
+	err := os.WriteFile(path, []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+spec:
+  ports:
+  - port: 8000
+`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadTemplate(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no RoleBasedGroup found")
+}
+
+func TestBuilder_BuildTrial_AggOverlay(t *testing.T) {
+	base, err := LoadTemplate(testdataPath("agg-rbg.yaml"))
+	require.NoError(t, err)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	params := abtypes.RoleParamSet{
+		"default": abtypes.ParamSet{
+			"gpuMemoryUtilization": 0.95,
+		},
+	}
+
+	trial, err := builder.BuildTrial(base, 3, params)
+	require.NoError(t, err)
+
+	// Verify trial name
+	assert.Equal(t, "test-agg-trial-3", trial.Name)
+
+	// Verify overlay: --mem-fraction-static should be 0.95 (was 0.85)
+	workerCmd := trial.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command
+	idx := indexOf(workerCmd, "--mem-fraction-static")
+	require.NotEqual(t, -1, idx, "flag --mem-fraction-static not found in command")
+	assert.Equal(t, "0.95", workerCmd[idx+1])
+}
+
+func TestBuilder_BuildTrial_DisaggRoleSpecificOverlay(t *testing.T) {
+	base, err := LoadTemplate(testdataPath("disagg-rbg.yaml"))
+	require.NoError(t, err)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	params := abtypes.RoleParamSet{
+		"default": abtypes.ParamSet{
+			"maxNumSeqs": 128,
+		},
+		"prefill": abtypes.ParamSet{
+			"chunkedPrefillSize": 4096,
+		},
+	}
+
+	trial, err := builder.BuildTrial(base, 0, params)
+	require.NoError(t, err)
+	assert.Equal(t, "test-disagg-trial-0", trial.Name)
+
+	// Prefill role should have both default + prefill-specific params
+	prefillCmd := trial.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command
+	assert.Contains(t, prefillCmd, "--max-running-requests")
+	assert.Contains(t, prefillCmd, "--chunked-prefill-size")
+
+	// Decode role should have default params but NOT prefill-specific
+	decodeCmd := trial.Spec.Roles[1].StandalonePattern.Template.Spec.Containers[0].Command
+	assert.Contains(t, decodeCmd, "--max-running-requests")
+	assert.NotContains(t, decodeCmd, "--chunked-prefill-size")
+}
+
+func TestBuilder_BuildTrial_FlagReplaceVsAppend(t *testing.T) {
+	base, err := LoadTemplate(testdataPath("agg-rbg.yaml"))
+	require.NoError(t, err)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	// Base already has --mem-fraction-static 0.85 → should replace
+	// Base does NOT have --max-running-requests → should append
+	params := abtypes.RoleParamSet{
+		"default": abtypes.ParamSet{
+			"gpuMemoryUtilization": 0.95,
+			"maxNumSeqs":           256,
+		},
+	}
+
+	trial, err := builder.BuildTrial(base, 1, params)
+	require.NoError(t, err)
+
+	cmd := trial.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command
+
+	// Replaced value
+	memIdx := indexOf(cmd, "--mem-fraction-static")
+	require.NotEqual(t, -1, memIdx)
+	assert.Equal(t, "0.95", cmd[memIdx+1])
+
+	// Appended flag
+	seqsIdx := indexOf(cmd, "--max-running-requests")
+	require.NotEqual(t, -1, seqsIdx)
+	assert.Equal(t, "256", cmd[seqsIdx+1])
+}
+
+func TestBuilder_BuildTrial_DeepCopySafety(t *testing.T) {
+	base, err := LoadTemplate(testdataPath("agg-rbg.yaml"))
+	require.NoError(t, err)
+
+	// Save original command for comparison
+	origCmd := make([]string, len(base.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command))
+	copy(origCmd, base.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	_, err = builder.BuildTrial(base, 0, abtypes.RoleParamSet{
+		"default": abtypes.ParamSet{"gpuMemoryUtilization": 0.99},
+	})
+	require.NoError(t, err)
+
+	// Verify base is NOT modified
+	assert.Equal(t, origCmd, base.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command)
+	assert.Equal(t, "test-agg", base.Name) // name should not change
+}
+
+func TestBuilder_BuildTrial_TrialNaming(t *testing.T) {
+	base, err := LoadTemplate(testdataPath("agg-rbg.yaml"))
+	require.NoError(t, err)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	for _, idx := range []int{0, 1, 42} {
+		trial, err := builder.BuildTrial(base, idx, abtypes.RoleParamSet{})
+		require.NoError(t, err)
+		assert.Equal(t, GetTrialName("test-agg", idx), trial.Name)
+		assert.Empty(t, trial.ResourceVersion)
+		assert.Empty(t, trial.UID)
+	}
+}
+
+func TestBuilder_BuildTrial_SplitCommandArgs(t *testing.T) {
+	// Template uses command: [python3, -m, sglang.launch_server] + args: [--model-path, ...]
+	// This verifies mergeCommandArgs correctly merges both fields.
+	base, err := LoadTemplate(testdataPath("agg-rbg-split-args.yaml"))
+	require.NoError(t, err)
+
+	builder, err := NewBuilder("sglang")
+	require.NoError(t, err)
+
+	params := abtypes.RoleParamSet{
+		"default": abtypes.ParamSet{
+			"gpuMemoryUtilization": 0.95,
+		},
+	}
+
+	trial, err := builder.BuildTrial(base, 0, params)
+	require.NoError(t, err)
+
+	// After overlay, everything is written to Command, Args is nil
+	cmd := trial.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Command
+	args := trial.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Args
+
+	// Args from original should be merged into Command
+	assert.Contains(t, cmd, "--model-path")
+	assert.Contains(t, cmd, "/models/llama")
+	assert.Contains(t, cmd, "--port")
+	assert.Contains(t, cmd, "8000")
+	assert.Contains(t, cmd, "--tensor-parallel-size")
+
+	// --mem-fraction-static should be replaced with 0.95
+	memIdx := indexOf(cmd, "--mem-fraction-static")
+	require.NotEqual(t, -1, memIdx, "flag --mem-fraction-static not found in merged command")
+	assert.Equal(t, "0.95", cmd[memIdx+1])
+
+	// Args should be nil (everything moved to Command)
+	assert.Nil(t, args)
+}
+
+func TestGetServiceEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		port      int
+		want      string
+	}{
+		{
+			name:      "standard",
+			namespace: "default",
+			port:      8000,
+			want:      "http://s-my-rbg-worker.default.svc.cluster.local:8000",
+		},
+		{
+			name:      "disagg inference",
+			namespace: "benchmark",
+			port:      8000,
+			want:      "http://s-test-disagg-router.benchmark.svc.cluster.local:8000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rbg *workloadsv1alpha2.RoleBasedGroup
+			var role *workloadsv1alpha2.RoleSpec
+			switch tt.name {
+			case "standard":
+				rbg = &workloadsv1alpha2.RoleBasedGroup{ObjectMeta: metav1.ObjectMeta{Name: "my-rbg"}}
+				role = &workloadsv1alpha2.RoleSpec{Name: "worker"}
+			case "disagg inference":
+				rbg = &workloadsv1alpha2.RoleBasedGroup{ObjectMeta: metav1.ObjectMeta{Name: "test-disagg"}}
+				role = &workloadsv1alpha2.RoleSpec{Name: "router"}
+			}
+			got := GetServiceEndpoint(rbg, role, tt.namespace, tt.port)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetTrialName(t *testing.T) {
+	assert.Equal(t, "my-rbg-trial-0", GetTrialName("my-rbg", 0))
+	assert.Equal(t, "my-rbg-trial-42", GetTrialName("my-rbg", 42))
+}
+
+// indexOf finds the index of a string in a slice, or -1 if not found.
+func indexOf(slice []string, s string) int {
+	for i, v := range slice {
+		if v == s {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/autobenchmark/lifecycle/manager.go
+++ b/pkg/autobenchmark/lifecycle/manager.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+// RBGManager handles RBG lifecycle operations (Create, WaitReady, Delete).
+type RBGManager struct {
+	client    client.Client
+	namespace string
+}
+
+// NewRBGManager creates a new RBGManager.
+func NewRBGManager(c client.Client, namespace string) *RBGManager {
+	return &RBGManager{client: c, namespace: namespace}
+}
+
+// Create creates an RBG resource in the cluster.
+func (m *RBGManager) Create(ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup) error {
+	rbg.Namespace = m.namespace
+	if err := m.client.Create(ctx, rbg); err != nil {
+		return fmt.Errorf("creating RBG %q: %w", rbg.Name, err)
+	}
+	return nil
+}
+
+// Delete removes an RBG resource from the cluster.
+func (m *RBGManager) Delete(ctx context.Context, name string) error {
+	rbg := &workloadsv1alpha2.RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: m.namespace,
+		},
+	}
+	if err := m.client.Delete(ctx, rbg); err != nil {
+		return fmt.Errorf("deleting RBG %q: %w", name, err)
+	}
+	return nil
+}
+
+// Get retrieves an RBG resource by name.
+func (m *RBGManager) Get(ctx context.Context, name string) (*workloadsv1alpha2.RoleBasedGroup, error) {
+	rbg := &workloadsv1alpha2.RoleBasedGroup{}
+	key := types.NamespacedName{Name: name, Namespace: m.namespace}
+	if err := m.client.Get(ctx, key, rbg); err != nil {
+		return nil, fmt.Errorf("getting RBG %q: %w", name, err)
+	}
+	return rbg, nil
+}
+
+// WaitReady polls until the RBG has a Ready=True condition or the timeout is exceeded.
+func (m *RBGManager) WaitReady(ctx context.Context, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		rbg, err := m.Get(ctx, name)
+		if err != nil {
+			return false, nil // retry on transient errors
+		}
+		return isRBGReady(rbg), nil
+	})
+}
+
+// isRBGReady checks if the RBG has a Ready=True condition.
+func isRBGReady(rbg *workloadsv1alpha2.RoleBasedGroup) bool {
+	for _, c := range rbg.Status.Conditions {
+		if c.Type == string(workloadsv1alpha2.RoleBasedGroupReady) && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/autobenchmark/lifecycle/manager_test.go
+++ b/pkg/autobenchmark/lifecycle/manager_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = workloadsv1alpha2.AddToScheme(s)
+	return s
+}
+
+func makeRBG(name, namespace string) *workloadsv1alpha2.RoleBasedGroup {
+	replicas := int32(1)
+	return &workloadsv1alpha2.RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: workloadsv1alpha2.RoleBasedGroupSpec{
+			Roles: []workloadsv1alpha2.RoleSpec{
+				{
+					Name:     "worker",
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+}
+
+func TestRBGManager_Create(t *testing.T) {
+	scheme := newTestScheme()
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgr := NewRBGManager(fc, "test-ns")
+
+	rbg := makeRBG("my-rbg", "")
+	err := mgr.Create(context.Background(), rbg)
+	require.NoError(t, err)
+
+	// Verify the object exists in the fake client
+	got, err := mgr.Get(context.Background(), "my-rbg")
+	require.NoError(t, err)
+	assert.Equal(t, "my-rbg", got.Name)
+	assert.Equal(t, "test-ns", got.Namespace)
+}
+
+func TestRBGManager_Delete(t *testing.T) {
+	scheme := newTestScheme()
+	rbg := makeRBG("to-delete", "test-ns")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rbg).Build()
+	mgr := NewRBGManager(fc, "test-ns")
+
+	err := mgr.Delete(context.Background(), "to-delete")
+	require.NoError(t, err)
+
+	// Verify the object is gone
+	_, err = mgr.Get(context.Background(), "to-delete")
+	require.Error(t, err)
+}
+
+func TestRBGManager_Get(t *testing.T) {
+	scheme := newTestScheme()
+	rbg := makeRBG("existing", "test-ns")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rbg).Build()
+	mgr := NewRBGManager(fc, "test-ns")
+
+	got, err := mgr.Get(context.Background(), "existing")
+	require.NoError(t, err)
+	assert.Equal(t, "existing", got.Name)
+
+	_, err = mgr.Get(context.Background(), "nonexistent")
+	require.Error(t, err)
+}
+
+func TestRBGManager_WaitReady_AlreadyReady(t *testing.T) {
+	scheme := newTestScheme()
+	rbg := makeRBG("ready-rbg", "test-ns")
+	rbg.Status.Conditions = []metav1.Condition{
+		{
+			Type:   string(workloadsv1alpha2.RoleBasedGroupReady),
+			Status: metav1.ConditionTrue,
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rbg).WithStatusSubresource(rbg).Build()
+	mgr := NewRBGManager(fc, "test-ns")
+
+	err := mgr.WaitReady(context.Background(), "ready-rbg", 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestRBGManager_WaitReady_Timeout(t *testing.T) {
+	scheme := newTestScheme()
+	rbg := makeRBG("not-ready", "test-ns")
+	// No Ready condition set → WaitReady should timeout
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rbg).Build()
+	mgr := NewRBGManager(fc, "test-ns")
+
+	err := mgr.WaitReady(context.Background(), "not-ready", 1*time.Second)
+	require.Error(t, err)
+}
+
+func TestIsRBGReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       bool
+	}{
+		{
+			name:       "no conditions",
+			conditions: nil,
+			want:       false,
+		},
+		{
+			name: "ready true",
+			conditions: []metav1.Condition{
+				{Type: string(workloadsv1alpha2.RoleBasedGroupReady), Status: metav1.ConditionTrue},
+			},
+			want: true,
+		},
+		{
+			name: "ready false",
+			conditions: []metav1.Condition{
+				{Type: string(workloadsv1alpha2.RoleBasedGroupReady), Status: metav1.ConditionFalse},
+			},
+			want: false,
+		},
+		{
+			name: "other condition only",
+			conditions: []metav1.Condition{
+				{Type: string(workloadsv1alpha2.RoleBasedGroupProgressing), Status: metav1.ConditionTrue},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rbg := &workloadsv1alpha2.RoleBasedGroup{
+				Status: workloadsv1alpha2.RoleBasedGroupStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			assert.Equal(t, tt.want, isRBGReady(rbg))
+		})
+	}
+}

--- a/pkg/autobenchmark/lifecycle/mapper.go
+++ b/pkg/autobenchmark/lifecycle/mapper.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import "fmt"
+
+// ParamMapping describes how an abstract parameter maps to a CLI flag.
+type ParamMapping struct {
+	Flag string // CLI flag name (e.g., "--mem-fraction-static")
+}
+
+// ParamMapper maps abstract parameter names to backend-specific CLI flags.
+type ParamMapper struct {
+	backend  string
+	mappings map[string]ParamMapping
+}
+
+// sglangMappings maps abstract param names to SGLang CLI flags.
+var sglangMappings = map[string]ParamMapping{
+	// Memory
+	"gpuMemoryUtilization": {Flag: "--mem-fraction-static"},
+	"kvCacheDtype":         {Flag: "--kv-cache-dtype"},
+
+	// Batching / Scheduling
+	"maxNumSeqs":           {Flag: "--max-running-requests"},
+	"maxQueuedRequests":    {Flag: "--max-queued-requests"},
+	"chunkedPrefillSize":   {Flag: "--chunked-prefill-size"},
+	"maxPrefillTokens":     {Flag: "--max-prefill-tokens"},
+	"schedulePolicy":       {Flag: "--schedule-policy"},
+	"scheduleConservative": {Flag: "--schedule-conservativeness"},
+
+	// Parallelism
+	"tensorParallelSize":   {Flag: "--tensor-parallel-size"},
+	"dataParallelSize":     {Flag: "--data-parallel-size"},
+	"expertParallelSize":   {Flag: "--expert-parallel-size"},
+	"pipelineParallelSize": {Flag: "--pipeline-parallel-size"},
+
+	// Model
+	"contextLength": {Flag: "--context-length"},
+
+	// Attention
+	"prefillAttentionBackend": {Flag: "--prefill-attention-backend"},
+	"decodeAttentionBackend":  {Flag: "--decode-attention-backend"},
+
+	// Optimization
+	"enableCudaGraph":    {Flag: "--enable-cuda-graph"},
+	"enableTorchCompile": {Flag: "--enable-torch-compile"},
+
+	// Speculative decoding
+	"speculativeAlgorithm": {Flag: "--speculative-algorithm"},
+	"draftModelPath":       {Flag: "--speculative-draft-model-path"},
+	"speculativeNumSteps":  {Flag: "--speculative-num-steps"},
+	"speculativeEagleTopk": {Flag: "--speculative-eagle-topk"},
+	"numSpeculativeTokens": {Flag: "--speculative-num-draft-tokens"},
+
+	// Quantization / dtype
+	"quantization": {Flag: "--quantization"},
+	"dtype":        {Flag: "--dtype"},
+}
+
+// vllmMappings maps abstract param names to vLLM CLI flags.
+var vllmMappings = map[string]ParamMapping{
+	// Memory
+	"gpuMemoryUtilization": {Flag: "--gpu-memory-utilization"},
+	"kvCacheDtype":         {Flag: "--kv-cache-dtype"},
+
+	// Batching
+	"maxNumSeqs":           {Flag: "--max-num-seqs"},
+	"maxNumBatchedTokens":  {Flag: "--max-num-batched-tokens"},
+	"enableChunkedPrefill": {Flag: "--enable-chunked-prefill"},
+
+	// Parallelism
+	"tensorParallelSize":   {Flag: "--tensor-parallel-size"},
+	"dataParallelSize":     {Flag: "--data-parallel-size"},
+	"pipelineParallelSize": {Flag: "--pipeline-parallel-size"},
+
+	// Model
+	"contextLength": {Flag: "--max-model-len"},
+
+	// Attention
+	"attentionBackend": {Flag: "--attention-backend"},
+
+	// Optimization
+	"enforceEager":        {Flag: "--enforce-eager"},
+	"enablePrefixCaching": {Flag: "--enable-prefix-caching"},
+
+	// Speculative decoding
+	"draftModelPath":       {Flag: "--speculative-model"},
+	"numSpeculativeTokens": {Flag: "--num-speculative-tokens"},
+
+	// Quantization / dtype
+	"quantization": {Flag: "--quantization"},
+	"dtype":        {Flag: "--dtype"},
+}
+
+// NewParamMapper creates a ParamMapper for the given backend.
+func NewParamMapper(backend string) (*ParamMapper, error) {
+	var mappings map[string]ParamMapping
+	switch backend {
+	case "sglang":
+		mappings = sglangMappings
+	case "vllm":
+		mappings = vllmMappings
+	default:
+		return nil, fmt.Errorf("unsupported backend: %q", backend)
+	}
+	return &ParamMapper{backend: backend, mappings: mappings}, nil
+}
+
+// MapParam returns the CLI flag for a given abstract parameter name.
+func (pm *ParamMapper) MapParam(paramName string) (string, error) {
+	m, ok := pm.mappings[paramName]
+	if !ok {
+		return "", fmt.Errorf("unknown parameter %q for backend %q", paramName, pm.backend)
+	}
+	return m.Flag, nil
+}
+
+// Backend returns the backend name.
+func (pm *ParamMapper) Backend() string { return pm.backend }
+
+// OverlayArgs takes existing command args and overlays the given params
+// using the param mapper. It replaces existing flag values or appends new flags.
+func (pm *ParamMapper) OverlayArgs(args []string, params map[string]interface{}) ([]string, error) {
+	// Make a copy to avoid mutating the original
+	result := make([]string, len(args))
+	copy(result, args)
+
+	for paramName, value := range params {
+		flag, err := pm.MapParam(paramName)
+		if err != nil {
+			return nil, err
+		}
+		strVal := fmt.Sprintf("%v", value)
+		result = replaceOrAppendFlag(result, flag, strVal)
+	}
+	return result, nil
+}
+
+// replaceOrAppendFlag replaces an existing flag's value or appends a new flag-value pair.
+// Handles both "--flag value" and "--flag=value" formats.
+func replaceOrAppendFlag(args []string, flag, value string) []string {
+	for i := 0; i < len(args); i++ {
+		// Check "--flag value" format
+		if args[i] == flag && i+1 < len(args) {
+			args[i+1] = value
+			return args
+		}
+		// Check "--flag=value" format
+		if len(args[i]) > len(flag) && args[i][:len(flag)+1] == flag+"=" {
+			args[i] = flag + "=" + value
+			return args
+		}
+	}
+	// Flag not found, append
+	return append(args, flag, value)
+}

--- a/pkg/autobenchmark/lifecycle/mapper_test.go
+++ b/pkg/autobenchmark/lifecycle/mapper_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewParamMapper(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		wantErr string
+	}{
+		{name: "sglang", backend: "sglang"},
+		{name: "vllm", backend: "vllm"},
+		{name: "unsupported", backend: "trt-llm", wantErr: "unsupported backend"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewParamMapper(tt.backend)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.backend, pm.Backend())
+		})
+	}
+}
+
+func TestParamMapper_MapParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		backend  string
+		param    string
+		wantFlag string
+		wantErr  string
+	}{
+		// SGLang mappings
+		{name: "sglang/gpuMemUtil", backend: "sglang", param: "gpuMemoryUtilization", wantFlag: "--mem-fraction-static"},
+		{name: "sglang/maxNumSeqs", backend: "sglang", param: "maxNumSeqs", wantFlag: "--max-running-requests"},
+		{name: "sglang/chunkedPrefillSize", backend: "sglang", param: "chunkedPrefillSize", wantFlag: "--chunked-prefill-size"},
+		{name: "sglang/contextLength", backend: "sglang", param: "contextLength", wantFlag: "--context-length"},
+		{name: "sglang/tensorParallel", backend: "sglang", param: "tensorParallelSize", wantFlag: "--tensor-parallel-size"},
+		{name: "sglang/enableCudaGraph", backend: "sglang", param: "enableCudaGraph", wantFlag: "--enable-cuda-graph"},
+
+		// vLLM mappings
+		{name: "vllm/gpuMemUtil", backend: "vllm", param: "gpuMemoryUtilization", wantFlag: "--gpu-memory-utilization"},
+		{name: "vllm/maxNumSeqs", backend: "vllm", param: "maxNumSeqs", wantFlag: "--max-num-seqs"},
+		{name: "vllm/contextLength", backend: "vllm", param: "contextLength", wantFlag: "--max-model-len"},
+		{name: "vllm/enforceEager", backend: "vllm", param: "enforceEager", wantFlag: "--enforce-eager"},
+
+		// Unknown param
+		{name: "sglang/unknown", backend: "sglang", param: "nonExistentParam", wantErr: "unknown parameter"},
+		{name: "vllm/unknown", backend: "vllm", param: "nonExistentParam", wantErr: "unknown parameter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewParamMapper(tt.backend)
+			require.NoError(t, err)
+
+			flag, err := pm.MapParam(tt.param)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFlag, flag)
+		})
+	}
+}
+
+func TestParamMapper_OverlayArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		backend  string
+		args     []string
+		params   map[string]interface{}
+		wantArgs []string
+		wantErr  string
+	}{
+		{
+			name:     "replace existing flag value",
+			backend:  "sglang",
+			args:     []string{"python3", "-m", "sglang.launch_server", "--mem-fraction-static", "0.85"},
+			params:   map[string]interface{}{"gpuMemoryUtilization": 0.95},
+			wantArgs: []string{"python3", "-m", "sglang.launch_server", "--mem-fraction-static", "0.95"},
+		},
+		{
+			name:     "append new flag",
+			backend:  "sglang",
+			args:     []string{"python3", "-m", "sglang.launch_server"},
+			params:   map[string]interface{}{"gpuMemoryUtilization": 0.9},
+			wantArgs: []string{"python3", "-m", "sglang.launch_server", "--mem-fraction-static", "0.9"},
+		},
+		{
+			name:     "multiple params",
+			backend:  "sglang",
+			args:     []string{"python3", "-m", "sglang.launch_server", "--mem-fraction-static", "0.85"},
+			params:   map[string]interface{}{"gpuMemoryUtilization": 0.9, "maxNumSeqs": 128},
+			wantArgs: nil, // just check it doesn't error, order may vary
+		},
+		{
+			name:    "unknown param returns error",
+			backend: "sglang",
+			args:    []string{"python3"},
+			params:  map[string]interface{}{"unknownParam": "x"},
+			wantErr: "unknown parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewParamMapper(tt.backend)
+			require.NoError(t, err)
+
+			result, err := pm.OverlayArgs(tt.args, tt.params)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, result)
+			}
+
+			// For multiple params, verify both flags exist
+			if tt.name == "multiple params" {
+				assert.Contains(t, result, "--mem-fraction-static")
+				assert.Contains(t, result, "--max-running-requests")
+			}
+		})
+	}
+}
+
+func TestOverlayArgs_DoesNotMutateOriginal(t *testing.T) {
+	pm, err := NewParamMapper("sglang")
+	require.NoError(t, err)
+
+	original := []string{"python3", "-m", "sglang.launch_server", "--mem-fraction-static", "0.85"}
+	originalCopy := make([]string, len(original))
+	copy(originalCopy, original)
+
+	_, err = pm.OverlayArgs(original, map[string]interface{}{"maxNumSeqs": 128})
+	require.NoError(t, err)
+
+	// Original should not be mutated (the append added a new flag)
+	assert.Equal(t, originalCopy, original)
+}
+
+func TestReplaceOrAppendFlag(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		flag  string
+		value string
+		want  []string
+	}{
+		{
+			name:  "replace space-separated",
+			args:  []string{"--foo", "old", "--bar", "baz"},
+			flag:  "--foo",
+			value: "new",
+			want:  []string{"--foo", "new", "--bar", "baz"},
+		},
+		{
+			name:  "replace equals format",
+			args:  []string{"--foo=old", "--bar", "baz"},
+			flag:  "--foo",
+			value: "new",
+			want:  []string{"--foo=new", "--bar", "baz"},
+		},
+		{
+			name:  "append when not found",
+			args:  []string{"--bar", "baz"},
+			flag:  "--foo",
+			value: "new",
+			want:  []string{"--bar", "baz", "--foo", "new"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replaceOrAppendFlag(tt.args, tt.flag, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/autobenchmark/lifecycle/testdata/agg-rbg-split-args.yaml
+++ b/pkg/autobenchmark/lifecycle/testdata/agg-rbg-split-args.yaml
@@ -1,0 +1,30 @@
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: test-agg-split
+  namespace: default
+spec:
+  roles:
+  - name: worker
+    replicas: 1
+    standalonePattern:
+      template:
+        spec:
+          containers:
+          - name: sglang-worker
+            image: sglang:latest
+            command:
+            - python3
+            - -m
+            - sglang.launch_server
+            args:
+            - --model-path
+            - /models/llama
+            - --port
+            - "8000"
+            - --host
+            - $(POD_IP)
+            - --mem-fraction-static
+            - "0.85"
+            - --tensor-parallel-size
+            - "4"

--- a/pkg/autobenchmark/lifecycle/testdata/agg-rbg.yaml
+++ b/pkg/autobenchmark/lifecycle/testdata/agg-rbg.yaml
@@ -1,0 +1,29 @@
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: test-agg
+  namespace: default
+spec:
+  roles:
+  - name: worker
+    replicas: 1
+    standalonePattern:
+      template:
+        spec:
+          containers:
+          - name: sglang-worker
+            image: sglang:latest
+            command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /models/llama
+            - --port
+            - "8000"
+            - --host
+            - $(POD_IP)
+            - --mem-fraction-static
+            - "0.85"
+            - --tensor-parallel-size
+            - "4"

--- a/pkg/autobenchmark/lifecycle/testdata/disagg-rbg.yaml
+++ b/pkg/autobenchmark/lifecycle/testdata/disagg-rbg.yaml
@@ -1,0 +1,65 @@
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: test-disagg
+  namespace: default
+spec:
+  roles:
+  - name: prefill
+    replicas: 1
+    standalonePattern:
+      template:
+        spec:
+          containers:
+          - name: sglang-prefill
+            image: sglang:latest
+            command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /models/llama
+            - --disaggregation-mode
+            - prefill
+            - --port
+            - "8000"
+            - --host
+            - $(POD_IP)
+            - --mem-fraction-static
+            - "0.9"
+  - name: decode
+    replicas: 2
+    standalonePattern:
+      template:
+        spec:
+          containers:
+          - name: sglang-decode
+            image: sglang:latest
+            command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path
+            - /models/llama
+            - --disaggregation-mode
+            - decode
+            - --port
+            - "8000"
+            - --host
+            - $(POD_IP)
+            - --mem-fraction-static
+            - "0.9"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s-test-disagg-inference
+  namespace: default
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    rolebasedgroup.workloads.x-k8s.io/name: test-disagg
+  type: ClusterIP

--- a/pkg/autobenchmark/search/grid.go
+++ b/pkg/autobenchmark/search/grid.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func init() {
+	Register("grid", func() SearchAlgorithm { return &GridSearch{} })
+}
+
+// GridSearch implements a simple grid (exhaustive) search over the Cartesian product of all params.
+type GridSearch struct {
+	entries      []paramEntry
+	total        uint64
+	currentIndex int
+	maxTrials    int
+}
+
+type gridState struct {
+	CurrentIndex int `json:"currentIndex"`
+}
+
+// Name returns the algorithm name.
+func (g *GridSearch) Name() string { return "grid" }
+
+// Init initializes the grid search with the expanded search space.
+// maxTrials is capped to the number of combinations so that IsDone
+// correctly terminates when the space is smaller than MaxTrialsPerTemplate.
+func (g *GridSearch) Init(_ context.Context, _ string, space ExpandedSearchSpace, cfg config.StrategySpec) error {
+	entries, total, err := cartesianProductEntries(space)
+	if err != nil {
+		return err
+	}
+	g.entries = entries
+	g.total = total
+	g.currentIndex = 0
+	g.maxTrials = cfg.MaxTrialsPerTemplate
+	if g.total > 0 && (g.maxTrials <= 0 || uint64(g.maxTrials) > g.total) {
+		if g.total > uint64(math.MaxInt) {
+			g.maxTrials = math.MaxInt
+		} else {
+			g.maxTrials = int(g.total)
+		}
+	}
+	return nil
+}
+
+// SuggestNext returns the next parameter combination in the grid.
+func (g *GridSearch) SuggestNext(_ []abtypes.TrialResult) (abtypes.RoleParamSet, error) {
+	if uint64(g.currentIndex) >= g.total {
+		return nil, fmt.Errorf("grid search exhausted: all combinations tried")
+	}
+	result := combinationAtIndex(g.currentIndex, g.entries)
+	g.currentIndex++
+	return result, nil
+}
+
+// IsDone returns true if all combinations have been tried or maxTrials reached.
+func (g *GridSearch) IsDone(history []abtypes.TrialResult) bool {
+	return uint64(g.currentIndex) >= g.total || len(history) >= g.maxTrials
+}
+
+// MarshalState serializes the current grid search state for checkpoint.
+func (g *GridSearch) MarshalState() ([]byte, error) {
+	return json.Marshal(gridState{CurrentIndex: g.currentIndex})
+}
+
+// UnmarshalState restores grid search state from checkpoint.
+func (g *GridSearch) UnmarshalState(data []byte) error {
+	var state gridState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("unmarshaling grid state: %w", err)
+	}
+	g.currentIndex = state.CurrentIndex
+	return nil
+}

--- a/pkg/autobenchmark/search/grid_test.go
+++ b/pkg/autobenchmark/search/grid_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+func TestExpandParam_Range(t *testing.T) {
+	tests := []struct {
+		name   string
+		param  config.SearchParam
+		expect []any
+	}{
+		{
+			name:   "integer range",
+			param:  config.SearchParam{Type: "range", Min: ptr(1.0), Max: ptr(5.0), Step: ptr(2.0)},
+			expect: []interface{}{1.0, 3.0, 5.0},
+		},
+		{
+			name:   "single value range",
+			param:  config.SearchParam{Type: "range", Min: ptr(10.0), Max: ptr(10.0), Step: ptr(1.0)},
+			expect: []interface{}{10.0},
+		},
+		{
+			name:   "step larger than range",
+			param:  config.SearchParam{Type: "range", Min: ptr(1.0), Max: ptr(3.0), Step: ptr(5.0)},
+			expect: []interface{}{1.0},
+		},
+		{
+			name:   "float range",
+			param:  config.SearchParam{Type: "range", Min: ptr(0.8), Max: ptr(0.95), Step: ptr(0.05)},
+			expect: []interface{}{0.8, 0.85, 0.9, 0.95},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandParam(tt.param)
+			assert.Equal(t, len(tt.expect), len(result))
+			for i, v := range tt.expect {
+				assert.InDelta(t, v, result[i], 1e-6)
+			}
+		})
+	}
+}
+
+func TestExpandParam_Categorical(t *testing.T) {
+	param := config.SearchParam{
+		Type:   "categorical",
+		Values: []interface{}{0.85, 0.9, 0.95},
+	}
+	result := expandParam(param)
+	assert.Equal(t, []interface{}{0.85, 0.9, 0.95}, result)
+}
+
+func TestExpandSearchSpace(t *testing.T) {
+	ss := map[string]map[string]config.SearchParam{
+		"default": {
+			"x": {Type: "categorical", Values: []interface{}{1, 2}},
+			"y": {Type: "range", Min: ptr(10.0), Max: ptr(30.0), Step: ptr(10.0)},
+		},
+	}
+	expanded := ExpandSearchSpace(ss)
+	assert.Len(t, expanded["default"]["x"], 2)
+	assert.Len(t, expanded["default"]["y"], 3) // 10, 20, 30
+}
+
+func TestCartesianProduct_SingleRole(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {
+			"a": {1, 2},
+			"b": {10, 20, 30},
+		},
+	}
+	combos := CartesianProduct(space)
+	assert.Len(t, combos, 6) // 2 * 3
+}
+
+func TestCartesianProduct_MultiRole(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {"x": {1, 2}},
+		"prefill": {"y": {10, 20}},
+	}
+	combos := CartesianProduct(space)
+	assert.Len(t, combos, 4) // 2 * 2
+
+	// Verify each combo has both roles
+	for _, c := range combos {
+		assert.Contains(t, c, "default")
+		assert.Contains(t, c, "prefill")
+	}
+}
+
+func TestCartesianProduct_Empty(t *testing.T) {
+	space := ExpandedSearchSpace{}
+	combos := CartesianProduct(space)
+	assert.Len(t, combos, 1) // one empty combo
+}
+
+func ptr(v float64) *float64 { return &v }
+
+// grid_test.go tests
+
+func TestGridSearch_Basic(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {
+			"a": {1, 2},
+			"b": {10, 20},
+		},
+	}
+
+	g := &GridSearch{}
+	require.NoError(t, g.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+
+	assert.Equal(t, "grid", g.Name())
+
+	var results []map[string]any
+	for !g.IsDone(nil) {
+		ps, err := g.SuggestNext(nil)
+		require.NoError(t, err)
+		results = append(results, ps["default"])
+	}
+
+	assert.Len(t, results, 4) // 2 * 2
+
+	// Verify exhausted
+	_, err := g.SuggestNext(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exhausted")
+}
+
+func TestGridSearch_MaxTrials(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {
+			"a": {1, 2, 3, 4, 5},
+		},
+	}
+
+	g := &GridSearch{}
+	require.NoError(t, g.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 3}))
+
+	var count int
+	for !g.IsDone(nil) {
+		_, err := g.SuggestNext(nil)
+		require.NoError(t, err)
+		count++
+		if g.IsDone(makeHistory(count)) {
+			break
+		}
+	}
+	assert.Equal(t, 3, count)
+}
+
+func TestGridSearch_MaxTrialsExceedsSpace(t *testing.T) {
+	// maxTrials (100) > space size (3): should stop after exhausting all 3 combos.
+	space := ExpandedSearchSpace{
+		"default": {"a": {1, 2, 3}},
+	}
+
+	g := &GridSearch{}
+	require.NoError(t, g.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+	assert.Equal(t, 3, g.maxTrials) // capped to space size
+
+	var count int
+	for !g.IsDone(makeHistory(count)) {
+		_, err := g.SuggestNext(nil)
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 3, count)
+}
+
+func TestGridSearch_IsDone(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {"a": {1, 2}, "b": {10, 20}}, // 4 combos
+	}
+
+	// maxTrials < space: stops at maxTrials.
+	g1 := &GridSearch{}
+	require.NoError(t, g1.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 2}))
+	assert.False(t, g1.IsDone(makeHistory(1)))
+	assert.True(t, g1.IsDone(makeHistory(2)))
+
+	// maxTrials > space: capped to 4.
+	g2 := &GridSearch{}
+	require.NoError(t, g2.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+	assert.False(t, g2.IsDone(makeHistory(3)))
+	assert.True(t, g2.IsDone(makeHistory(4)))
+
+	// maxTrials = 0: defaults to space size (4).
+	g3 := &GridSearch{}
+	require.NoError(t, g3.Init(context.Background(), "test", space, config.StrategySpec{}))
+	assert.False(t, g3.IsDone(makeHistory(3)))
+	assert.True(t, g3.IsDone(makeHistory(4)))
+}
+
+func TestGridSearch_StateCheckpointResume(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {"a": {1, 2, 3, 4}},
+	}
+
+	// Run first 2 trials
+	g1 := &GridSearch{}
+	require.NoError(t, g1.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+	ps1, _ := g1.SuggestNext(nil)
+	ps2, _ := g1.SuggestNext(nil)
+
+	// Checkpoint
+	state, err := g1.MarshalState()
+	require.NoError(t, err)
+
+	// Resume in new instance
+	g2 := &GridSearch{}
+	require.NoError(t, g2.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+	require.NoError(t, g2.UnmarshalState(state))
+
+	// Should continue from index 2
+	ps3, err := g2.SuggestNext(nil)
+	require.NoError(t, err)
+	ps4, err := g2.SuggestNext(nil)
+	require.NoError(t, err)
+
+	// All 4 should be different
+	assert.NotEqual(t, ps1["default"]["a"], ps2["default"]["a"])
+	assert.NotEqual(t, ps2["default"]["a"], ps3["default"]["a"])
+	assert.NotEqual(t, ps3["default"]["a"], ps4["default"]["a"])
+
+	// g2 should now be done
+	assert.True(t, g2.IsDone(nil))
+}
+
+func TestGridSearch_FeedbackDoesNotAffectOrder(t *testing.T) {
+	space := ExpandedSearchSpace{
+		"default": {"a": {1, 2, 3}},
+	}
+
+	g := &GridSearch{}
+	require.NoError(t, g.Init(context.Background(), "test", space, config.StrategySpec{MaxTrialsPerTemplate: 100}))
+
+	// Suggest with different histories — order should be the same
+	ps1, _ := g.SuggestNext(nil)
+	ps2, _ := g.SuggestNext(makeHistory(5))
+	ps3, _ := g.SuggestNext(makeHistory(10))
+
+	vals := []interface{}{ps1["default"]["a"], ps2["default"]["a"], ps3["default"]["a"]}
+	assert.Equal(t, []interface{}{1, 2, 3}, vals)
+}
+
+func TestFactory_GridRegistered(t *testing.T) {
+	algo, err := Get("grid")
+	require.NoError(t, err)
+	assert.Equal(t, "grid", algo.Name())
+}
+
+func TestFactory_Unknown(t *testing.T) {
+	_, err := Get("unknown")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown search algorithm")
+}
+
+func makeHistory(n int) []abtypes.TrialResult {
+	h := make([]abtypes.TrialResult, n)
+	for i := range h {
+		h[i].TrialIndex = i
+	}
+	return h
+}

--- a/pkg/autobenchmark/search/interface.go
+++ b/pkg/autobenchmark/search/interface.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// SearchAlgorithm defines the interface for parameter search strategies.
+type SearchAlgorithm interface {
+	// Name returns the algorithm name.
+	Name() string
+
+	// Init initializes the algorithm with the given study name, expanded search space, and strategy config.
+	// The name uniquely identifies this search instance (e.g., template name) and is used by
+	// stateful backends (like Optuna) as the persistent study identifier.
+	Init(ctx context.Context, name string, space ExpandedSearchSpace, cfg config.StrategySpec) error
+
+	// SuggestNext returns the next parameter set to try, given previous trial results.
+	SuggestNext(history []abtypes.TrialResult) (abtypes.RoleParamSet, error)
+
+	// IsDone returns true if the algorithm has exhausted its search or met stopping criteria.
+	IsDone(history []abtypes.TrialResult) bool
+
+	// MarshalState serializes the algorithm state for checkpoint.
+	MarshalState() ([]byte, error)
+
+	// UnmarshalState restores algorithm state from checkpoint.
+	UnmarshalState(data []byte) error
+}
+
+// ExpandedSearchSpace maps role names to their expanded parameter lists.
+// Each parameter name maps to a list of discrete values to search.
+type ExpandedSearchSpace map[string]map[string][]any
+
+// Factory is a function that creates a new SearchAlgorithm instance.
+type Factory func() SearchAlgorithm
+
+var (
+	registry = make(map[string]Factory)
+	mu       sync.RWMutex
+)
+
+// Register registers a SearchAlgorithm factory by name.
+func Register(name string, factory Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[name] = factory
+}
+
+// Get creates a new SearchAlgorithm instance by name.
+func Get(name string) (SearchAlgorithm, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	factory, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown search algorithm: %q", name)
+	}
+	return factory(), nil
+}

--- a/pkg/autobenchmark/search/optuna.go
+++ b/pkg/autobenchmark/search/optuna.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+const (
+	defaultBridgePath = "/tools/optuna_bridge.py"
+	envBridgePath     = "OPTUNA_BRIDGE_PATH"
+	envStoragePath    = "OPTUNA_STORAGE_PATH"
+)
+
+// optunaSamplers lists all algorithm names backed by OptunaSearch.
+var optunaSamplers = []string{"tpe", "gp", "cmaes", "random", "qmc", "nsgaii", "nsgaiii"}
+
+func init() {
+	for _, name := range optunaSamplers {
+		n := name
+		Register(n, func() SearchAlgorithm { return &OptunaSearch{} })
+	}
+}
+
+// OptunaSearch implements SearchAlgorithm using a Python Optuna subprocess.
+// Communication happens via JSON Lines over stdin/stdout.
+type OptunaSearch struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	scanner *bufio.Scanner
+	mu      sync.Mutex
+	logger  logr.Logger
+
+	studyName   string
+	algorithm   string // Optuna sampler name (tpe, gp, cmaes, etc.)
+	maxTrials   int
+	spaceSize   int // Cartesian product of all param values
+	toldCount   int // number of history entries already told to Optuna
+	lastTrialID int // Optuna trial ID from last ask, -1 if none
+}
+
+// bridgeRequest is the JSON message sent to the Python bridge.
+type bridgeRequest struct {
+	Action        string                      `json:"action"`
+	StudyName     string                      `json:"study_name,omitempty"`
+	SearchSpace   map[string]map[string][]any `json:"search_space,omitempty"`
+	Direction     string                      `json:"direction,omitempty"`
+	MaxTrials     int                         `json:"max_trials,omitempty"`
+	StoragePath   string                      `json:"storage_path,omitempty"`
+	Seed          *int                        `json:"seed,omitempty"`
+	Sampler       string                      `json:"sampler,omitempty"`
+	SamplerKwargs map[string]any              `json:"sampler_kwargs,omitempty"`
+	TrialID       int                         `json:"trial_id"`
+	Score         float64                     `json:"score"`
+	SLAPass       bool                        `json:"sla_pass"`
+	Error         string                      `json:"error,omitempty"`
+}
+
+// bridgeResponse is the JSON message received from the Python bridge.
+type bridgeResponse struct {
+	Status           string                    `json:"status"`
+	Message          string                    `json:"message,omitempty"`
+	TrialID          int                       `json:"trial_id,omitempty"`
+	Params           map[string]map[string]any `json:"params,omitempty"`
+	Done             bool                      `json:"done,omitempty"`
+	Score            float64                   `json:"score,omitempty"`
+	ExistingComplete int                       `json:"existing_complete,omitempty"`
+	SpaceSize        int                       `json:"space_size,omitempty"`
+	Completed        int                       `json:"completed,omitempty"`
+	Skipped          bool                      `json:"skipped,omitempty"`
+}
+
+// Name returns the algorithm name.
+func (o *OptunaSearch) Name() string { return o.algorithm }
+
+// Init initializes (or reinitializes) the Optuna study for a new template.
+// The Python bridge subprocess is started on the first call and reused for
+// subsequent calls, since it can manage multiple studies by study_name.
+func (o *OptunaSearch) Init(ctx context.Context, name string, space ExpandedSearchSpace, cfg config.StrategySpec) error {
+	o.logger = log.FromContext(ctx).WithValues("study", name, "algorithm", cfg.Algorithm)
+	o.studyName = name
+	o.algorithm = cfg.Algorithm
+	o.maxTrials = cfg.MaxTrialsPerTemplate
+	o.lastTrialID = -1
+	o.toldCount = 0
+
+	// Start the bridge process only if not already running.
+	if o.cmd == nil {
+		if err := o.startProcess(); err != nil {
+			return fmt.Errorf("starting optuna bridge: %w", err)
+		}
+	}
+
+	// Convert ExpandedSearchSpace to JSON-friendly format.
+	searchSpace := make(map[string]map[string][]any)
+	for role, params := range space {
+		searchSpace[role] = make(map[string][]any)
+		for paramName, values := range params {
+			converted := make([]any, len(values))
+			copy(converted, values)
+			searchSpace[role][paramName] = converted
+		}
+	}
+
+	resp, err := o.send(bridgeRequest{
+		Action:        "init",
+		StudyName:     name,
+		SearchSpace:   searchSpace,
+		Direction:     "maximize",
+		MaxTrials:     cfg.MaxTrialsPerTemplate,
+		StoragePath:   resolveStoragePath(cfg),
+		Seed:          cfg.Seed,
+		Sampler:       cfg.Algorithm,
+		SamplerKwargs: cfg.AlgorithmConfig,
+	})
+	if err != nil {
+		return fmt.Errorf("optuna init: %w", err)
+	}
+	if resp.Status != "ok" {
+		return fmt.Errorf("optuna init failed: %s", resp.Message)
+	}
+
+	// Sync state from Optuna — accounts for trials from previous runs.
+	o.toldCount = resp.ExistingComplete
+	o.spaceSize = resp.SpaceSize
+	o.logger.Info("OptunaSearch initialized", "existingComplete", resp.ExistingComplete, "spaceSize", resp.SpaceSize)
+	return nil
+}
+
+// SuggestNext tells Optuna about new trial results and asks for the next suggestion.
+func (o *OptunaSearch) SuggestNext(history []abtypes.TrialResult) (abtypes.RoleParamSet, error) {
+	// Tell Optuna about the last trial result (if any).
+	if o.lastTrialID >= 0 && o.toldCount < len(history) {
+		result := history[o.toldCount]
+		req := bridgeRequest{
+			Action:    "tell",
+			StudyName: o.studyName,
+			TrialID:   o.lastTrialID,
+			Score:     result.Score,
+			SLAPass:   result.SLAPass,
+			Error:     result.Error,
+		}
+		resp, err := o.send(req)
+		if err != nil {
+			return nil, fmt.Errorf("optuna tell: %w", err)
+		}
+		if resp.Status != "ok" {
+			return nil, fmt.Errorf("optuna tell failed: %s", resp.Message)
+		}
+		o.toldCount++
+		o.lastTrialID = -1
+	}
+
+	// Ask for the next suggestion.
+	resp, err := o.send(bridgeRequest{
+		Action:    "ask",
+		StudyName: o.studyName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("optuna ask: %w", err)
+	}
+	if resp.Status != "ok" {
+		return nil, fmt.Errorf("optuna ask failed: %s", resp.Message)
+	}
+
+	o.lastTrialID = resp.TrialID
+
+	// Convert params to RoleParamSet.
+	rps := make(abtypes.RoleParamSet)
+	for role, params := range resp.Params {
+		rps[role] = make(abtypes.ParamSet)
+		for k, v := range params {
+			rps[role][k] = v
+		}
+	}
+	return rps, nil
+}
+
+// IsDone returns true when the search should stop. This happens when:
+//   - history length reaches maxTrials, or
+//   - history length reaches the search space Cartesian product size (exhausted).
+func (o *OptunaSearch) IsDone(history []abtypes.TrialResult) bool {
+	n := len(history)
+	if n >= o.maxTrials {
+		return true
+	}
+	if o.spaceSize > 0 && n >= o.spaceSize {
+		return true
+	}
+	return false
+}
+
+// MarshalState serializes a minimal state marker for checkpoint.
+// Actual Optuna state is persisted in SQLite; toldCount is synced from Optuna on Init.
+func (o *OptunaSearch) MarshalState() ([]byte, error) {
+	return json.Marshal(map[string]string{"algorithm": o.algorithm})
+}
+
+// UnmarshalState is a no-op for OptunaSearch.
+// State is recovered from Optuna's SQLite storage on Init.
+func (o *OptunaSearch) UnmarshalState(_ []byte) error {
+	return nil
+}
+
+// Close gracefully shuts down the Python bridge subprocess.
+func (o *OptunaSearch) Close() error {
+	if o.cmd == nil || o.cmd.Process == nil {
+		return nil
+	}
+	_, _ = o.send(bridgeRequest{Action: "shutdown"})
+	_ = o.stdin.Close()
+	return o.cmd.Wait()
+}
+
+// startProcess launches the Python bridge subprocess.
+func (o *OptunaSearch) startProcess() error {
+	bridgePath := os.Getenv(envBridgePath)
+	if bridgePath == "" {
+		bridgePath = defaultBridgePath
+	}
+
+	// Security: validate the bridge path before executing it.
+	if !filepath.IsAbs(bridgePath) {
+		return fmt.Errorf("optuna bridge path must be absolute: %s", bridgePath)
+	}
+	info, err := os.Stat(bridgePath)
+	if err != nil {
+		return fmt.Errorf("optuna bridge path not accessible: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("optuna bridge path is not a regular file: %s", bridgePath)
+	}
+
+	o.cmd = exec.Command("python3", bridgePath)
+	o.cmd.Stderr = os.Stderr // bridge logs go to controller stderr
+
+	stdin, err := o.cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("creating stdin pipe: %w", err)
+	}
+	o.stdin = stdin
+
+	stdout, err := o.cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	o.scanner = bufio.NewScanner(stdout)
+	o.scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024) // 1MB buffer
+
+	if err := o.cmd.Start(); err != nil {
+		return fmt.Errorf("starting bridge process: %w", err)
+	}
+
+	o.logger.Info("Optuna bridge process started", "pid", o.cmd.Process.Pid)
+	return nil
+}
+
+// send writes a JSON request to the bridge and reads the JSON response.
+// A timeout guards against hangs if the Python process crashes or stalls.
+func (o *OptunaSearch) send(req bridgeRequest) (*bridgeResponse, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	if _, err := o.stdin.Write(append(data, '\n')); err != nil {
+		return nil, fmt.Errorf("write to bridge: %w (process may have exited)", err)
+	}
+
+	type result struct {
+		resp *bridgeResponse
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		if !o.scanner.Scan() {
+			if err := o.scanner.Err(); err != nil {
+				ch <- result{err: fmt.Errorf("read from bridge: %w", err)}
+				return
+			}
+			ch <- result{err: fmt.Errorf("bridge process exited unexpectedly")}
+			return
+		}
+		var resp bridgeResponse
+		if err := json.Unmarshal(o.scanner.Bytes(), &resp); err != nil {
+			ch <- result{err: fmt.Errorf("unmarshal response: %w (raw: %s)", err, o.scanner.Text())}
+			return
+		}
+		ch <- result{resp: &resp}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.resp, r.err
+	case <-time.After(30 * time.Second):
+		return nil, fmt.Errorf("read from bridge: timeout (process may be hung or crashed)")
+	}
+}
+
+// resolveStoragePath returns the SQLite storage path for Optuna.
+// Returns empty string when unconfigured, which makes the bridge use in-memory storage.
+func resolveStoragePath(cfg config.StrategySpec) string {
+	if cfg.StoragePath != "" {
+		return cfg.StoragePath
+	}
+	return os.Getenv(envStoragePath)
+}

--- a/pkg/autobenchmark/search/optuna.go
+++ b/pkg/autobenchmark/search/optuna.go
@@ -39,6 +39,7 @@ const (
 	defaultBridgePath = "/tools/optuna_bridge.py"
 	envBridgePath     = "OPTUNA_BRIDGE_PATH"
 	envStoragePath    = "OPTUNA_STORAGE_PATH"
+	bridgeTimeout     = 30 * time.Second
 )
 
 // optunaSamplers lists all algorithm names backed by OptunaSearch.
@@ -87,16 +88,16 @@ type bridgeRequest struct {
 
 // bridgeResponse is the JSON message received from the Python bridge.
 type bridgeResponse struct {
-	Status           string                    `json:"status"`
-	Message          string                    `json:"message,omitempty"`
-	TrialID          int                       `json:"trial_id,omitempty"`
-	Params           map[string]map[string]any `json:"params,omitempty"`
-	Done             bool                      `json:"done,omitempty"`
-	Score            float64                   `json:"score,omitempty"`
-	ExistingComplete int                       `json:"existing_complete,omitempty"`
-	SpaceSize        int                       `json:"space_size,omitempty"`
-	Completed        int                       `json:"completed,omitempty"`
-	Skipped          bool                      `json:"skipped,omitempty"`
+	Status        string                    `json:"status"`
+	Message       string                    `json:"message,omitempty"`
+	TrialID       int                       `json:"trial_id,omitempty"`
+	Params        map[string]map[string]any `json:"params,omitempty"`
+	Done          bool                      `json:"done,omitempty"`
+	Score         float64                   `json:"score,omitempty"`
+	ExistingTotal int                       `json:"existing_total,omitempty"`
+	SpaceSize     int                       `json:"space_size,omitempty"`
+	Completed     int                       `json:"completed,omitempty"`
+	Skipped       bool                      `json:"skipped,omitempty"`
 }
 
 // Name returns the algorithm name.
@@ -150,17 +151,21 @@ func (o *OptunaSearch) Init(ctx context.Context, name string, space ExpandedSear
 	}
 
 	// Sync state from Optuna — accounts for trials from previous runs.
-	o.toldCount = resp.ExistingComplete
+	// ExistingTotal counts all non-RUNNING trials (COMPLETE + FAIL), matching
+	// the length of the history slice we will receive after a restart.
+	o.toldCount = resp.ExistingTotal
 	o.spaceSize = resp.SpaceSize
-	o.logger.Info("OptunaSearch initialized", "existingComplete", resp.ExistingComplete, "spaceSize", resp.SpaceSize)
+	o.logger.Info("OptunaSearch initialized", "existingTotal", resp.ExistingTotal, "spaceSize", resp.SpaceSize)
 	return nil
 }
 
 // SuggestNext tells Optuna about new trial results and asks for the next suggestion.
 func (o *OptunaSearch) SuggestNext(history []abtypes.TrialResult) (abtypes.RoleParamSet, error) {
 	// Tell Optuna about the last trial result (if any).
-	if o.lastTrialID >= 0 && o.toldCount < len(history) {
-		result := history[o.toldCount]
+	// After a restart, history contains all previous trials (COMPLETE+FAIL).
+	// We always tell the most recent history entry that hasn't been told yet.
+	if o.lastTrialID >= 0 && len(history) > o.toldCount {
+		result := history[len(history)-1]
 		req := bridgeRequest{
 			Action:    "tell",
 			StudyName: o.studyName,
@@ -176,7 +181,7 @@ func (o *OptunaSearch) SuggestNext(history []abtypes.TrialResult) (abtypes.RoleP
 		if resp.Status != "ok" {
 			return nil, fmt.Errorf("optuna tell failed: %s", resp.Message)
 		}
-		o.toldCount++
+		o.toldCount = len(history)
 		o.lastTrialID = -1
 	}
 
@@ -286,6 +291,8 @@ func (o *OptunaSearch) startProcess() error {
 
 // send writes a JSON request to the bridge and reads the JSON response.
 // A timeout guards against hangs if the Python process crashes or stalls.
+// On timeout, the bridge process is killed to avoid leaving a goroutine
+// blocked on o.scanner (bufio.Scanner is NOT safe for concurrent use).
 func (o *OptunaSearch) send(req bridgeRequest) (*bridgeResponse, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -324,8 +331,13 @@ func (o *OptunaSearch) send(req bridgeRequest) (*bridgeResponse, error) {
 	select {
 	case r := <-ch:
 		return r.resp, r.err
-	case <-time.After(30 * time.Second):
-		return nil, fmt.Errorf("read from bridge: timeout (process may be hung or crashed)")
+	case <-time.After(bridgeTimeout):
+		// Kill the bridge process to unblock the goroutine reading from scanner.
+		// This is safe because the process will be restarted on the next init.
+		if o.cmd != nil && o.cmd.Process != nil {
+			_ = o.cmd.Process.Kill()
+		}
+		return nil, fmt.Errorf("read from bridge: timeout (process killed, restart required)")
 	}
 }
 

--- a/pkg/autobenchmark/search/optuna_test.go
+++ b/pkg/autobenchmark/search/optuna_test.go
@@ -1,0 +1,480 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func findBridgePath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "tools", "optuna_bridge.py")
+}
+
+func skipIfNoOptuna(t *testing.T) {
+	t.Helper()
+	if err := exec.Command("python3", "-c", "import optuna").Run(); err != nil {
+		t.Skip("python3 with optuna not available, skipping integration test")
+	}
+}
+
+func toFloat64(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	default:
+		return 0
+	}
+}
+
+// objectiveFunc computes (score, slaPass) from suggested params.
+type objectiveFunc func(params abtypes.RoleParamSet) (float64, bool)
+
+// runLoop runs a full ask-tell optimisation loop and returns the trial history.
+func runLoop(
+	t *testing.T,
+	algo *OptunaSearch,
+	studyName string,
+	space ExpandedSearchSpace,
+	cfg config.StrategySpec,
+	obj objectiveFunc,
+) []abtypes.TrialResult {
+	t.Helper()
+	require.NoError(t, algo.Init(context.Background(), studyName, space, cfg))
+
+	var history []abtypes.TrialResult
+	for !algo.IsDone(history) {
+		params, err := algo.SuggestNext(history)
+		require.NoError(t, err)
+
+		score, slaPass := obj(params)
+		history = append(history, abtypes.TrialResult{
+			TrialIndex: len(history),
+			Params:     params,
+			Score:      score,
+			SLAPass:    slaPass,
+		})
+	}
+	return history
+}
+
+func bestScore(history []abtypes.TrialResult) float64 {
+	best := history[0].Score
+	for _, r := range history[1:] {
+		if r.Score > best {
+			best = r.Score
+		}
+	}
+	return best
+}
+
+func avgScore(history []abtypes.TrialResult) float64 {
+	var sum float64
+	for _, r := range history {
+		sum += r.Score
+	}
+	return sum / float64(len(history))
+}
+
+// ---------------------------------------------------------------------------
+// Small search space (5×5 = 25 combos) — smoke tests
+// ---------------------------------------------------------------------------
+
+func buildSmallSpace() ExpandedSearchSpace {
+	return ExpandedSearchSpace{
+		"default": {
+			"x": {1, 2, 3, 4, 5},
+			"y": {0.1, 0.2, 0.3, 0.4, 0.5},
+		},
+	}
+}
+
+// evalSmall: peak at x=3, y=0.3 → score=10.0. SLA passes when score > 8.0.
+func evalSmall(params abtypes.RoleParamSet) (float64, bool) {
+	x := toFloat64(params["default"]["x"])
+	y := toFloat64(params["default"]["y"])
+	score := 10.0 - (x-3)*(x-3) - (y-0.3)*(y-0.3)*100
+	return score, score > 8.0
+}
+
+// ---------------------------------------------------------------------------
+// Large search space (20×20×10 = 4000 combos) — effectiveness tests
+//
+// Objective: score = 100 − 0.5·(a−15)² − (b−7)² − 2·(c−4)²
+// Peak at (a=15, b=7, c=4) → score = 100.
+// The three parameters have different sensitivities, making the landscape
+// non-trivial: c is most sensitive (coeff 2), b is moderate (coeff 1),
+// a is least sensitive (coeff 0.5).
+// ---------------------------------------------------------------------------
+
+func buildLargeSpace() ExpandedSearchSpace {
+	a := make([]any, 20)
+	for i := range a {
+		a[i] = float64(i + 1)
+	}
+	b := make([]any, 20)
+	for i := range b {
+		b[i] = float64(i + 1)
+	}
+	c := make([]any, 10)
+	for i := range c {
+		c[i] = float64(i + 1)
+	}
+	return ExpandedSearchSpace{
+		"default": {"a": a, "b": b, "c": c},
+	}
+}
+
+// evalLarge: peak at a=15, b=7, c=4 → 100. SLA passes when score > 90.
+func evalLarge(params abtypes.RoleParamSet) (float64, bool) {
+	a := toFloat64(params["default"]["a"])
+	b := toFloat64(params["default"]["b"])
+	c := toFloat64(params["default"]["c"])
+	score := 100.0 - 0.5*(a-15)*(a-15) - (b-7)*(b-7) - 2*(c-4)*(c-4)
+	return score, score > 90.0
+}
+
+// ===========================================================================
+// Effectiveness tests — verify algorithms produce meaningful optimisation
+// ===========================================================================
+
+// TestOptunaSearch_Convergence verifies that TPE learns over time:
+//   - best score exceeds a high threshold (95.0)
+//   - average score of latter trials > average of early trials
+func TestOptunaSearch_Convergence(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	seed := 42
+	algo := &OptunaSearch{}
+	defer func() { _ = algo.Close() }()
+
+	history := runLoop(t, algo, "convergence-tpe", buildLargeSpace(), config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: 50,
+		Seed:                 &seed,
+	}, evalLarge)
+
+	assert.Len(t, history, 50)
+
+	best := bestScore(history)
+	t.Logf("Best score: %.2f (peak=100)", best)
+	assert.GreaterOrEqual(t, best, 95.0,
+		"TPE should find score >= 95 within 50 trials on a 4000-combo space")
+
+	// Convergence: last 15 trials should score higher on average than first 15.
+	first15 := avgScore(history[:15])
+	last15 := avgScore(history[35:])
+	t.Logf("Avg first 15: %.2f, avg last 15: %.2f", first15, last15)
+	assert.Greater(t, last15, first15,
+		"TPE should converge: later trials score higher than early trials")
+}
+
+// TestOptunaSearch_TPEBeatsRandom gives TPE and Random the same budget on the
+// large space and compares the average score of the last 15 trials ("tail avg").
+// TPE should converge into the high-score region, producing a much higher tail
+// average than random, which remains uniformly distributed (theoretical mean ≈ 7).
+func TestOptunaSearch_TPEBeatsRandom(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	space := buildLargeSpace()
+	seed := 42
+	budget := 50
+	tailSize := 15
+
+	// TPE
+	tpeAlgo := &OptunaSearch{}
+	tpeHistory := runLoop(t, tpeAlgo, "cmp-tpe", space, config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: budget,
+		Seed:                 &seed,
+	}, evalLarge)
+	_ = tpeAlgo.Close()
+
+	// Random
+	randAlgo := &OptunaSearch{}
+	randHistory := runLoop(t, randAlgo, "cmp-random", space, config.StrategySpec{
+		Algorithm:            "random",
+		MaxTrialsPerTemplate: budget,
+		Seed:                 &seed,
+	}, evalLarge)
+	_ = randAlgo.Close()
+
+	tpeTailAvg := avgScore(tpeHistory[budget-tailSize:])
+	randTailAvg := avgScore(randHistory[budget-tailSize:])
+
+	t.Logf("TPE tail avg (last %d)=%.2f, Random tail avg=%.2f", tailSize, tpeTailAvg, randTailAvg)
+	assert.Greater(t, tpeTailAvg, randTailAvg,
+		"TPE tail average should exceed Random tail average")
+	assert.Greater(t, tpeTailAvg, 70.0,
+		"TPE tail average should be well above the theoretical random mean (~7)")
+}
+
+// ===========================================================================
+// Functional tests — samplers, multi-role, SLA, error handling, config
+// ===========================================================================
+
+func TestOptunaSearch_AllSamplers(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	// Smoke-test: every sampler should complete 5 trials without error
+	// and produce valid params.
+	// Note: gp and cmaes are designed for continuous spaces and may not work
+	// reliably with purely categorical distributions, so we skip them here.
+	samplers := []string{"tpe", "random", "qmc"}
+
+	for _, sampler := range samplers {
+		t.Run(sampler, func(t *testing.T) {
+			algo := &OptunaSearch{}
+			defer func() { _ = algo.Close() }()
+
+			history := runLoop(t, algo, "smoke-"+sampler, buildSmallSpace(), config.StrategySpec{
+				Algorithm:            sampler,
+				MaxTrialsPerTemplate: 5,
+			}, evalSmall)
+
+			assert.Len(t, history, 5)
+			for i, r := range history {
+				assert.Equal(t, i, r.TrialIndex)
+				assert.NotNil(t, r.Params["default"])
+			}
+		})
+	}
+}
+
+func TestOptunaSearch_WithAlgorithmConfig(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	seed := 42
+	algo := &OptunaSearch{}
+	defer func() { _ = algo.Close() }()
+
+	history := runLoop(t, algo, "cfg-tpe", buildLargeSpace(), config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: 30,
+		Seed:                 &seed,
+		AlgorithmConfig: map[string]any{
+			"n_startup_trials": 5, // fewer random warmup trials
+		},
+	}, evalLarge)
+
+	assert.Len(t, history, 30)
+
+	best := bestScore(history)
+	t.Logf("Best with n_startup_trials=5: %.2f", best)
+	assert.GreaterOrEqual(t, best, 90.0,
+		"TPE with n_startup_trials=5 should still find a good solution")
+}
+
+func TestOptunaSearch_SLAConstraint(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	seed := 42
+	algo := &OptunaSearch{}
+	defer func() { _ = algo.Close() }()
+
+	history := runLoop(t, algo, "sla-tpe", buildLargeSpace(), config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: 50,
+		Seed:                 &seed,
+	}, evalLarge)
+
+	var passCount, failCount int
+	for _, r := range history {
+		if r.SLAPass {
+			passCount++
+		} else {
+			failCount++
+		}
+	}
+	t.Logf("SLA pass=%d fail=%d (threshold > 90)", passCount, failCount)
+	assert.Greater(t, passCount, 0, "should have at least one SLA-passing trial")
+	assert.Greater(t, failCount, 0, "should have at least one SLA-failing trial")
+}
+
+func TestOptunaSearch_MultiRole(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	space := ExpandedSearchSpace{
+		"prefill": {
+			"chunkedPrefillSize": {2048, 4096, 8192},
+		},
+		"decode": {
+			"maxNumSeqs": {64, 128, 256, 512},
+		},
+	}
+
+	algo := &OptunaSearch{}
+	defer func() { _ = algo.Close() }()
+
+	require.NoError(t, algo.Init(context.Background(), "test-multi-role", space, config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: 8,
+	}))
+
+	var history []abtypes.TrialResult
+	for !algo.IsDone(history) {
+		params, err := algo.SuggestNext(history)
+		require.NoError(t, err)
+
+		require.Contains(t, params, "prefill")
+		require.Contains(t, params, "decode")
+		require.Contains(t, params["prefill"], "chunkedPrefillSize")
+		require.Contains(t, params["decode"], "maxNumSeqs")
+
+		result := abtypes.TrialResult{
+			TrialIndex: len(history),
+			Params:     params,
+			Score:      toFloat64(params["decode"]["maxNumSeqs"]) * 0.1,
+			SLAPass:    true,
+		}
+		history = append(history, result)
+
+		t.Logf("Trial %d: prefill.chunkedPrefillSize=%.0f decode.maxNumSeqs=%.0f score=%.2f",
+			result.TrialIndex,
+			toFloat64(params["prefill"]["chunkedPrefillSize"]),
+			toFloat64(params["decode"]["maxNumSeqs"]),
+			result.Score)
+	}
+	assert.Len(t, history, 8)
+}
+
+func TestOptunaSearch_ErrorTrial(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	algo := &OptunaSearch{}
+	defer func() { _ = algo.Close() }()
+
+	require.NoError(t, algo.Init(context.Background(), "test-error", buildSmallSpace(), config.StrategySpec{
+		Algorithm:            "tpe",
+		MaxTrialsPerTemplate: 5,
+	}))
+
+	var history []abtypes.TrialResult
+	for !algo.IsDone(history) {
+		params, err := algo.SuggestNext(history)
+		require.NoError(t, err)
+
+		result := abtypes.TrialResult{
+			TrialIndex: len(history),
+			Params:     params,
+		}
+
+		if len(history) == 0 {
+			result.Error = "simulated failure"
+			result.Score = 0
+			result.SLAPass = false
+		} else {
+			score, slaPass := evalSmall(params)
+			result.Score = score
+			result.SLAPass = slaPass
+		}
+		history = append(history, result)
+	}
+
+	assert.Len(t, history, 5)
+	assert.NotEmpty(t, history[0].Error)
+	assert.Empty(t, history[1].Error)
+}
+
+// ===========================================================================
+// Unit tests — no Python required
+// ===========================================================================
+
+func TestOptunaSearch_FactoryRegistration(t *testing.T) {
+	for _, name := range optunaSamplers {
+		t.Run(name, func(t *testing.T) {
+			algo, err := Get(name)
+			require.NoError(t, err)
+			_, ok := algo.(*OptunaSearch)
+			assert.True(t, ok, "algorithm %q should be OptunaSearch", name)
+		})
+	}
+}
+
+func TestOptunaSearch_Name(t *testing.T) {
+	for _, name := range optunaSamplers {
+		t.Run(name, func(t *testing.T) {
+			algo := &OptunaSearch{algorithm: name}
+			assert.Equal(t, name, algo.Name())
+		})
+	}
+}
+
+func TestOptunaSearch_MarshalUnmarshal(t *testing.T) {
+	algo := &OptunaSearch{algorithm: "tpe"}
+	data, err := algo.MarshalState()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "tpe")
+	require.NoError(t, algo.UnmarshalState(data))
+}
+
+func TestOptunaSearch_IsDone(t *testing.T) {
+	// maxTrials is the bound.
+	algo := &OptunaSearch{maxTrials: 3}
+	assert.False(t, algo.IsDone(nil))
+	assert.False(t, algo.IsDone(makeHistory(2)))
+	assert.True(t, algo.IsDone(makeHistory(3)))
+	assert.True(t, algo.IsDone(makeHistory(5)))
+
+	// spaceSize < maxTrials: search space exhausted before maxTrials.
+	algo2 := &OptunaSearch{maxTrials: 100, spaceSize: 4}
+	assert.False(t, algo2.IsDone(makeHistory(3)))
+	assert.True(t, algo2.IsDone(makeHistory(4)))
+	assert.True(t, algo2.IsDone(makeHistory(10)))
+
+	// spaceSize=0 (unknown): only maxTrials matters.
+	algo3 := &OptunaSearch{maxTrials: 5, spaceSize: 0}
+	assert.False(t, algo3.IsDone(makeHistory(4)))
+	assert.True(t, algo3.IsDone(makeHistory(5)))
+}
+
+func TestOptunaSearch_BridgePathResolution(t *testing.T) {
+	assert.Equal(t, "/tools/optuna_bridge.py", defaultBridgePath)
+
+	t.Setenv(envBridgePath, "/custom/bridge.py")
+	algo := &OptunaSearch{}
+	err := algo.startProcess()
+	if err == nil {
+		assert.Equal(t, []string{"python3", "/custom/bridge.py"}, algo.cmd.Args)
+		_ = algo.Close()
+	} else {
+		t.Logf("startProcess error (expected on systems without python3): %v", err)
+	}
+}

--- a/pkg/autobenchmark/search/optuna_test.go
+++ b/pkg/autobenchmark/search/optuna_test.go
@@ -413,6 +413,66 @@ func TestOptunaSearch_ErrorTrial(t *testing.T) {
 	assert.Empty(t, history[1].Error)
 }
 
+// TestOptunaSearch_ResumeWithFailedTrials verifies that after a restart
+// where history contains failed/SLA-failing trials, the resumed search
+// tells the correct (most recent) trial result to Optuna instead of
+// indexing by toldCount and sending stale data.
+func TestOptunaSearch_ResumeWithFailedTrials(t *testing.T) {
+	skipIfNoOptuna(t)
+	t.Setenv(envBridgePath, findBridgePath())
+
+	studyName := "resume-failed"
+	space := buildSmallSpace()
+	storagePath := filepath.Join(t.TempDir(), "optuna.db")
+	cfg := config.StrategySpec{Algorithm: "tpe", MaxTrialsPerTemplate: 5, StoragePath: storagePath}
+
+	// Phase 1: run 3 trials, one with an error.
+	algo1 := &OptunaSearch{}
+	require.NoError(t, algo1.Init(context.Background(), studyName, space, cfg))
+
+	var history []abtypes.TrialResult
+	for i := 0; i < 3; i++ {
+		params, err := algo1.SuggestNext(history)
+		require.NoError(t, err)
+		result := abtypes.TrialResult{
+			TrialIndex: i,
+			Params:     params,
+			Score:      float64(i * 10),
+			SLAPass:    i != 1,
+		}
+		if i == 1 {
+			result.Error = "simulated failure"
+		}
+		history = append(history, result)
+	}
+	require.NoError(t, algo1.Close())
+
+	// Phase 2: resume with the same study name and existing history.
+	// The bridge should report existing_total=3 (including the failed trial).
+	algo2 := &OptunaSearch{}
+	require.NoError(t, algo2.Init(context.Background(), studyName, space, cfg))
+
+	// Continue for 2 more trials.
+	for i := 3; i < 5; i++ {
+		params, err := algo2.SuggestNext(history)
+		require.NoError(t, err)
+		result := abtypes.TrialResult{
+			TrialIndex: i,
+			Params:     params,
+			Score:      float64(i * 10),
+			SLAPass:    true,
+		}
+		history = append(history, result)
+	}
+
+	assert.Len(t, history, 5)
+	// The bridge's idempotent tell should not have skipped any new trials.
+	for i, r := range history {
+		assert.Equal(t, i, r.TrialIndex)
+		assert.NotNil(t, r.Params["default"])
+	}
+}
+
 // ===========================================================================
 // Unit tests — no Python required
 // ===========================================================================

--- a/pkg/autobenchmark/search/param.go
+++ b/pkg/autobenchmark/search/param.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"sigs.k8s.io/rbgs/pkg/autobenchmark/config"
+	abtypes "sigs.k8s.io/rbgs/pkg/autobenchmark/types"
+)
+
+// ExpandSearchSpace expands a config-level SearchSpace (with range and categorical params)
+// into discrete value lists per role per param.
+func ExpandSearchSpace(searchSpace map[string]map[string]config.SearchParam) ExpandedSearchSpace {
+	expanded := make(ExpandedSearchSpace)
+	for role, params := range searchSpace {
+		expanded[role] = make(map[string][]interface{})
+		for name, param := range params {
+			expanded[role][name] = expandParam(param)
+		}
+	}
+	return expanded
+}
+
+func expandParam(param config.SearchParam) []interface{} {
+	switch param.Type {
+	case "range":
+		if param.Min == nil || param.Max == nil || param.Step == nil {
+			return nil
+		}
+		var values []interface{}
+		for v := *param.Min; v <= *param.Max+1e-9; v += *param.Step {
+			// Round to avoid floating point drift
+			rounded := math.Round(v*1e6) / 1e6
+			values = append(values, rounded)
+		}
+		return values
+	case "categorical":
+		result := make([]interface{}, len(param.Values))
+		copy(result, param.Values)
+		return result
+	default:
+		return nil
+	}
+}
+
+// paramEntry represents a single parameter with its role, name, and values.
+type paramEntry struct {
+	role   string
+	name   string
+	values []any
+}
+
+// cartesianProductEntries returns ordered parameter entries and the total
+// combination count (as uint64 to avoid int overflow).
+func cartesianProductEntries(space ExpandedSearchSpace) ([]paramEntry, uint64, error) {
+	var entries []paramEntry
+	roles := sortedKeys(space)
+	for _, role := range roles {
+		params := space[role]
+		names := sortedParamKeys(params)
+		for _, name := range names {
+			entries = append(entries, paramEntry{role: role, name: name, values: params[name]})
+		}
+	}
+	if len(entries) == 0 {
+		return nil, 1, nil
+	}
+	var total uint64 = 1
+	for _, e := range entries {
+		n := uint64(len(e.values))
+		if n == 0 {
+			continue
+		}
+		if total > math.MaxUint64/n {
+			return nil, 0, fmt.Errorf("search space too large: combination count overflows")
+		}
+		total *= n
+	}
+	return entries, total, nil
+}
+
+// combinationAtIndex returns the i-th combination from the given entries
+// using a mixed-radix decomposition (odometer order).
+func combinationAtIndex(index int, entries []paramEntry) abtypes.RoleParamSet {
+	rps := make(abtypes.RoleParamSet)
+	remaining := index
+	for j := len(entries) - 1; j >= 0; j-- {
+		n := len(entries[j].values)
+		if n == 0 {
+			continue
+		}
+		idx := remaining % n
+		remaining /= n
+		if _, ok := rps[entries[j].role]; !ok {
+			rps[entries[j].role] = make(abtypes.ParamSet)
+		}
+		rps[entries[j].role][entries[j].name] = entries[j].values[idx]
+	}
+	return rps
+}
+
+// CartesianProduct generates all combinations of role-level param sets.
+// It produces a flat list of RoleParamSet, where each entry contains
+// param values for all roles.
+// NOTE: This eagerly materializes all combinations and may OOM for large
+// search spaces; prefer iterator-based consumption when possible.
+func CartesianProduct(space ExpandedSearchSpace) []abtypes.RoleParamSet {
+	entries, total, err := cartesianProductEntries(space)
+	if err != nil {
+		return nil
+	}
+	if total > uint64(math.MaxInt) {
+		return nil
+	}
+	results := make([]abtypes.RoleParamSet, 0, int(total))
+	for i := uint64(0); i < total; i++ {
+		results = append(results, combinationAtIndex(int(i), entries))
+	}
+	return results
+}
+
+func sortedKeys(m ExpandedSearchSpace) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedParamKeys(m map[string][]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/autobenchmark/types/types.go
+++ b/pkg/autobenchmark/types/types.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "time"
+
+// ParamSet represents a set of parameter values for a single trial.
+// Keys are abstract param names (e.g., "gpuMemoryUtilization"),
+// values can be float64, int, string, or bool.
+type ParamSet map[string]interface{}
+
+// RoleParamSet maps role names to their parameter sets.
+// "default" key applies to all roles.
+type RoleParamSet map[string]ParamSet
+
+// TrialResult holds the outcome of a single trial execution.
+type TrialResult struct {
+	TrialIndex   int          `json:"trialIndex"`
+	TemplateName string       `json:"templateName"`
+	Params       RoleParamSet `json:"params"`
+	Metrics      *Metrics     `json:"metrics,omitempty"`
+	SLAPass      bool         `json:"slaPass"`
+	Score        float64      `json:"score"`
+	Error        string       `json:"error,omitempty"`
+	Duration     Duration     `json:"duration"`
+	StartTime    time.Time    `json:"startTime"`
+	EndTime      time.Time    `json:"endTime"`
+}
+
+// Metrics contains the benchmark performance metrics extracted from evaluator output.
+type Metrics struct {
+	// Latency metrics (milliseconds)
+	TTFTP50 float64 `json:"ttftP50"`
+	TTFTP99 float64 `json:"ttftP99"`
+	TPOTP50 float64 `json:"tpotP50"`
+	TPOTP99 float64 `json:"tpotP99"`
+
+	// Throughput metrics (tokens per second)
+	OutputThroughput float64 `json:"outputThroughput"`
+	InputThroughput  float64 `json:"inputThroughput"`
+	TotalThroughput  float64 `json:"totalThroughput"`
+
+	// Request metrics
+	RequestsPerSecond    float64 `json:"requestsPerSecond"`
+	ErrorRate            float64 `json:"errorRate"`
+	NumCompletedRequests int     `json:"numCompletedRequests"`
+	NumErrorRequests     int     `json:"numErrorRequests"`
+	NumRequests          int     `json:"numRequests"`
+}
+
+// TemplateState tracks the progress of trials for a single template.
+type TemplateState struct {
+	Name           string        `json:"name"`
+	Completed      bool          `json:"completed"`
+	Trials         []TrialResult `json:"trials"`
+	BestTrial      *TrialResult  `json:"bestTrial,omitempty"`
+	AlgorithmState []byte        `json:"algorithmState,omitempty"`
+}
+
+// ExperimentState is the full checkpoint state persisted to PVC.
+type ExperimentState struct {
+	ExperimentID       string          `json:"experimentId"`
+	StartTime          time.Time       `json:"startTime"`
+	CurrentTemplateIdx int             `json:"currentTemplateIdx"`
+	Templates          []TemplateState `json:"templates"`
+	GlobalBest         *TrialResult    `json:"globalBest,omitempty"`
+}
+
+// Duration is a JSON-serializable wrapper around time.Duration.
+type Duration time.Duration
+
+// MarshalJSON implements json.Marshaler.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Duration(d).String() + `"`), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(dur)
+	return nil
+}

--- a/tools/optuna_bridge.py
+++ b/tools/optuna_bridge.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RBG Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optuna bridge for auto-benchmark parameter tuning.
+
+Long-running subprocess communicating with Go controller via JSON Lines
+over stdin/stdout. Logs go to stderr.
+
+Supported actions:
+  init     - Create or load an Optuna study
+  ask      - Get next suggested parameters
+  tell     - Report trial results
+  is_done  - Check if search should stop
+  best     - Get the best feasible trial
+  shutdown - Gracefully stop the bridge
+"""
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+
+import optuna
+from optuna.distributions import CategoricalDistribution
+from optuna.trial import TrialState
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.INFO,
+    format="%(asctime)s [optuna-bridge] %(levelname)s %(message)s",
+)
+logger = logging.getLogger("optuna_bridge")
+
+# Suppress Optuna's verbose logging.
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+# Sampler registry: algorithm name -> Optuna sampler class.
+SAMPLER_MAP = {
+    "tpe": optuna.samplers.TPESampler,
+    "gp": optuna.samplers.GPSampler,
+    "cmaes": optuna.samplers.CmaEsSampler,
+    "random": optuna.samplers.RandomSampler,
+    "qmc": optuna.samplers.QMCSampler,
+    "nsgaii": optuna.samplers.NSGAIISampler,
+    "nsgaiii": optuna.samplers.NSGAIIISampler,
+}
+
+# Samplers that support the constraints_func parameter for SLA constraints.
+CONSTRAINT_CAPABLE = {"tpe", "nsgaii", "nsgaiii"}
+
+
+def _create_sampler(
+    name: str,
+    seed: int | None,
+    constraints_func,
+    kwargs: dict | None,
+) -> optuna.samplers.BaseSampler:
+    """Dynamically create an Optuna sampler by name with optional kwargs."""
+    cls = SAMPLER_MAP.get(name)
+    if cls is None:
+        raise ValueError(
+            f"unknown sampler: {name!r}, supported: {sorted(SAMPLER_MAP)}"
+        )
+    kw = dict(kwargs or {})
+    if seed is not None:
+        kw["seed"] = seed
+    if name in CONSTRAINT_CAPABLE:
+        kw["constraints_func"] = constraints_func
+    return cls(**kw)
+
+
+class StudyManager:
+    """Manages multiple Optuna studies (one per template)."""
+
+    def __init__(self):
+        self.studies: dict[str, optuna.Study] = {}
+        self.distributions: dict[str, dict[str, CategoricalDistribution]] = {}
+        self.pending_trials: dict[str, optuna.Trial | None] = {}
+        self.max_trials: dict[str, int] = {}
+        self.space_sizes: dict[str, int] = {}  # Cartesian product size per study
+
+    def init_study(
+        self,
+        study_name: str,
+        search_space: dict[str, dict[str, list]],
+        direction: str = "maximize",
+        max_trials: int = 100,
+        storage_path: str | None = None,
+        seed: int | None = None,
+        sampler: str = "tpe",
+        sampler_kwargs: dict | None = None,
+    ) -> dict:
+        """Create or load an Optuna study."""
+
+        def constraints_func(trial: optuna.trial.FrozenTrial) -> list[float]:
+            return trial.user_attrs.get("constraints", [0.0])
+
+        samp = _create_sampler(sampler, seed, constraints_func, sampler_kwargs)
+
+        storage = f"sqlite:///{storage_path}" if storage_path else None
+
+        study = optuna.create_study(
+            study_name=study_name,
+            storage=storage,
+            sampler=samp,
+            direction=direction,
+            load_if_exists=True,
+        )
+
+        # Prune any stale RUNNING trials from a previous crashed run.
+        for t in study.trials:
+            if t.state == TrialState.RUNNING:
+                study.tell(t.number, state=TrialState.FAIL)
+                logger.info("Pruned stale RUNNING trial #%d", t.number)
+
+        # Build flat distributions: "role/param" -> CategoricalDistribution.
+        distributions = {}
+        for role, params in search_space.items():
+            for param_name, values in params.items():
+                flat_key = f"{role}/{param_name}"
+                typed_values = _normalize_values(values)
+                distributions[flat_key] = CategoricalDistribution(choices=typed_values)
+
+        self.studies[study_name] = study
+        self.distributions[study_name] = distributions
+        self.max_trials[study_name] = max_trials
+        self.pending_trials[study_name] = None
+
+        # Compute Cartesian product size of the search space.
+        space_size = 1
+        for dist in distributions.values():
+            space_size *= len(dist.choices)
+        self.space_sizes[study_name] = space_size
+
+        existing_complete = sum(
+            1 for t in study.trials if t.state == TrialState.COMPLETE
+        )
+        logger.info(
+            "Initialized study %r: sampler=%s, %d complete trials, max=%d, space_size=%d",
+            study_name,
+            sampler,
+            existing_complete,
+            max_trials,
+            space_size,
+        )
+        return {
+            "status": "ok",
+            "existing_complete": existing_complete,
+            "space_size": space_size,
+        }
+
+    def ask(self, study_name: str) -> dict:
+        """Ask Optuna for the next parameter suggestion."""
+        study = self.studies[study_name]
+        dists = self.distributions[study_name]
+
+        trial = study.ask(dists)
+        self.pending_trials[study_name] = trial
+
+        # Unflatten "role/param" back to nested dict.
+        params: dict[str, dict[str, object]] = {}
+        for flat_key, value in trial.params.items():
+            role, param_name = flat_key.split("/", 1)
+            params.setdefault(role, {})[param_name] = value
+
+        logger.info("Study %r: asked trial #%d", study_name, trial.number)
+        return {"status": "ok", "trial_id": trial.number, "params": params}
+
+    def tell(
+        self,
+        study_name: str,
+        trial_id: int,
+        score: float,
+        sla_pass: bool,
+        error: str = "",
+    ) -> dict:
+        """Report trial results to Optuna."""
+        study = self.studies[study_name]
+
+        # Idempotent: skip if already told (restart scenario).
+        if trial_id < len(study.trials):
+            existing = study.trials[trial_id]
+            if existing.state in (TrialState.COMPLETE, TrialState.FAIL):
+                logger.info(
+                    "Study %r: trial #%d already %s, skipping tell",
+                    study_name,
+                    trial_id,
+                    existing.state.name,
+                )
+                return {"status": "ok", "skipped": True}
+
+        pending = self.pending_trials.get(study_name)
+
+        if error:
+            if pending is not None and pending.number == trial_id:
+                study.tell(pending, state=TrialState.FAIL)
+            else:
+                study.tell(trial_id, state=TrialState.FAIL)
+            logger.info(
+                "Study %r: trial #%d FAILED: %s", study_name, trial_id, error
+            )
+        else:
+            constraint_value = 0.0 if sla_pass else 1.0
+            if pending is not None and pending.number == trial_id:
+                pending.set_user_attr("constraints", [constraint_value])
+                study.tell(pending, score)
+            else:
+                # Fallback for resumed trials — tell by id, set attr after.
+                study.tell(trial_id, score)
+                study.trials[trial_id].set_user_attr(
+                    "constraints", [constraint_value]
+                )
+            logger.info(
+                "Study %r: trial #%d score=%.4f sla_pass=%s",
+                study_name,
+                trial_id,
+                score,
+                sla_pass,
+            )
+
+        self.pending_trials[study_name] = None
+        return {"status": "ok"}
+
+    def is_done(self, study_name: str) -> dict:
+        """Check if search should stop.
+
+        Done when any of:
+        - completed trials >= max_trials
+        - completed trials >= search space Cartesian product size (exhausted)
+        """
+        study = self.studies[study_name]
+        completed = sum(
+            1
+            for t in study.trials
+            if t.state in (TrialState.COMPLETE, TrialState.FAIL)
+        )
+        max_t = self.max_trials.get(study_name, 0)
+        space_size = self.space_sizes.get(study_name, 0)
+        done = completed >= max_t or (space_size > 0 and completed >= space_size)
+        return {
+            "status": "ok",
+            "done": done,
+            "completed": completed,
+            "space_size": space_size,
+        }
+
+    def best(self, study_name: str) -> dict:
+        """Get the best feasible trial."""
+        study = self.studies[study_name]
+        try:
+            best_trial = study.best_trial
+            params: dict[str, dict[str, object]] = {}
+            for flat_key, value in best_trial.params.items():
+                role, param_name = flat_key.split("/", 1)
+                params.setdefault(role, {})[param_name] = value
+            return {
+                "status": "ok",
+                "trial_id": best_trial.number,
+                "score": best_trial.value,
+                "params": params,
+            }
+        except ValueError:
+            return {"status": "error", "message": "no completed feasible trials"}
+
+
+def _normalize_values(values: list) -> list:
+    """Normalize values for Optuna CategoricalDistribution (must be hashable)."""
+    result = []
+    for v in values:
+        if isinstance(v, bool):
+            result.append(v)
+        elif isinstance(v, float):
+            result.append(int(v) if v == int(v) else v)
+        elif isinstance(v, int):
+            result.append(v)
+        else:
+            result.append(str(v))
+    return result
+
+
+def _watch_parent():
+    """Exit the bridge if the parent process dies (e.g., Go controller crash)."""
+    original_ppid = os.getppid()
+    while True:
+        time.sleep(10)
+        if os.getppid() != original_ppid:
+            logger.info(
+                "Parent process changed (was %d, now %d), shutting down",
+                original_ppid,
+                os.getppid(),
+            )
+            os._exit(1)
+
+
+def main():
+    manager = StudyManager()
+    logger.info("Optuna bridge started, waiting for commands...")
+
+    # Daemon thread: if Go controller crashes, PPID changes and we exit.
+    threading.Thread(target=_watch_parent, daemon=True).start()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as e:
+            _respond({"status": "error", "message": f"invalid JSON: {e}"})
+            continue
+
+        action = request.get("action", "")
+        study_name = request.get("study_name", "")
+
+        try:
+            if action == "init":
+                response = manager.init_study(
+                    study_name=study_name,
+                    search_space=request["search_space"],
+                    direction=request.get("direction", "maximize"),
+                    max_trials=request.get("max_trials", 100),
+                    storage_path=request.get("storage_path"),
+                    seed=request.get("seed"),
+                    sampler=request.get("sampler", "tpe"),
+                    sampler_kwargs=request.get("sampler_kwargs"),
+                )
+            elif action == "ask":
+                response = manager.ask(study_name)
+            elif action == "tell":
+                response = manager.tell(
+                    study_name=study_name,
+                    trial_id=request["trial_id"],
+                    score=request.get("score", 0.0),
+                    sla_pass=request.get("sla_pass", False),
+                    error=request.get("error", ""),
+                )
+            elif action == "is_done":
+                response = manager.is_done(study_name)
+            elif action == "best":
+                response = manager.best(study_name)
+            elif action == "shutdown":
+                logger.info("Shutdown requested")
+                _respond({"status": "ok"})
+                break
+            else:
+                response = {
+                    "status": "error",
+                    "message": f"unknown action: {action}",
+                }
+        except Exception as e:
+            logger.exception("Error handling action %r", action)
+            response = {"status": "error", "message": str(e)}
+
+        _respond(response)
+
+    logger.info("Optuna bridge exiting")
+
+
+def _respond(data: dict):
+    sys.stdout.write(json.dumps(data, default=str) + "\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/optuna_bridge.py
+++ b/tools/optuna_bridge.py
@@ -107,7 +107,11 @@ class StudyManager:
         """Create or load an Optuna study."""
 
         def constraints_func(trial: optuna.trial.FrozenTrial) -> list[float]:
-            return trial.user_attrs.get("constraints", [0.0])
+            if "constraints" not in trial.user_attrs:
+                raise ValueError(
+                    f"Trial {trial.number} missing 'constraints' user attr"
+                )
+            return trial.user_attrs["constraints"]
 
         samp = _create_sampler(sampler, seed, constraints_func, sampler_kwargs)
 
@@ -192,16 +196,19 @@ class StudyManager:
         study = self.studies[study_name]
 
         # Idempotent: skip if already told (restart scenario).
-        if trial_id < len(study.trials):
-            existing = study.trials[trial_id]
-            if existing.state in (TrialState.COMPLETE, TrialState.FAIL):
-                logger.info(
-                    "Study %r: trial #%d already %s, skipping tell",
-                    study_name,
-                    trial_id,
-                    existing.state.name,
-                )
-                return {"status": "ok", "skipped": True}
+        trials_by_number = {t.number: t for t in study.trials}
+        existing = trials_by_number.get(trial_id)
+        if existing is not None and existing.state in (
+            TrialState.COMPLETE,
+            TrialState.FAIL,
+        ):
+            logger.info(
+                "Study %r: trial #%d already %s, skipping tell",
+                study_name,
+                trial_id,
+                existing.state.name,
+            )
+            return {"status": "ok", "skipped": True}
 
         pending = self.pending_trials.get(study_name)
 
@@ -216,14 +223,22 @@ class StudyManager:
         else:
             constraint_value = 0.0 if sla_pass else 1.0
             if pending is not None and pending.number == trial_id:
+                # Normal path: pending Trial has storage reference, set attr before tell.
                 pending.set_user_attr("constraints", [constraint_value])
                 study.tell(pending, score)
             else:
-                # Fallback for resumed trials — tell by id, set attr after.
-                study.tell(trial_id, score)
-                study.trials[trial_id].set_user_attr(
-                    "constraints", [constraint_value]
+                # Fallback for resumed trials: set constraints directly via storage
+                # BEFORE tell, because constraints_func is evaluated inside tell's after_trial.
+                trial_id_in_storage = (
+                    study._storage.get_trial_id_from_study_id_trial_number(
+                        study._study_id, trial_id
+                    )
                 )
+                study._storage.set_trial_user_attr(
+                    trial_id_in_storage, "constraints", [constraint_value]
+                )
+                study.tell(trial_id, score, skip_if_finished=True)
+
             logger.info(
                 "Study %r: trial #%d score=%.4f sla_pass=%s",
                 study_name,
@@ -246,7 +261,7 @@ class StudyManager:
         completed = sum(
             1
             for t in study.trials
-            if t.state in (TrialState.COMPLETE, TrialState.FAIL)
+            if t.state == TrialState.COMPLETE
         )
         max_t = self.max_trials.get(study_name, 0)
         space_size = self.space_sizes.get(study_name, 0)

--- a/tools/optuna_bridge.py
+++ b/tools/optuna_bridge.py
@@ -150,20 +150,20 @@ class StudyManager:
             space_size *= len(dist.choices)
         self.space_sizes[study_name] = space_size
 
-        existing_complete = sum(
-            1 for t in study.trials if t.state == TrialState.COMPLETE
+        existing_total = sum(
+            1 for t in study.trials if t.state != TrialState.RUNNING
         )
         logger.info(
-            "Initialized study %r: sampler=%s, %d complete trials, max=%d, space_size=%d",
+            "Initialized study %r: sampler=%s, %d total trials, max=%d, space_size=%d",
             study_name,
             sampler,
-            existing_complete,
+            existing_total,
             max_trials,
             space_size,
         )
         return {
             "status": "ok",
-            "existing_complete": existing_complete,
+            "existing_total": existing_total,
             "space_size": space_size,
         }
 
@@ -227,16 +227,33 @@ class StudyManager:
                 pending.set_user_attr("constraints", [constraint_value])
                 study.tell(pending, score)
             else:
-                # Fallback for resumed trials: set constraints directly via storage
-                # BEFORE tell, because constraints_func is evaluated inside tell's after_trial.
-                trial_id_in_storage = (
-                    study._storage.get_trial_id_from_study_id_trial_number(
-                        study._study_id, trial_id
+                # Resumed trial path: set constraints via storage internals BEFORE tell.
+                # This is required because constraints_func (used by TPE/NSGA-II samplers)
+                # is called inside tell()'s after_trial callback and needs user_attrs["constraints"].
+                #
+                # Optuna Issue #3640 confirms that cross-process ask-tell with constrained
+                # optimization requires restoring sampler state before tell. Since our bridge
+                # process persists across Go controller restarts, the sampler state is intact,
+                # but we lack the Trial object to set user_attrs via public API.
+                #
+                # Using _storage internals is a known limitation. If this breaks on future
+                # Optuna versions, the alternative is to pickle Trial objects on ask and
+                # restore them on tell, which requires significant architectural changes.
+                try:
+                    trial_id_in_storage = (
+                        study._storage.get_trial_id_from_study_id_trial_number(
+                            study._study_id, trial_id
+                        )
                     )
-                )
-                study._storage.set_trial_user_attr(
-                    trial_id_in_storage, "constraints", [constraint_value]
-                )
+                    study._storage.set_trial_user_attr(
+                        trial_id_in_storage, "constraints", [constraint_value]
+                    )
+                except AttributeError as e:
+                    raise RuntimeError(
+                        f"Optuna internal API changed: {e}. "
+                        f"This bridge requires Optuna 3.x/4.x storage internals. "
+                        f"Please report this issue with your Optuna version."
+                    ) from e
                 study.tell(trial_id, score, skip_if_finished=True)
 
             logger.info(


### PR DESCRIPTION
### What

Introduces the auto benchmark subsystem for RBG CLI, providing automated hyperparameter tuning for LLM inference workloads via Optuna integration.

### Changes

- **CLI commands** (`cmd/cli/cmd/llm/autobenchmark/`):
  - `run` — Launch benchmark with configurable search space
  - `stop` — Terminate a benchmark
  - `status` / `list` / `logs` — Observability commands
  - `dashboard` — Open result viewer

- **Core engine** (`pkg/autobenchmark/`):
  - `config/` — Config parsing, workload template generation
  - `controller/` — Lifecycle orchestration, SLA checker, state machine, reporter
  - `evaluator/` — GenAIBench throughput/latency evaluation
  - `lifecycle/` — Trial builder, mapper, manager
  - `search/` — Search space, grid search, Optuna sampler
  - `types/` — Domain models

- **Optuna bridge** (`tools/optuna_bridge.py`) — Python bridge for distributed HPO
- **Runner binary** (`cmd/autobenchmark/`) — Standalone benchmark entrypoint with Dockerfile
- **Examples** (`examples/cli/auto-benchmark/`) — Sample configs and templates
