### PR TITLE
feat: change default restartPolicy to RecreateRoleInstanceOnPodRestart

### DIFF
--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -184,6 +184,7 @@ type RoleSpec struct {
 	RolloutStrategy *RolloutStrategy `json:"rolloutStrategy,omitempty"`
 
 	// RestartPolicy defines the restart policy when pod failures happen.
+	// Default is RecreateRoleInstanceOnPodRestart for all patterns.
 	// +kubebuilder:validation:Enum={None,RecreateRoleInstanceOnPodRestart}
 	// +optional
 	RestartPolicy RestartPolicyType `json:"restartPolicy,omitempty"`

--- a/api/workloads/v1alpha2/roleinstance_types.go
+++ b/api/workloads/v1alpha2/roleinstance_types.go
@@ -32,7 +32,7 @@ type RoleInstanceSpec struct {
 	ReadyPolicy RoleInstanceReadyPolicyType `json:"readyPolicy,omitempty"`
 
 	// RestartPolicy defines the restart policy for all pods within the RoleInstance.
-	RestartPolicy RoleInstanceRestartPolicyType `json:"restartPolicy,omitempty"`
+	RestartPolicy RestartPolicyType `json:"restartPolicy,omitempty"`
 
 	// ReadinessGates is an optional list of PodReadinessGates for the whole RoleInstance.
 	ReadinessGates []RoleInstanceReadinessGate `json:"readinessGates,omitempty"`
@@ -54,16 +54,6 @@ const (
 	RoleInstanceReadyPolicyTypeNone RoleInstanceReadyPolicyType = "None"
 )
 
-type RoleInstanceRestartPolicyType string
-
-const (
-	// NoneRoleInstanceRestartPolicy will follow the same behavior as the Pod.
-	NoneRoleInstanceRestartPolicy RoleInstanceRestartPolicyType = "None"
-
-	// RoleInstanceRestartPolicyRecreateOnPodRestart will recreate a role instance if its Pod restarted.
-	// It equals to RecreateRoleInstanceOnPodRestart of RBG.
-	RoleInstanceRestartPolicyRecreateOnPodRestart RoleInstanceRestartPolicyType = "RecreateRoleInstanceOnPodRestart"
-)
 
 type RoleInstanceComponent struct {
 	// Name is the type name of the component.

--- a/client-go/applyconfiguration/workloads/v1alpha2/roleinstancespec.go
+++ b/client-go/applyconfiguration/workloads/v1alpha2/roleinstancespec.go
@@ -24,10 +24,10 @@ import (
 // RoleInstanceSpecApplyConfiguration represents a declarative configuration of the RoleInstanceSpec type for use
 // with apply.
 type RoleInstanceSpecApplyConfiguration struct {
-	Components     []RoleInstanceComponentApplyConfiguration        `json:"components,omitempty"`
-	ReadyPolicy    *workloadsv1alpha2.RoleInstanceReadyPolicyType   `json:"readyPolicy,omitempty"`
-	RestartPolicy  *workloadsv1alpha2.RoleInstanceRestartPolicyType `json:"restartPolicy,omitempty"`
-	ReadinessGates []RoleInstanceReadinessGateApplyConfiguration    `json:"readinessGates,omitempty"`
+	Components     []RoleInstanceComponentApplyConfiguration      `json:"components,omitempty"`
+	ReadyPolicy    *workloadsv1alpha2.RoleInstanceReadyPolicyType `json:"readyPolicy,omitempty"`
+	RestartPolicy  *workloadsv1alpha2.RestartPolicyType           `json:"restartPolicy,omitempty"`
+	ReadinessGates []RoleInstanceReadinessGateApplyConfiguration  `json:"readinessGates,omitempty"`
 }
 
 // RoleInstanceSpecApplyConfiguration constructs a declarative configuration of the RoleInstanceSpec type for use with
@@ -60,7 +60,7 @@ func (b *RoleInstanceSpecApplyConfiguration) WithReadyPolicy(value workloadsv1al
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *RoleInstanceSpecApplyConfiguration) WithRestartPolicy(value workloadsv1alpha2.RoleInstanceRestartPolicyType) *RoleInstanceSpecApplyConfiguration {
+func (b *RoleInstanceSpecApplyConfiguration) WithRestartPolicy(value workloadsv1alpha2.RestartPolicyType) *RoleInstanceSpecApplyConfiguration {
 	b.RestartPolicy = &value
 	return b
 }

--- a/client-go/applyconfiguration/workloads/v1alpha2/roleinstancetemplate.go
+++ b/client-go/applyconfiguration/workloads/v1alpha2/roleinstancetemplate.go
@@ -57,7 +57,7 @@ func (b *RoleInstanceTemplateApplyConfiguration) WithReadyPolicy(value workloads
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *RoleInstanceTemplateApplyConfiguration) WithRestartPolicy(value workloadsv1alpha2.RoleInstanceRestartPolicyType) *RoleInstanceTemplateApplyConfiguration {
+func (b *RoleInstanceTemplateApplyConfiguration) WithRestartPolicy(value workloadsv1alpha2.RestartPolicyType) *RoleInstanceTemplateApplyConfiguration {
 	b.RoleInstanceSpecApplyConfiguration.RestartPolicy = &value
 	return b
 }

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -32816,8 +32816,9 @@ spec:
                       minimum: 0
                       type: integer
                     restartPolicy:
-                      description: RestartPolicy defines the restart policy when pod
-                        failures happen.
+                      description: |-
+                        RestartPolicy defines the restart policy when pod failures happen.
+                        Default is RecreateRoleInstanceOnPodRestart for all patterns.
                       enum:
                       - None
                       - RecreateRoleInstanceOnPodRestart

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -33629,8 +33629,9 @@ spec:
                               minimum: 0
                               type: integer
                             restartPolicy:
-                              description: RestartPolicy defines the restart policy
-                                when pod failures happen.
+                              description: |-
+                                RestartPolicy defines the restart policy when pod failures happen.
+                                Default is RecreateRoleInstanceOnPodRestart for all patterns.
                               enum:
                               - None
                               - RecreateRoleInstanceOnPodRestart

--- a/doc/features/failure-handling.md
+++ b/doc/features/failure-handling.md
@@ -10,7 +10,7 @@ RBG supports multiple failure handling policies: `None`, `RecreateRBGOnPodRestar
 |--------|-------------|
 | `None` | No automatic restart action; rely on default pod restart behavior. |
 | `RecreateRBGOnPodRestart` | Recreate the entire RoleBasedGroup when any pod in this role restarts. Useful for critical roles that require all pods to be healthy. |
-| `RecreateRoleInstanceOnPodRestart` | Recreate only the affected role instance when a pod restarts. More granular control for less critical roles. |
+| `RecreateRoleInstanceOnPodRestart` | Recreate only the affected role instance when a pod restarts. More granular control for less critical roles. **This is the default policy for all patterns** (standalonePattern, leaderWorkerPattern, customComponentsPattern). |
 
 ## Configuration
 

--- a/doc/reference/api.md
+++ b/doc/reference/api.md
@@ -30,7 +30,7 @@ This document describes the API fields for RoleBasedGroup and related CRDs in v1
 | `leaderWorkerPattern` | *LeaderWorkerPattern — leader + workers per instance |
 | `customComponentsPattern` | *CustomComponentsPattern — heterogeneous pod groups |
 | `rolloutStrategy` | *RolloutStrategy — update strategy configuration |
-| `restartPolicy` | RestartPolicyType — restart behavior enum |
+| `restartPolicy` | RestartPolicyType — restart behavior enum (default: `RecreateRoleInstanceOnPodRestart` for all patterns) |
 | `minReadySeconds` | *int32 — minimum seconds before considered ready |
 | `scalingAdapter` | *ScalingAdapter — external autoscaling config |
 | `engineRuntimes` | []EngineRuntime — runtime profiles to inject |

--- a/examples/basic/rbg/patterns/custom-components-pattern.yaml
+++ b/examples/basic/rbg/patterns/custom-components-pattern.yaml
@@ -2,6 +2,7 @@
 # customComponentsPattern creates instances with multiple different types of pods
 # (components), each component can have a different size and template.
 # Use this for workloads requiring heterogeneous pod groups, e.g. disaggregated inference.
+# Default restartPolicy for customComponentsPattern is RecreateRoleInstanceOnPodRestart.
 apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
 metadata:
@@ -11,6 +12,7 @@ spec:
   roles:
     - name: engine
       replicas: 3
+      # restartPolicy defaults to RecreateRoleInstanceOnPodRestart
       rolloutStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/examples/basic/rbg/patterns/leader-worker-pattern.yaml
+++ b/examples/basic/rbg/patterns/leader-worker-pattern.yaml
@@ -1,6 +1,7 @@
 # Example: LeaderWorkerPattern - multi-pod pattern with leader and workers (v1alpha2)
 # leaderWorkerPattern creates grouped instances where each instance has one leader
 # and multiple workers. Use this for LLM inference with tensor parallelism.
+# Default restartPolicy for leaderWorkerPattern is RecreateRoleInstanceOnPodRestart.
 apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
 metadata:
@@ -10,6 +11,7 @@ spec:
   roles:
     - name: prefill
       replicas: 2
+      # restartPolicy defaults to RecreateRoleInstanceOnPodRestart
       # leaderWorkerPattern: each replica creates 1 leader + (size-1) workers
       leaderWorkerPattern:
         size: 4    # total pods per instance: 1 leader + 3 workers

--- a/examples/basic/rbg/patterns/standalone-pattern.yaml
+++ b/examples/basic/rbg/patterns/standalone-pattern.yaml
@@ -1,6 +1,7 @@
 # Example: Basic RoleBasedGroup with two roles
 # This example demonstrates the fundamental usage of RoleBasedGroup v1alpha2.
 # Each role uses standalonePattern for single-pod-per-instance deployment.
+# Default restartPolicy for standalonePattern is RecreateRoleInstanceOnPodRestart.
 apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
 metadata:
@@ -10,6 +11,7 @@ spec:
   roles:
     - name: frontend
       replicas: 1
+      # restartPolicy defaults to RecreateRoleInstanceOnPodRestart
       standalonePattern:
         template:
           spec:

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -242,7 +242,7 @@ func (c *realControl) createOnePod(ctx context.Context, instance *workloadsv1alp
 // and should not trigger Instance recreation.
 func shouldRecreateInstance(instance *workloadsv1alpha2.RoleInstance, pods []*v1.Pod) bool {
 	// Only apply when restartPolicy is RecreateRoleInstanceOnPodRestart
-	if instance.Spec.RestartPolicy != workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart {
+	if instance.Spec.RestartPolicy != workloadsv1alpha2.RecreateRoleInstanceOnPodRestart {
 		return false
 	}
 

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -45,7 +45,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -79,7 +79,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](1)},
 					},
@@ -113,7 +113,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.NoneRoleInstanceRestartPolicy,
+					RestartPolicy: workloadsv1alpha2.RestartPolicyNone,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -147,7 +147,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -181,7 +181,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 2,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -215,7 +215,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -242,7 +242,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -276,7 +276,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](1)},
 					},
@@ -310,7 +310,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](2)},
 					},
@@ -344,7 +344,7 @@ func TestShouldRecreateInstance(t *testing.T) {
 					Generation: 1,
 				},
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
-					RestartPolicy: workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart,
+					RestartPolicy: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
 					Components: []workloadsv1alpha2.RoleInstanceComponent{
 						{Size: ptr.To[int32](1)},
 					},

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -151,11 +151,10 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceSetApplyConfiguration(
 	}
 
 	// 1. construct role instance configuration
-	var restartPolicy workloadsv1alpha2.RoleInstanceRestartPolicyType
-	if role.RestartPolicy == workloadsv1alpha2.RecreateRoleInstanceOnPodRestart {
-		restartPolicy = workloadsv1alpha2.RoleInstanceRestartPolicyType(workloadsv1alpha2.RecreateRoleInstanceOnPodRestart)
-	} else {
-		restartPolicy = workloadsv1alpha2.NoneRoleInstanceRestartPolicy
+	// Default to RecreateRoleInstanceOnPodRestart for all patterns when not explicitly set.
+	restartPolicy := role.RestartPolicy
+	if restartPolicy == "" {
+		restartPolicy = workloadsv1alpha2.RecreateRoleInstanceOnPodRestart
 	}
 	roleInstanceTemplateConfig := workloadsv1alpha2client.RoleInstanceTemplate().
 		WithRestartPolicy(restartPolicy)
@@ -285,7 +284,6 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByCustomCompone
 			}
 		}
 		roleInstanceTemplateConfig.
-			WithRestartPolicy(workloadsv1alpha2.NoneRoleInstanceRestartPolicy).
 			WithComponents(workloadsv1alpha2client.RoleInstanceComponent().
 				WithName(component.Name).
 				WithServiceName(svcName).
@@ -369,7 +367,6 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 
 	workerSize := utils.NonZeroValue(*lwp.Size - 1)
 	roleInstanceTemplateConfig.
-		WithRestartPolicy(workloadsv1alpha2.RoleInstanceRestartPolicyRecreateOnPodRestart).
 		WithComponents(
 			workloadsv1alpha2client.RoleInstanceComponent().
 				WithName("leader").
@@ -411,7 +408,6 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateFromStandaloneP
 	}
 
 	roleInstanceTemplateConfig.
-		WithRestartPolicy(workloadsv1alpha2.NoneRoleInstanceRestartPolicy).
 		WithComponents(workloadsv1alpha2client.RoleInstanceComponent().
 			WithName(role.Name).
 			WithServiceName(svcName).

--- a/test/e2e/testcase/v1alpha2/inactive_pod.go
+++ b/test/e2e/testcase/v1alpha2/inactive_pod.go
@@ -144,7 +144,8 @@ func RunInactivePodTestCases(f *framework.Framework) {
 			wrappersv2.BuildStandaloneRole("role-1").
 				WithWorkload("apps/v1", "Deployment").
 				WithReplicas(3).
-				Obj(), // RestartPolicy defaults to None
+				WithRestartPolicy(workloadsv1alpha2.RestartPolicyNone).
+				Obj(),
 		}).Obj()
 
 		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })

--- a/test/e2e/testcase/v1alpha2/ris.go
+++ b/test/e2e/testcase/v1alpha2/ris.go
@@ -74,6 +74,7 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 				wrappersv2.BuildStandaloneRole("role-1").
 					WithReplicas(4).
 					WithTemplate(&initialTemplate).
+					WithRestartPolicy(workloadsv1alpha2.RestartPolicyNone).
 					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
 						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
 						MaxSurge:       ptr.To(intstr.FromInt32(2)),
@@ -129,6 +130,7 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 				wrappersv2.BuildStandaloneRole("role-1").
 					WithReplicas(4).
 					WithTemplate(&initialTemplate).
+					WithRestartPolicy(workloadsv1alpha2.RestartPolicyNone).
 					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
 						MaxUnavailable: ptr.To(intstr.FromInt32(2)),
 						MaxSurge:       ptr.To(intstr.FromInt32(2)),


### PR DESCRIPTION
…t for all patterns

Previously, the default restartPolicy was different for each pattern:
- StandalonePattern: None
- CustomComponentsPattern: None
- LeaderWorkerPattern: RecreateRoleInstanceOnPodRestart

This change unifies the default to RecreateRoleInstanceOnPodRestart for all patterns, providing consistent failure handling behavior across deployment types.

Updates:
- pkg/reconciler/roleinstanceset_reconciler.go: modify default values for StandalonePattern and CustomComponentsPattern
- doc/reference/api.md: add default value documentation
- doc/features/failure-handling.md: document default policy
- examples/basic/rbg/patterns/*.yaml: add comments for default values

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
