### PR TITLE
fix(controller): prevent RestartInProgress condition loss due to stal…

### DIFF
--- a/internal/controller/workloads/pod_controller.go
+++ b/internal/controller/workloads/pod_controller.go
@@ -48,14 +48,16 @@ import (
 
 // PodReconciler reconciles a Pod object owned by RBG
 type PodReconciler struct {
-	client client.Client
-	scheme *runtime.Scheme
+	client    client.Client
+	apiReader client.Reader
+	scheme    *runtime.Scheme
 }
 
 func NewPodReconciler(mgr ctrl.Manager) *PodReconciler {
 	return &PodReconciler{
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
+		client:    mgr.GetClient(),
+		apiReader: mgr.GetAPIReader(),
+		scheme:    mgr.GetScheme(),
 	}
 }
 
@@ -149,10 +151,15 @@ func (r *PodReconciler) setRestartCondition(
 	// Use RetryOnConflict + UpdateStatus to avoid SSA field-manager ownership conflicts.
 	// RoleBasedGroupStatus.Conditions is an atomic list in SSA, so two field managers cannot
 	// safely manage different entries. Instead, we use a standard UpdateStatus with optimistic
-	// locking: re-fetch the latest RBG, merge the RestartInProgress condition, then update.
+	// locking: re-fetch the latest RBG from the API server (NOT the informer cache), merge
+	// the RestartInProgress condition, then update.
+	// IMPORTANT: We use apiReader (non-caching) to read the latest RBG from the API server.
+	// Using the caching client would risk a read-modify-write race: if the informer cache is
+	// stale, we would overwrite status fields (e.g. RoleStatuses, Ready condition) that were
+	// updated by the RBG controller but not yet reflected in the cache.
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest := &workloadsv1alpha2.RoleBasedGroup{}
-		if err := r.client.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latest); err != nil {
+		if err := r.apiReader.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latest); err != nil {
 			return err
 		}
 		meta.SetStatusCondition(&latest.Status.Conditions, restartCondition)

--- a/internal/controller/workloads/pod_controller_test.go
+++ b/internal/controller/workloads/pod_controller_test.go
@@ -359,8 +359,9 @@ func TestPodReconciler_podToRBG_EdgeCases(t *testing.T) {
 
 				fclient := fake.NewClientBuilder().WithScheme(schema).WithObjects(objects...).Build()
 				r := &PodReconciler{
-					client: fclient,
-					scheme: schema,
+					client:    fclient,
+					apiReader: fclient,
+					scheme:    schema,
 				}
 				got := r.podToRBG(tt.args.ctx, tt.args.pod)
 				assert.Equal(t, tt.want, got)
@@ -389,8 +390,9 @@ func TestPodReconciler_Reconcile(t *testing.T) {
 
 	fclient := fake.NewClientBuilder().WithScheme(schema).WithObjects(obj).WithStatusSubresource(obj).Build()
 	r := &PodReconciler{
-		client: fclient,
-		scheme: schema,
+		client:    fclient,
+		apiReader: fclient,
+		scheme:    schema,
 	}
 
 	req := reconcile.Request{

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -758,21 +758,26 @@ func (r *RoleBasedGroupReconciler) updateRBGStatus(
 		}
 	}
 
-	// CRITICAL: Fetch the latest RBG from API server to preserve conditions set by other controllers.
-	// The pod controller uses UpdateStatus to set RestartInProgress, which may not be reflected
-	// in the informer cache yet. Without this, SSA with Force=true would overwrite those conditions.
-	latestRBG := &workloadsv1alpha2.RoleBasedGroup{}
-	if err := r.apiReader.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latestRBG); err != nil {
-		logger := log.FromContext(ctx)
-		logger.Error(err, "Failed to get latest RBG from API server for status update")
-		return err
+	// CRITICAL: Preserve the RestartInProgress condition managed by the pod controller.
+	// We check BOTH the cached rbg (which may already have it from the informer) AND
+	// the latest RBG from the API server. This double-check provides defense-in-depth
+	// against the condition being lost due to SSA with Force=true.
+	restartCond := apimeta.FindStatusCondition(
+		rbg.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
+	)
+	if restartCond == nil {
+		// Not in cache, fetch from API server (bypass informer cache).
+		latestRBG := &workloadsv1alpha2.RoleBasedGroup{}
+		if err := r.apiReader.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latestRBG); err != nil {
+			logger := log.FromContext(ctx)
+			logger.Error(err, "Failed to get latest RBG from API server for status update")
+			return err
+		}
+		restartCond = apimeta.FindStatusCondition(
+			latestRBG.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
+		)
 	}
-
-	// Preserve RestartInProgress condition if it exists in the latest RBG from API server.
-	// This condition is managed by the pod controller and should not be overwritten by RBG controller.
-	if restartCond := apimeta.FindStatusCondition(
-		latestRBG.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
-	); restartCond != nil {
+	if restartCond != nil {
 		apimeta.SetStatusCondition(&rbg.Status.Conditions, *restartCond)
 	}
 


### PR DESCRIPTION
…e cache race

When the PodReconciler triggers a restart (RecreateRBGOnPodRestart), the RestartInProgress condition was being permanently lost from the RBG status after the restart completed. This caused e2e test "standalone role with restartPolicy" to time out waiting for RestartInProgress=False.

Root cause: a read-modify-write race between two controllers sharing the same RBG status subresource.

1) PodReconciler.setRestartCondition() used the caching client to read the
   RBG before Status().Update(). If the informer cache had not yet synced
   the RBG controller's latest status writes (Ready condition,
   RoleStatuses), the pod controller would overwrite those fields with
   stale data.

2) RoleBasedGroupReconciler.updateRBGStatus() patches status via SSA with
   Force=true. It only checked the API reader for RestartInProgress. If
   the pod controller had not yet committed its write, the condition would
   be absent from the patch and SSA Force=true would remove it from API.

Fixes:
- PodReconciler: add apiReader (non-caching) and use it in setRestartCondition to always read the authoritative API state before updating, avoiding informer cache staleness.
- updateRBGStatus: check both the cached rbg AND the API reader for RestartInProgress (defense-in-depth), only falling back to the API reader when the cache does not have it.

Ancillary reconcile error "workload generation not equal to observed generation" is expected and self-resolving: after the pod controller deletes and recreates a Deployment, the Deployment controller needs time to update ObservedGeneration to match Generation.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
