### PR TITLE
fix(controller): fix stateful RoleInstanceSet surge rolling update

### DIFF
--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go
@@ -20,14 +20,13 @@ package statefulmode
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sort"
 	"time"
 
 	apps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -46,7 +45,84 @@ const (
 
 	// Realistic value for maximum in-flight requests when processing in parallel mode.
 	MaxBatchSize = 500
+
+	// stableUnhealthyDuration is the minimum CONSECUTIVE time an instance must
+	// be observed unhealthy before progressUpdate is allowed to treat it as
+	// "free" (cleanup-unhealthy semantics — i.e. delete it without consuming
+	// the maxUnavailable budget).
+	//
+	// Without this gate, a transient cache view that briefly reports a ready
+	// base instance as not-ready could let progressUpdate wrongly free-delete
+	// it. Combined with surge that has just become available, this can
+	// cascade into wiping out healthy ready replicas mid-rollout.
+	//
+	// The gate is enforced by tracking, per RoleInstance UID, the first time
+	// THIS controller observed the instance as unhealthy (in
+	// instanceUnhealthySince). The timer resets whenever the same UID is
+	// subsequently observed as healthy — so flapping cache (Ready toggling on
+	// the order of milliseconds) can never accumulate enough continuous time
+	// to satisfy the gate. A genuinely broken instance is observed unhealthy
+	// continuously and becomes eligible after this window.
+	//
+	// 10s is well above the typical informer cache lag (sub-second) while
+	// keeping the recovery delay for genuinely broken pods small enough to
+	// avoid wasting GPU resources for too long.
+	stableUnhealthyDuration = 10 * time.Second
 )
+
+// observeInstanceHealth maintains the instanceUnhealthySince map: for each
+// instance, record the first observation time when unhealthy, and clear the
+// entry when observed healthy. Called once at the top of every reconcile in
+// Phase A so the timestamps reflect the current cache snapshot.
+//
+// Also opportunistically removes entries for UIDs that no longer appear in
+// the supplied instances slice, preventing the map from growing unbounded as
+// instances are recreated (each delete-and-recreate produces a new UID).
+func observeInstanceHealth(instances []*workloadsv1alpha2.RoleInstance) {
+	now := time.Now()
+	live := make(map[types.UID]struct{}, len(instances))
+	for _, inst := range instances {
+		if inst == nil || inst.UID == "" {
+			continue
+		}
+		live[inst.UID] = struct{}{}
+		if isHealthy(inst) {
+			instanceUnhealthySince.Delete(inst.UID)
+			continue
+		}
+		// Unhealthy: record first-observed time if not already recorded.
+		instanceUnhealthySince.LoadOrStore(inst.UID, now)
+	}
+	// Drop entries for instances that have disappeared (different UID after
+	// recreate, or fully deleted).
+	instanceUnhealthySince.Range(func(key, _ interface{}) bool {
+		uid, _ := key.(types.UID)
+		if _, alive := live[uid]; !alive {
+			instanceUnhealthySince.Delete(uid)
+		}
+		return true
+	})
+}
+
+// isStablyUnhealthy returns true when the controller has observed `inst` as
+// unhealthy for at least stableUnhealthyDuration of CONSECUTIVE time. This is
+// the only signal progressUpdate uses to decide whether a base instance is
+// "free" to update without consuming maxUnavailable budget. See
+// stableUnhealthyDuration for the rationale.
+func isStablyUnhealthy(inst *workloadsv1alpha2.RoleInstance) bool {
+	if inst == nil || inst.UID == "" {
+		return false
+	}
+	v, ok := instanceUnhealthySince.Load(inst.UID)
+	if !ok {
+		return false
+	}
+	first, ok := v.(time.Time)
+	if !ok {
+		return false
+	}
+	return time.Since(first) >= stableUnhealthyDuration
+}
 
 // StatefulInstanceSetControlInterface implements the control logic for updating InstanceSets managing Instances
 type StatefulInstanceSetControlInterface interface {
@@ -267,7 +343,22 @@ func (ssc *defaultStatefulInstanceSetControl) getInstanceSetRevisions(
 	return currentRevision, updateRevision, collisionCount, nil
 }
 
-// updateStatefulInstanceSet performs the update function for a InstanceSet managing instances
+// updateStatefulInstanceSet drives a single reconcile pass over the
+// RoleInstanceSet, in four ordered phases that each have a clear contract:
+//
+//	Phase A — observe         compute revisions & topology, build the
+//	                          desired status skeleton.
+//	Phase B — scale & identity ensure ord [start, end) is fully populated:
+//	                          condemn out-of-range, create missing slots,
+//	                          process replicas (creation) & condemned (delete).
+//	Phase C — progress update for in-rollout sets, drive rolling update with
+//	                          a free-vs-costly maxUnavailable budget.
+//	Phase D — status & advance recompute counts, decide whether to advance
+//	                          status.CurrentRevision (multi-layer guard).
+//
+// The four phases share the topology computed in Phase A as the single source
+// of truth for ordinal range, surge sizing, partition, and budget — so there
+// is no second place that recomputes "where surge ends".
 func (ssc *defaultStatefulInstanceSetControl) updateStatefulInstanceSet(
 	ctx context.Context,
 	set *workloadsv1alpha2.RoleInstanceSet,
@@ -276,12 +367,12 @@ func (ssc *defaultStatefulInstanceSetControl) updateStatefulInstanceSet(
 	collisionCount int32,
 	instances []*workloadsv1alpha2.RoleInstance,
 	revisions []*apps.ControllerRevision) (*workloadsv1alpha2.RoleInstanceSetStatus, error) {
+
+	// =====================  Phase A — observe  =====================
 	selector, err := utils.ValidatedLabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
 		return set.Status.DeepCopy(), err
 	}
-
-	// get the current and update revisions of the set.
 	currentSet, err := ApplyRevision(set, currentRevision)
 	if err != nil {
 		return set.Status.DeepCopy(), err
@@ -290,61 +381,120 @@ func (ssc *defaultStatefulInstanceSetControl) updateStatefulInstanceSet(
 	if err != nil {
 		return set.Status.DeepCopy(), err
 	}
+	topo, err := computeTopology(set, instances, currentRevision.Name, updateRevision.Name)
+	if err != nil {
+		return set.Status.DeepCopy(), err
+	}
 
-	// set the generation, and revisions in the returned status
+	// Update the per-UID "first observed unhealthy" timestamps so the time
+	// gate (isStablyUnhealthy) reflects the cache snapshot we are about to
+	// reason over. Healthy instances clear their entry; unhealthy instances
+	// either start a new timer or carry forward the prior one. See
+	// stableUnhealthyDuration for why this gate is the bug-3 defense.
+	observeInstanceHealth(instances)
+
+	minReadySeconds := getMinReadySeconds(set)
+	monotonic := !allowsBurst(set)
+
 	status := workloadsv1alpha2.RoleInstanceSetStatus{}
 	status.ObservedGeneration = set.Generation
 	status.CurrentRevision = currentRevision.Name
 	status.UpdateRevision = updateRevision.Name
 	status.CollisionCount = ptr.To[int32](collisionCount)
 	status.LabelSelector = selector.String()
-	minReadySeconds := getMinReadySeconds(set)
-
+	status.ExpectedUpdatedReplicas = int32(topo.replicas - topo.partition)
 	updateStatus(&status, minReadySeconds, currentRevision, updateRevision, instances)
 
-	startOrdinal, endOrdinal, reserveOrdinals := getInstanceSetReplicasRange(set)
-	// slice that will contain all Instances such that startOrdinal <= getOrdinal(instance) < endOrdinal
-	replicas := make([]*workloadsv1alpha2.RoleInstance, endOrdinal-startOrdinal)
-	// slice that will contain all Instances such that getOrdinal(instance) < startOrdinal or getOrdinal(instance) >= endOrdinal
+	// ===============  Phase B — scale & identity  ==================
+	// Partition instances into in-range slots and condemned (out-of-range).
+	// Anything beyond endOrdinal — including stale-rev surge from a prior
+	// rollout — falls into condemned and gets deleted by processCondemned.
+	replicas := make([]*workloadsv1alpha2.RoleInstance, topo.endOrdinal-topo.startOrdinal)
 	condemned := make([]*workloadsv1alpha2.RoleInstance, 0, len(instances))
-	unhealthy := 0
-	firstUnhealthyOrdinal := math.MaxInt32
-	var firstUnhealthyInstance *workloadsv1alpha2.RoleInstance
-	monotonic := !allowsBurst(set)
-
-	// First we partition instances into two lists valid replicas and condemned Instances
 	for i := range instances {
-		if ord := getOrdinal(instances[i]); instanceInOrdinalRangeWithParams(instances[i], startOrdinal, endOrdinal, reserveOrdinals) {
-			// if the ordinal of the instance is within the range of the current number of replicas
-			// insert it at the indirection of its ordinal
-			replicas[ord-startOrdinal] = instances[i]
-
+		ord := getOrdinal(instances[i])
+		if instanceInOrdinalRangeWithParams(instances[i], topo.startOrdinal, topo.endOrdinal, topo.reserveOrdinals) {
+			replicas[ord-topo.startOrdinal] = instances[i]
 		} else if ord >= 0 {
-			// if the ordinal is valid, but not within the range
-			// add it to the condemned list
 			condemned = append(condemned, instances[i])
 		}
 	}
-
-	// for any empty indices in the sequence [startOrdinal,endOrdinal) create a new Instance at the correct revision
-	for ord := startOrdinal; ord < endOrdinal; ord++ {
-		if reserveOrdinals.Has(ord) {
+	// Fill empty in-range slots. ord < partition uses currentRev (per
+	// newVersionedInstance), the rest get updateRev — including surge slots.
+	for ord := topo.startOrdinal; ord < topo.endOrdinal; ord++ {
+		if topo.reserveOrdinals.Has(ord) {
 			continue
 		}
-		replicaIdx := ord - startOrdinal
-		if replicas[replicaIdx] == nil {
-			replicas[replicaIdx] = newVersionedInstance(
-				currentSet,
-				updateSet,
-				currentRevision.Name,
-				updateRevision.Name, ord, replicas)
+		idx := ord - topo.startOrdinal
+		if replicas[idx] == nil {
+			replicas[idx] = newVersionedInstance(currentSet, updateSet, currentRevision.Name, updateRevision.Name, ord, replicas)
+		}
+	}
+	sort.Sort(descendingOrdinal(condemned))
+	_, firstUnhealthyInstance := countUnhealthy(replicas, condemned)
+
+	if set.DeletionTimestamp != nil {
+		return &status, nil
+	}
+
+	// Refresh in-place readiness condition for all created instances. Without
+	// this, freshly created instances would carry InPlaceUpdateReady=False
+	// from the instance controller and could deadlock processReplica in
+	// OrderedReady mode (which gates on isHealthy).
+	for i := range replicas {
+		if replicas[i] == nil || !isCreated(replicas[i]) {
+			continue
+		}
+		if _, duration, err := ssc.refreshInstanceState(set, replicas[i], updateRevision.Name); err != nil {
+			return &status, err
+		} else if duration > 0 {
+			durationStore.Push(getInstanceSetKey(set), duration)
 		}
 	}
 
-	// sort the condemned Instances by their ordinals
-	sort.Sort(descendingOrdinal(condemned))
+	scaleMaxUnavailable, err := getScaleMaxUnavailable(set)
+	if err != nil {
+		return &status, err
+	}
+	processReplicaFn := func(i int) (bool, bool, error) {
+		return ssc.processReplica(ctx, set, updateSet, monotonic, replicas, i, &status, scaleMaxUnavailable)
+	}
+	if shouldExit, err := runForAllWithBreak(replicas, processReplicaFn, monotonic); shouldExit || err != nil {
+		updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
+		return &status, err
+	}
+	processCondemnedFn := func(i int) (bool, error) {
+		return ssc.processCondemned(ctx, set, firstUnhealthyInstance, monotonic, condemned, i)
+	}
+	if shouldExit, err := runForAll(condemned, processCondemnedFn, monotonic); shouldExit || err != nil {
+		updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
+		return &status, err
+	}
 
-	// find the first unhealthy Instance
+	// ===============  Phase C — progress rolling update  ===========
+	if topo.inRollout {
+		if _, err := ssc.progressUpdate(set, &status, currentRevision, updateRevision, revisions, instances, replicas, minReadySeconds, topo); err != nil {
+			updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
+			return &status, err
+		}
+	}
+
+	// ===============  Phase D — final status & advance  ============
+	updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
+	if shouldAdvanceCurrentRevision(set, replicas, updateRevision.Name, topo) {
+		klog.V(2).InfoS("Advancing CurrentRevision", "instanceSet", klog.KObj(set), "from", status.CurrentRevision, "to", updateRevision.Name)
+		status.CurrentRevision = updateRevision.Name
+	}
+	return &status, nil
+}
+
+// countUnhealthy returns the count of unhealthy instances across the in-range
+// replicas slice and the condemned list, plus the lowest-ordinal unhealthy
+// instance (used by processCondemned in OrderedReady mode).
+func countUnhealthy(replicas, condemned []*workloadsv1alpha2.RoleInstance) (int, *workloadsv1alpha2.RoleInstance) {
+	unhealthy := 0
+	firstUnhealthyOrdinal := math.MaxInt32
+	var firstUnhealthyInstance *workloadsv1alpha2.RoleInstance
 	for i := range replicas {
 		if replicas[i] == nil {
 			continue
@@ -357,8 +507,6 @@ func (ssc *defaultStatefulInstanceSetControl) updateStatefulInstanceSet(
 			}
 		}
 	}
-
-	// or the first unhealthy condemned Instance (condemned are sorted in descending order for ease of use)
 	for i := len(condemned) - 1; i >= 0; i-- {
 		if !isHealthy(condemned[i]) {
 			unhealthy++
@@ -368,69 +516,41 @@ func (ssc *defaultStatefulInstanceSetControl) updateStatefulInstanceSet(
 			}
 		}
 	}
-
-	if unhealthy > 0 {
-		klog.V(4).InfoS("InstanceSet has unhealthy Instances", "instanceSet", klog.KObj(set), "unhealthyReplicas", unhealthy, "instance", klog.KObj(firstUnhealthyInstance))
+	if unhealthy > 0 && firstUnhealthyInstance != nil {
+		klog.V(4).InfoS("InstanceSet has unhealthy Instances", "unhealthyReplicas", unhealthy, "instance", klog.KObj(firstUnhealthyInstance))
 	}
-
-	// If the InstanceSet is being deleted, don't do anything other than updating status.
-	if set.DeletionTimestamp != nil {
-		return &status, nil
-	}
-
-	// Refresh states for all created instances to ensure InstanceInPlaceUpdateReady condition is up-to-date.
-	// Newly created instances default to InstanceInPlaceUpdateReady=False at the Instance controller level,
-	// but they don't actually need an in-place update. Without this refresh, these instances would remain
-	// unhealthy and block the processReplica loop in monotonic (OrderedReady) mode, creating a deadlock
-	// where processReplica waits for healthy instances, but refreshInstanceState (which sets the condition
-	// to True) is only called in rollingUpdateInstances which is never reached.
-	for i := range replicas {
-		if replicas[i] == nil || !isCreated(replicas[i]) {
-			continue
-		}
-		if _, duration, err := ssc.refreshInstanceState(set, replicas[i], updateRevision.Name); err != nil {
-			return &status, err
-		} else if duration > 0 {
-			durationStore.Push(getInstanceSetKey(set), duration)
-		}
-	}
-
-	// First, process each living replica. Exit if we run into an error or something blocking in monotonic mode.
-	scaleMaxUnavailable, err := getScaleMaxUnavailable(set)
-	if err != nil {
-		return &status, err
-	}
-	processReplicaFn := func(i int) (bool, bool, error) {
-		return ssc.processReplica(ctx, set, updateSet, monotonic, replicas, i, &status, scaleMaxUnavailable)
-	}
-	if shouldExit, err := runForAllWithBreak(replicas, processReplicaFn, monotonic); shouldExit || err != nil {
-		updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
-		return &status, err
-	}
-
-	// Process condemned instances
-	processCondemnedFn := func(i int) (bool, error) {
-		return ssc.processCondemned(ctx, set, firstUnhealthyInstance, monotonic, condemned, i)
-	}
-	if shouldExit, err := runForAll(condemned, processCondemnedFn, monotonic); shouldExit || err != nil {
-		updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
-		return &status, err
-	}
-	updateStatus(&status, minReadySeconds, currentRevision, updateRevision, replicas, condemned)
-
-	// TODO: support OnDelete
-	// for the OnDelete strategy we short circuit.
-	// if set.Spec.UpdateStrategy.Type == apps.OnDeleteStatefulSetStrategyType {
-	// 	return &status, nil
-	// }
-
-	return ssc.rollingUpdateInstances(
-		set, &status, currentRevision, updateRevision, revisions, instances, replicas, minReadySeconds,
-	)
+	return unhealthy, firstUnhealthyInstance
 }
 
-// rollingUpdateInstances implements the rolling update logic for instances
-func (ssc *defaultStatefulInstanceSetControl) rollingUpdateInstances(
+// progressUpdate is Phase C: drive the rolling update by replacing base
+// instances at non-update revision with their updateRev counterparts (in-place
+// or delete-and-recreate).
+//
+// Budget model:
+//
+//	effectiveBudget = maxUnavailable + availableSurge
+//
+// where availableSurge counts surge ords [replicas, endOrdinal) that already
+// hold a healthy, non-terminating instance at updateRev — only those provide a
+// real availability buffer for base unavailability.
+//
+// Each target is classified:
+//
+//   - free   = target is not currently contributing to availability (already
+//     unhealthy or terminating). Updating it does not violate the
+//     maxUnavailable contract; it does not consume budget. This is the
+//     k8s Deployment cleanupUnhealthyReplicas semantics.
+//   - costly = target is currently healthy. Updating consumes 1 unit of
+//     budget. The combined check
+//     newlyUnavail >= maxUnavailable
+//     OR (initialBaseUnavail+newlyUnavail >= effectiveBudget AND target not
+//     already counted as unavailable)
+//     blocks further costly updates this loop.
+//
+// The "costly" path is what protects ready instances from being deleted faster
+// than maxUnavailable allows. The "free" path lets us recover from already-
+// degraded states (broken rollout, mid-rollout config change with stale base).
+func (ssc *defaultStatefulInstanceSetControl) progressUpdate(
 	set *workloadsv1alpha2.RoleInstanceSet,
 	status *workloadsv1alpha2.RoleInstanceSetStatus,
 	currentRevision *apps.ControllerRevision,
@@ -439,47 +559,275 @@ func (ssc *defaultStatefulInstanceSetControl) rollingUpdateInstances(
 	instances []*workloadsv1alpha2.RoleInstance,
 	replicas []*workloadsv1alpha2.RoleInstance,
 	minReadySeconds int32,
+	topo topology,
 ) (*workloadsv1alpha2.RoleInstanceSetStatus, error) {
-
-	// If update expectations have not satisfied yet, skip updating instances
-	if updateSatisfied, _, updateDirtyInstances := updateExpectations.SatisfiedExpectations(getInstanceSetKey(set), updateRevision.Name); !updateSatisfied {
-		klog.InfoS("Update expectations not satisfied, skipping update", "instanceSet", klog.KObj(set), "updateDirtyInstances", updateDirtyInstances, "updateRevision", updateRevision.Name)
+	if updateSatisfied, _, dirty := updateExpectations.SatisfiedExpectations(getInstanceSetKey(set), updateRevision.Name); !updateSatisfied {
+		klog.InfoS("Update expectations not satisfied, skipping update",
+			"instanceSet", klog.KObj(set), "dirty", dirty, "updateRevision", updateRevision.Name)
 		return status, nil
 	}
-	klog.InfoS("Update expectations satisfied, proceeding with update", "instanceSet", klog.KObj(set), "updateRevision", updateRevision.Name)
-
-	// refresh states for all instances
 	if modified, err := ssc.refreshAllInstanceStates(set, instances, updateRevision.Name); err != nil {
 		return status, err
 	} else if modified {
 		return status, nil
 	}
 
-	if set.Spec.UpdateStrategy.Paused {
-		return status, nil
-	}
+	availableSurge := countAvailableSurge(replicas, topo, updateRevision.Name)
+	effectiveBudget := topo.maxUnavailable + availableSurge
+	baseUnavail := ssc.collectBaseUnavailable(set, replicas, topo, minReadySeconds)
+	initialBaseUnavail := len(baseUnavail)
+	targets := buildUpdateTargets(replicas, topo, updateRevision.Name)
 
-	maxUnavailable, err := ssc.getMaxUnavailable(set)
-	if err != nil {
-		return status, err
-	}
+	klog.InfoS("Progress rolling update", "instanceSet", klog.KObj(set),
+		"targets", targets, "maxUnavailable", topo.maxUnavailable,
+		"maxSurge", topo.maxSurge, "activeSurge", topo.activeSurge,
+		"availableSurge", availableSurge, "effectiveBudget", effectiveBudget,
+		"initialBaseUnavail", initialBaseUnavail)
 
-	unavailableInstances := ssc.collectUnavailableInstances(set, replicas, minReadySeconds)
+	newlyUnavail := 0
+	for _, idx := range targets {
+		target := replicas[idx]
+		// "free" = updating this target does not violate the maxUnavailable
+		// contract on BASE ordinals. Three sources of free:
+		//   - surge slot: surge is extra capacity, not part of the base
+		//     availability contract; replacing it never affects base availability.
+		//   - target already terminating: nothing more to do this loop.
+		//   - target stably unhealthy (Ready=False observed CONSECUTIVELY for
+		//     >= stableUnhealthyDuration): cleanupUnhealthy semantics. The
+		//     time gate prevents transient cache flap from triggering a
+		//     wrongful free-delete on a base instance that is actually ready —
+		//     millisecond-level mislabeling cannot accumulate enough continuous
+		//     unhealthy time to satisfy it, while a genuinely broken instance
+		//     accrues quickly.
+		isSurgeSlot := getOrdinal(target) >= topo.replicas
+		isFree := isSurgeSlot || isTerminating(target) || isStablyUnhealthy(target)
 
-	// Sort instances to update
-	if set.Spec.Replicas == nil {
-		return status, fmt.Errorf("Replicas is nil")
-	}
-	updateIndexes := sortInstancesToUpdate(&set.Spec.UpdateStrategy, updateRevision.Name, *set.Spec.Replicas, replicas)
-	// Log detailed instance revisions for debugging
-	for i, instance := range replicas {
-		if instance != nil {
-			klog.InfoS("Instance revision status", "instanceSet", klog.KObj(set), "index", i, "instance", klog.KObj(instance), "currentRevision", getInstanceRevision(instance), "updateRevision", updateRevision.Name, "needsUpdate", getInstanceRevision(instance) != updateRevision.Name)
+		if !isFree && initialBaseUnavail+newlyUnavail >= effectiveBudget {
+			klog.InfoS("Rolling update budget exhausted",
+				"instanceSet", klog.KObj(set), "instance", klog.KObj(target),
+				"initialBaseUnavail", initialBaseUnavail, "newlyUnavail", newlyUnavail,
+				"effectiveBudget", effectiveBudget)
+			return status, nil
+		}
+		if isTerminating(target) {
+			continue
+		}
+
+		decrement, err := ssc.applyTargetUpdate(set, target, currentRevision, updateRevision, revisions, isSurgeSlot, isFree)
+		if err != nil {
+			return status, err
+		}
+		if !isFree {
+			baseUnavail.Insert(target.Name)
+			newlyUnavail++
+		}
+		if decrement {
+			status.CurrentReplicas--
 		}
 	}
-	klog.InfoS("Prepare to update instance indexes for InstanceSet", "instanceSet", klog.KObj(set), "instanceIndexes", updateIndexes, "maxUnavailable", maxUnavailable, "unavailableInstances", unavailableInstances.UnsortedList())
+	return status, nil
+}
 
-	return ssc.updateInstancesInSequence(set, status, currentRevision, updateRevision, revisions, replicas, updateIndexes, unavailableInstances, maxUnavailable)
+// countAvailableSurge counts surge slots [replicas, endOrdinal) whose instance
+// is at updateRev AND healthy AND not terminating. Only those provide a real
+// availability buffer — stale-rev or unhealthy surge does not.
+func countAvailableSurge(
+	replicas []*workloadsv1alpha2.RoleInstance,
+	topo topology,
+	updateRev string,
+) int {
+	out := 0
+	for ord := topo.surgeStart; ord < topo.endOrdinal; ord++ {
+		idx := ord - topo.startOrdinal
+		if idx < 0 || idx >= len(replicas) {
+			continue
+		}
+		inst := replicas[idx]
+		if inst != nil && isCreated(inst) && isHealthy(inst) && !isTerminating(inst) &&
+			getInstanceRevision(inst) == updateRev {
+			out++
+		}
+	}
+	return out
+}
+
+// collectBaseUnavailable returns the set of base ord [start, replicas) instance
+// names that are currently NOT contributing to availability (unhealthy,
+// in-place-update incomplete, or not-yet-available under minReadySeconds).
+// These are "already unavailable" for budget purposes — updating them in
+// progressUpdate is free. Also pushes any minReadySeconds wait into
+// durationStore so the controller is requeued when those windows expire.
+func (ssc *defaultStatefulInstanceSetControl) collectBaseUnavailable(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	replicas []*workloadsv1alpha2.RoleInstance,
+	topo topology,
+	minReadySeconds int32,
+) sets.Set[string] {
+	out := sets.New[string]()
+	opts := instanceinplace.SetOptionsDefaults(&instanceinplace.UpdateOptions{})
+	minWaitTime := MaxMinReadySeconds * time.Second
+
+	for ord := topo.startOrdinal; ord < topo.replicas; ord++ {
+		idx := ord - topo.startOrdinal
+		if idx < 0 || idx >= len(replicas) {
+			continue
+		}
+		inst := replicas[idx]
+		if inst == nil {
+			continue
+		}
+		if !isHealthy(inst) || opts.CheckRoleInstanceUpdateCompleted(inst) != nil {
+			out.Insert(inst.Name)
+			continue
+		}
+		isAvailable, waitTime := isInstanceRunningAndAvailable(inst, minReadySeconds)
+		if isAvailable {
+			continue
+		}
+		out.Insert(inst.Name)
+		if waitTime != 0 && waitTime <= minWaitTime {
+			minWaitTime = waitTime
+			durationStore.Push(getInstanceSetKey(set), waitTime)
+		}
+	}
+	return out
+}
+
+// buildUpdateTargets returns indices into replicas[] of in-range ords
+// [partition, endOrdinal) holding an instance whose revision != updateRev,
+// sorted by descending ordinal. The range deliberately includes surge ords
+// [replicas, endOrdinal): a surge slot may hold a stale-rev instance from a
+// superseded rollout, and Phase B cannot condemn it (the slot is still
+// in-range for the current rollout's surge needs), so progressUpdate must
+// recycle it — otherwise stale-rev surge persists forever.
+func buildUpdateTargets(
+	replicas []*workloadsv1alpha2.RoleInstance,
+	topo topology,
+	updateRev string,
+) []int {
+	out := make([]int, 0, topo.endOrdinal-topo.partition)
+	for ord := topo.partition; ord < topo.endOrdinal; ord++ {
+		idx := ord - topo.startOrdinal
+		if idx < 0 || idx >= len(replicas) {
+			continue
+		}
+		if replicas[idx] == nil {
+			continue
+		}
+		if getInstanceRevision(replicas[idx]) == updateRev {
+			continue
+		}
+		out = append(out, idx)
+	}
+	// Highest ordinal first (statefulset convention; also means surge slots
+	// are recycled before base, so we re-establish fresh surge at updateRev
+	// before chipping at base).
+	sort.Slice(out, func(i, j int) bool {
+		return getOrdinal(replicas[out[i]]) > getOrdinal(replicas[out[j]])
+	})
+	return out
+}
+
+// applyTargetUpdate performs a single target's update — in-place when possible,
+// otherwise delete-and-recreate via Phase B on the next reconcile. Returns
+// `decrementCurrent=true` when the operation actually transitioned the target
+// away from currentRevision (so caller can decrement status.CurrentReplicas).
+func (ssc *defaultStatefulInstanceSetControl) applyTargetUpdate(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	target *workloadsv1alpha2.RoleInstance,
+	currentRevision *apps.ControllerRevision,
+	updateRevision *apps.ControllerRevision,
+	revisions []*apps.ControllerRevision,
+	isSurgeSlot bool,
+	isFree bool,
+) (bool, error) {
+	klog.InfoS("Updating instance", "instanceSet", klog.KObj(set), "instance", klog.KObj(target),
+		"from", getInstanceRevision(target), "to", updateRevision.Name,
+		"isSurge", isSurgeSlot, "free", isFree)
+	inplacing, err := ssc.inPlaceUpdateInstance(set, target, updateRevision, revisions)
+	if err != nil {
+		return false, err
+	}
+	transitioned := inplacing
+	if !inplacing {
+		_, actualDeleting, err := ssc.deleteInstance(set, target)
+		if err != nil {
+			return false, err
+		}
+		transitioned = actualDeleting
+	}
+	return transitioned && getInstanceRevision(target) == currentRevision.Name, nil
+}
+
+// shouldAdvanceCurrentRevision decides whether status.CurrentRevision can be
+// advanced to updateRev this reconcile. Multi-layer guard:
+//
+//	① We are actually in a rollout (currentRev != updateRev, !Paused).
+//	② Partition has been fully consumed (partition == 0). When partition > 0
+//	   the ords below partition are pinned at the "old" revision, so
+//	   advancing CurrentRevision to updateRev would lie about their state and
+//	   prevent later partition decreases from being recognized as
+//	   "currentRev != updateRev → in rollout" — exactly the bug behind
+//	   "lower partition does not progress".
+//	③ The PRIOR persisted status already named updateRev as UpdateRevision
+//	   AND counted UpdatedReplicas >= replicas - partition. This forces the
+//	   "all base updated" observation to have survived at least one full
+//	   reconcile cycle, so a transient cache lag in the current cycle cannot
+//	   cause an erroneous advance. This is the central defense against the
+//	   "rollout right after creation deletes everything" cascade.
+//	④ updateExpectations are satisfied (no in-place updates we are still
+//	   waiting for the API to acknowledge).
+//	⑤ The observed in-memory snapshot for every base ord [partition,
+//	   replicas) shows: at updateRev, isCreated, isHealthy, !isTerminating,
+//	   and ObservedGeneration synced.
+//
+// We never write to the in-memory rev label after an in-place update (see
+// inPlaceUpdateInstance), so the snapshot is the unmodified Phase-A read.
+func shouldAdvanceCurrentRevision(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	replicas []*workloadsv1alpha2.RoleInstance,
+	updateRev string,
+	topo topology,
+) bool {
+	if !topo.inRollout {
+		return false
+	}
+	// ② only advance once partition is fully consumed
+	if topo.partition > 0 {
+		return false
+	}
+	// ③ prior persisted concurrence
+	if set.Status.UpdateRevision != updateRev {
+		return false
+	}
+	if set.Status.UpdatedReplicas < int32(topo.replicas-topo.partition) {
+		return false
+	}
+	// ④ no in-flight in-place updates
+	if satisfied, _, _ := updateExpectations.SatisfiedExpectations(getInstanceSetKey(set), updateRev); !satisfied {
+		return false
+	}
+	// ⑤ observed snapshot all green
+	for ord := topo.partition; ord < topo.replicas; ord++ {
+		idx := ord - topo.startOrdinal
+		if idx < 0 || idx >= len(replicas) {
+			return false
+		}
+		inst := replicas[idx]
+		if inst == nil || !isCreated(inst) || isTerminating(inst) {
+			return false
+		}
+		if getInstanceRevision(inst) != updateRev {
+			return false
+		}
+		if !isHealthy(inst) {
+			return false
+		}
+		if inst.Status.ObservedGeneration < inst.Generation {
+			return false
+		}
+	}
+	return true
 }
 
 // refreshAllInstanceStates refreshes states for all instances and returns if any was modified
@@ -505,122 +853,6 @@ func (ssc *defaultStatefulInstanceSetControl) refreshAllInstanceStates(
 		}
 	}
 	return modified, nil
-}
-
-// getMaxUnavailable computes the maxUnavailable value from the update strategy
-func (ssc *defaultStatefulInstanceSetControl) getMaxUnavailable(set *workloadsv1alpha2.RoleInstanceSet) (int, error) {
-	maxUnavailable := 1
-	if set.Spec.UpdateStrategy.MaxUnavailable != nil {
-		if set.Spec.Replicas == nil {
-			return 0, fmt.Errorf("Replicas is nil")
-		}
-		var err error
-		maxUnavailable, err = intstrutil.GetValueFromIntOrPercent(
-			set.Spec.UpdateStrategy.MaxUnavailable,
-			int(*set.Spec.Replicas), false)
-		if err != nil {
-			return 0, err
-		}
-	}
-	// maxUnavailable should not be less than 1
-	if maxUnavailable < 1 {
-		maxUnavailable = 1
-	}
-	return maxUnavailable, nil
-}
-
-// collectUnavailableInstances counts instances that are unhealthy for checking maxUnavailable limit
-func (ssc *defaultStatefulInstanceSetControl) collectUnavailableInstances(
-	set *workloadsv1alpha2.RoleInstanceSet,
-	replicas []*workloadsv1alpha2.RoleInstance,
-	minReadySeconds int32,
-) sets.Set[string] {
-	minWaitTime := MaxMinReadySeconds * time.Second
-	unavailableInstances := sets.New[string]()
-	opts := &instanceinplace.UpdateOptions{}
-	opts = instanceinplace.SetOptionsDefaults(opts)
-
-	for target := range replicas {
-		if replicas[target] == nil {
-			continue
-		}
-		if !isHealthy(replicas[target]) {
-			unavailableInstances.Insert(replicas[target].Name)
-		} else if completedErr := opts.CheckRoleInstanceUpdateCompleted(replicas[target]); completedErr != nil {
-			klog.V(4).ErrorS(completedErr, "InstanceSet found Instance in-place update not-ready",
-				"instanceSet", klog.KObj(set), "instance", klog.KObj(replicas[target]))
-			unavailableInstances.Insert(replicas[target].Name)
-		} else if isAvailable, waitTime := isInstanceRunningAndAvailable(replicas[target], minReadySeconds); !isAvailable {
-			unavailableInstances.Insert(replicas[target].Name)
-			if waitTime != 0 && waitTime <= minWaitTime {
-				minWaitTime = waitTime
-				durationStore.Push(getInstanceSetKey(set), waitTime)
-			}
-		}
-	}
-	return unavailableInstances
-}
-
-// updateInstancesInSequence updates instances in sequence respecting maxUnavailable
-func (ssc *defaultStatefulInstanceSetControl) updateInstancesInSequence(
-	set *workloadsv1alpha2.RoleInstanceSet,
-	status *workloadsv1alpha2.RoleInstanceSetStatus,
-	currentRevision *apps.ControllerRevision,
-	updateRevision *apps.ControllerRevision,
-	revisions []*apps.ControllerRevision,
-	replicas []*workloadsv1alpha2.RoleInstance,
-	updateIndexes []int,
-	unavailableInstances sets.Set[string],
-	maxUnavailable int,
-) (*workloadsv1alpha2.RoleInstanceSetStatus, error) {
-	// Track instances updated in this reconcile loop
-	updatedInThisLoop := 0
-
-	// update instances in sequence
-	for _, target := range updateIndexes {
-		// the target is already up-to-date, go to next
-		if getInstanceRevision(replicas[target]) == updateRevision.Name {
-			continue
-		}
-
-		// Block if:
-		// 1. We already triggered maxUnavailable updates in this reconcile loop
-		// 2. OR there are already maxUnavailable instances that are unavailable (not counting current target)
-		if updatedInThisLoop >= maxUnavailable || (len(unavailableInstances) >= maxUnavailable && !unavailableInstances.Has(replicas[target].Name)) {
-			klog.InfoS("InstanceSet was waiting for unavailable Instances to update, blocked instance",
-				"instanceSet", klog.KObj(set), "unavailableInstances", unavailableInstances.UnsortedList(), "blockedInstance", klog.KObj(replicas[target]), "updatedInThisLoop", updatedInThisLoop, "maxUnavailable", maxUnavailable)
-			return status, nil
-		}
-
-		// delete or inplace update the Instance if it does not match the update revision
-		if !isTerminating(replicas[target]) {
-			klog.InfoS("InstanceSet attempting to update Instance", "instanceSet", klog.KObj(set), "instance", klog.KObj(replicas[target]), "currentRevision", getInstanceRevision(replicas[target]), "targetRevision", updateRevision.Name)
-			inplacing, inplaceUpdateErr := ssc.inPlaceUpdateInstance(set, replicas[target], updateRevision, revisions)
-			if inplaceUpdateErr != nil {
-				return status, inplaceUpdateErr
-			}
-			klog.InfoS("InstanceSet update Instance result", "instanceSet", klog.KObj(set), "instance", klog.KObj(replicas[target]), "inplacing", inplacing)
-			// if instance is inplacing or actual deleting, update status
-			revisionNeedDecrease := inplacing
-			if !inplacing {
-				klog.V(2).InfoS("InstanceSet terminating Instance for update", "instanceSet", klog.KObj(set), "instance", klog.KObj(replicas[target]))
-				if _, actualDeleting, err := ssc.deleteInstance(set, replicas[target]); err != nil {
-					return status, err
-				} else {
-					revisionNeedDecrease = actualDeleting
-				}
-			}
-			// Mark target as unavailable for this reconcile loop
-			unavailableInstances.Insert(replicas[target].Name)
-			updatedInThisLoop++
-
-			if revisionNeedDecrease && getInstanceRevision(replicas[target]) == currentRevision.Name {
-				status.CurrentReplicas--
-			}
-		}
-	}
-
-	return status, nil
 }
 
 // processReplica processes a single replica instance.
@@ -789,12 +1021,15 @@ func (ssc *defaultStatefulInstanceSetControl) inPlaceUpdateInstance(
 			"instanceSet", klog.KObj(set), "instance", klog.KObj(instance))
 		updateExpectations.ExpectUpdated(getInstanceSetKey(set), updateRevision.Name, instance)
 
-		// Update the instance's revision label in memory to reflect the update
-		// This prevents the controller from repeatedly triggering updates
-		if instance.Labels == nil {
-			instance.Labels = make(map[string]string)
-		}
-		instance.Labels[apps.ControllerRevisionHashLabelKey] = updateRevision.Name
+		// NOTE: Do NOT mutate instance.Labels in memory here. inplaceControl.Update
+		// patched the API server (label + spec + condition Ready=False), but the
+		// in-memory object we hold reflects the snapshot from the start of this
+		// reconcile. If we forced the rev label here, shouldAdvanceCurrentRevision
+		// would see "rev=updateRev AND isHealthy=true (stale Ready)" and could
+		// erroneously advance status.CurrentRevision, which is exactly the
+		// cascade behind the "rollout right after creation deletes everything"
+		// bug. Next reconcile reads fresh state and sees both new rev and
+		// updated condition, at which point advance can fire safely.
 	}
 
 	return result.InPlaceUpdate, nil
@@ -815,43 +1050,4 @@ func (ssc *defaultStatefulInstanceSetControl) deleteInstance(
 	}
 
 	return true, true, nil
-}
-
-// sortInstancesToUpdate returns the indexes of instances in the order they should be updated
-func sortInstancesToUpdate(
-	rollingUpdate *workloadsv1alpha2.RoleInstanceSetUpdateStrategy,
-	updateRevision string,
-	replicas int32,
-	instances []*workloadsv1alpha2.RoleInstance,
-) []int {
-	var partition int32 = 0
-	if rollingUpdate != nil && rollingUpdate.Partition != nil {
-		// Convert IntOrString to int32
-		partitionValue, err := intstrutil.GetValueFromIntOrPercent(
-			rollingUpdate.Partition,
-			int(replicas),
-			false,
-		)
-		if err == nil {
-			partition = int32(partitionValue)
-		}
-	}
-
-	var updateIndexes []int
-	for i := range instances {
-		if instances[i] == nil {
-			continue
-		}
-		ordinal := getOrdinal(instances[i])
-		if ordinal >= int(partition) && getInstanceRevision(instances[i]) != updateRevision {
-			updateIndexes = append(updateIndexes, i)
-		}
-	}
-
-	// sort by ordinal in reverse order (start from the largest ordinal)
-	sort.Slice(updateIndexes, func(i, j int) bool {
-		return getOrdinal(instances[updateIndexes[i]]) > getOrdinal(instances[updateIndexes[j]])
-	})
-
-	return updateIndexes
 }

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
@@ -17,15 +17,24 @@ limitations under the License.
 package statefulmode
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	instanceinplace "sigs.k8s.io/rbgs/pkg/inplace/instance/inplaceupdate"
 )
 
 func TestTruncateHistoryKeepsLiveInstanceRevision(t *testing.T) {
@@ -122,4 +131,821 @@ func (f *fakeStatefulHistory) AdoptControllerRevision(metav1.Object, schema.Grou
 
 func (f *fakeStatefulHistory) ReleaseControllerRevision(metav1.Object, *apps.ControllerRevision) (*apps.ControllerRevision, error) {
 	return nil, nil
+}
+
+const (
+	testOldRev    = "old-rev"
+	testUpdateRev = "update-rev"
+)
+
+// buildSet constructs a minimal RoleInstanceSet useful for topology /
+// progressUpdate tests.
+func buildSet(name string, replicas int32, surge, unavail *intstrutil.IntOrString) *workloadsv1alpha2.RoleInstanceSet {
+	set := &workloadsv1alpha2.RoleInstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: workloadsv1alpha2.RoleInstanceSetSpec{
+			Replicas: ptr.To(replicas),
+		},
+	}
+	if surge != nil {
+		set.Spec.UpdateStrategy.MaxSurge = surge
+	}
+	if unavail != nil {
+		set.Spec.UpdateStrategy.MaxUnavailable = unavail
+	}
+	return set
+}
+
+// buildInst returns a RoleInstance at given ord, revision, and Ready cond.
+// `ready=true` sets RoleInstanceReady=True; otherwise condition is False.
+// `created=true` sets a UID so isCreated returns true.
+func buildInst(setName string, ord int, rev string, ready, created bool) *workloadsv1alpha2.RoleInstance {
+	inst := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", setName, ord),
+			Namespace: "default",
+			Labels: map[string]string{
+				apps.ControllerRevisionHashLabelKey: rev,
+			},
+		},
+	}
+	if created {
+		// Unique per (setName, ord) so the time-gate map (keyed on UID) does
+		// not collapse all test instances onto a single entry.
+		inst.UID = types.UID(fmt.Sprintf("uid-%s-%d", setName, ord))
+	}
+	cond := workloadsv1alpha2.RoleInstanceCondition{
+		Type:               workloadsv1alpha2.RoleInstanceReady,
+		Status:             v1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+	}
+	if ready {
+		cond.Status = v1.ConditionTrue
+	}
+	inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{cond}
+	return inst
+}
+
+// withTerminating marks the instance as terminating (DeletionTimestamp set).
+func withTerminating(inst *workloadsv1alpha2.RoleInstance) *workloadsv1alpha2.RoleInstance {
+	now := metav1.Now()
+	inst.DeletionTimestamp = &now
+	return inst
+}
+
+func TestComputeTopology(t *testing.T) {
+	tests := []struct {
+		name              string
+		set               *workloadsv1alpha2.RoleInstanceSet
+		instances         []*workloadsv1alpha2.RoleInstance
+		currentRev        string
+		updateRev         string
+		paused            bool
+		expectedActSurge  int
+		expectedEndOrd    int
+		expectedPartition int
+		expectedMaxUnav   int
+		expectedMaxSurge  int
+		expectedInRollout bool
+	}{
+		{
+			name:              "no rollout: currentRev == updateRev",
+			set:               buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0))),
+			instances:         []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), buildInst("s", 1, testUpdateRev, true, true), buildInst("s", 2, testUpdateRev, true, true), buildInst("s", 3, testUpdateRev, true, true)},
+			currentRev:        testUpdateRev,
+			updateRev:         testUpdateRev,
+			expectedActSurge:  0,
+			expectedEndOrd:    4,
+			expectedMaxSurge:  2,
+			expectedMaxUnav:   0,
+			expectedInRollout: false,
+		},
+		{
+			name: "paused with no existing surge: do not allocate new surge",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Paused = true
+				return s
+			}(),
+			instances:  []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true), buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true)},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 0, expectedEndOrd: 4,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: false,
+		},
+		{
+			// Paused mid-rollout while surge already exists: preserve the
+			// surge so Phase B does not condemn it. Pod startup is expensive,
+			// throwing away surge on pause and re-creating on unpause wastes
+			// minutes of GPU time.
+			name: "paused mid-rollout: preserve existing surge at updateRev",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Paused = true
+				return s
+			}(),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true),
+				buildInst("s", 4, testUpdateRev, true, true), buildInst("s", 5, testUpdateRev, true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 2, expectedEndOrd: 6,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: false, // paused → rollout phases skipped
+		},
+		{
+			// Paused with stale-rev surge (from a superseded rollout): those
+			// surge slots are at a rev that is neither currentRev nor the new
+			// updateRev. They are NOT counted by countExistingValidSurge, so
+			// activeSurge stays 0 and they get condemned. This is the right
+			// call: stale surge is not contributing toward the current target.
+			name: "paused mid-rollout: stale-rev surge is NOT preserved",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Paused = true
+				return s
+			}(),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true),
+				buildInst("s", 4, "stale-rev", true, true), buildInst("s", 5, "stale-rev", true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 0, expectedEndOrd: 4,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: false,
+		},
+		{
+			name: "rollout, all healthy old: surge=min(maxSurge, healthyOld-maxUnav)",
+			set:  buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0))),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 2, expectedEndOrd: 6,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: true,
+		},
+		{
+			name: "all unhealthy old → no surge needed (broken instances aren't contributing to availability)",
+			set:  buildSet("s", 2, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0))),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, false, true), buildInst("s", 1, testOldRev, false, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 0, expectedEndOrd: 2,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: true,
+		},
+		{
+			name: "maxUnav covers all: surge=2, unav=2, healthyOld=2 → surge=0",
+			set:  buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(2))),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 2, expectedEndOrd: 6, // healthyOld=4, surgeNeeded=4-2=2
+			expectedMaxSurge: 2, expectedMaxUnav: 2,
+			expectedInRollout: true,
+		},
+		{
+			name: "partition=2: only [2,4) update; healthyOld counted in range only",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Partition = ptr.To(intstrutil.FromInt32(2))
+				return s
+			}(),
+			instances:         []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true), buildInst("s", 2, testOldRev, true, true), buildInst("s", 3, testOldRev, true, true)},
+			currentRev:        testOldRev,
+			updateRev:         testUpdateRev,
+			expectedActSurge:  2, // healthyOld in [2,4) = 2
+			expectedEndOrd:    6,
+			expectedPartition: 2,
+			expectedMaxSurge:  2,
+			expectedMaxUnav:   0,
+			expectedInRollout: true,
+		},
+		{
+			name: "chained rollout: stale-rev surge condemned (existingValidSurge counts updateRev only)",
+			// Chained rollout: a previous rollout left base + surge at rev
+			// "mid". User pushes a new rev "update" before "mid" finished.
+			// existingValidSurge for "update" = 0 (the in-flight surge is at
+			// the wrong rev). With healthyOldInBase = 0 here, activeSurge
+			// collapses to 0 and the stale surge falls outside endOrdinal so
+			// Phase B condemns it.
+			set: buildSet("s", 2, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0))),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, "mid-rev", false, true), buildInst("s", 1, "mid-rev", false, true),
+				buildInst("s", 2, "mid-rev", true, true), buildInst("s", 3, "mid-rev", true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 0, expectedEndOrd: 2, // surge condemned, ords 2,3 will be condemned in Phase B
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: true,
+		},
+		{
+			// Partitioned rollout completed: ords [partition, replicas) at
+			// updateRev healthy. surgeNeeded=0 and stickiness MUST drop
+			// (allBaseAtUpdateRevHealthy=true), otherwise surge would persist
+			// forever — currentRevision never advances under partition>0,
+			// so the "inRollout=false next reconcile" cleanup path never
+			// triggers either.
+			name: "partition rollout completed: drop sticky surge so it can be condemned",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Partition = ptr.To(intstrutil.FromInt32(2))
+				return s
+			}(),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), // below partition, untouched
+				buildInst("s", 1, testOldRev, true, true), // below partition, untouched
+				func() *workloadsv1alpha2.RoleInstance {
+					i := buildInst("s", 2, testUpdateRev, true, true)
+					i.Generation = 1
+					i.Status.ObservedGeneration = 1
+					return i
+				}(), // updated, ObservedGen synced
+				func() *workloadsv1alpha2.RoleInstance {
+					i := buildInst("s", 3, testUpdateRev, true, true)
+					i.Generation = 1
+					i.Status.ObservedGeneration = 1
+					return i
+				}(),
+				buildInst("s", 4, testUpdateRev, true, true), // surge slot still exists from rollout
+				buildInst("s", 5, testUpdateRev, true, true),
+			},
+			currentRev:        testOldRev,
+			updateRev:         testUpdateRev,
+			expectedActSurge:  0, // stickiness dropped
+			expectedEndOrd:    4,
+			expectedPartition: 2,
+			expectedMaxSurge:  2,
+			expectedMaxUnav:   0,
+			expectedInRollout: true,
+		},
+		{
+			// Bug: partition decrease should re-trigger work. After a
+			// partition=2 rollout we have ords [0,2) at oldRev, ords [2,4)
+			// at updateRev. CurrentRevision stays at oldRev (partition>0
+			// guard). User now lowers partition to 1: topology must see ord
+			// 1 as old-rev work and allocate surge for it.
+			name: "partition decrease: ord at non-updateRev in newly-exposed range triggers surge",
+			set: func() *workloadsv1alpha2.RoleInstanceSet {
+				s := buildSet("s", 4, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0)))
+				s.Spec.UpdateStrategy.Partition = ptr.To(intstrutil.FromInt32(1))
+				return s
+			}(),
+			instances:         []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, true, true), buildInst("s", 2, testUpdateRev, true, true), buildInst("s", 3, testUpdateRev, true, true)},
+			currentRev:        testOldRev, // not advanced because previous rollout had partition>0
+			updateRev:         testUpdateRev,
+			expectedActSurge:  1, // healthyOld in [1,4) = 1 (only ord 1)
+			expectedEndOrd:    5,
+			expectedPartition: 1,
+			expectedMaxSurge:  2,
+			expectedMaxUnav:   0,
+			expectedInRollout: true,
+		},
+		{
+			name: "stickiness: existingValidSurge keeps surge alive even as healthyOld shrinks",
+			// 2 base at oldRev (one healthy, one becoming unhealthy mid-rollout) +
+			// 2 surge at updateRev healthy. healthyOld = 1. surgeNeeded = 1-0 = 1.
+			// existingValidSurge = 2 (healthy at updateRev). activeSurge =
+			// max(1, 2) = 2. So we keep surge = 2 even though "need" dropped.
+			set: buildSet("s", 2, ptr.To(intstrutil.FromInt32(2)), ptr.To(intstrutil.FromInt32(0))),
+			instances: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testOldRev, false, true),
+				buildInst("s", 2, testUpdateRev, true, true), buildInst("s", 3, testUpdateRev, true, true),
+			},
+			currentRev: testOldRev, updateRev: testUpdateRev,
+			expectedActSurge: 2, expectedEndOrd: 4,
+			expectedMaxSurge: 2, expectedMaxUnav: 0,
+			expectedInRollout: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeTopology(tt.set, tt.instances, tt.currentRev, tt.updateRev)
+			if err != nil {
+				t.Fatalf("computeTopology() unexpected error: %v", err)
+			}
+			if got.activeSurge != tt.expectedActSurge {
+				t.Errorf("activeSurge = %d, want %d", got.activeSurge, tt.expectedActSurge)
+			}
+			if got.endOrdinal != tt.expectedEndOrd {
+				t.Errorf("endOrdinal = %d, want %d", got.endOrdinal, tt.expectedEndOrd)
+			}
+			if got.partition != tt.expectedPartition {
+				t.Errorf("partition = %d, want %d", got.partition, tt.expectedPartition)
+			}
+			if got.maxSurge != tt.expectedMaxSurge {
+				t.Errorf("maxSurge = %d, want %d", got.maxSurge, tt.expectedMaxSurge)
+			}
+			if got.maxUnavailable != tt.expectedMaxUnav {
+				t.Errorf("maxUnavailable = %d, want %d", got.maxUnavailable, tt.expectedMaxUnav)
+			}
+			if got.inRollout != tt.expectedInRollout {
+				t.Errorf("inRollout = %v, want %v", got.inRollout, tt.expectedInRollout)
+			}
+		})
+	}
+}
+
+// fakeInstanceObjectManager records create/delete calls without API.
+type fakeInstanceObjectManager struct {
+	created []string
+	deleted []string
+}
+
+func (f *fakeInstanceObjectManager) CreateInstance(_ context.Context, instance *workloadsv1alpha2.RoleInstance) error {
+	f.created = append(f.created, instance.Name)
+	return nil
+}
+func (f *fakeInstanceObjectManager) GetInstance(_, _ string) (*workloadsv1alpha2.RoleInstance, error) {
+	return nil, nil
+}
+func (f *fakeInstanceObjectManager) UpdateInstance(_ *workloadsv1alpha2.RoleInstance) error {
+	return nil
+}
+func (f *fakeInstanceObjectManager) DeleteInstance(instance *workloadsv1alpha2.RoleInstance) error {
+	f.deleted = append(f.deleted, instance.Name)
+	return nil
+}
+
+// fakeInplaceControl always returns CanUpdateInPlace=false so progressUpdate
+// falls through to delete-and-recreate (the path we want to observe).
+type fakeInplaceControl struct{}
+
+func (f *fakeInplaceControl) CanUpdateInPlace(_, _ *apps.ControllerRevision, _ *instanceinplace.UpdateOptions) bool {
+	return false
+}
+func (f *fakeInplaceControl) Update(_ *workloadsv1alpha2.RoleInstance, _, _ *apps.ControllerRevision, _ *instanceinplace.UpdateOptions) instanceinplace.UpdateResult {
+	return instanceinplace.UpdateResult{InPlaceUpdate: false}
+}
+func (f *fakeInplaceControl) Refresh(_ *workloadsv1alpha2.RoleInstance, _ *instanceinplace.UpdateOptions) instanceinplace.RefreshResult {
+	return instanceinplace.RefreshResult{}
+}
+
+func TestProgressUpdateBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas []*workloadsv1alpha2.RoleInstance
+		topo     topology
+		// markStablyUnhealthy, when true, seeds instanceUnhealthySince with a
+		// past timestamp for every unhealthy replica in `replicas`, so they
+		// satisfy the time gate without the test having to sleep. Tests that
+		// want to exercise the cleanup-unhealthy free-delete path set this;
+		// tests that exercise the cache-lag protection (transiently mislabeled
+		// ready instances must NOT be free-deleted) leave it false so those
+		// instances fail the gate and stay protected.
+		markStablyUnhealthy bool
+		expectedDels        []string // names that MUST be deleted (subset)
+		expectNoDelet       []string // names that MUST NOT be deleted
+	}{
+		{
+			// All base healthy old, surge already healthy at updateRev → can update
+			// up to maxUnav + availSurge.
+			name: "healthy old base, surge ready: budget = maxUnav + availSurge",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testUpdateRev, true, true),
+				buildInst("s", 3, testUpdateRev, true, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 4, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 2, inRollout: true,
+			},
+			expectedDels: []string{"s-1", "s-0"},
+		},
+		{
+			// All base STABLY unhealthy at oldRev → free-delete eligible
+			// (cleanup-unhealthy path; broken instances are not contributing
+			// to availability so deleting them does not consume budget).
+			name: "stably unhealthy base free-deletes without budget",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, false, true),
+				buildInst("s", 1, testOldRev, false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 0, inRollout: true,
+			},
+			markStablyUnhealthy: true,
+			expectedDels:        []string{"s-0", "s-1"},
+		},
+		{
+			// Same shape as the prior case but the unhealthy state is FRESH
+			// (not stably observed for stableUnhealthyDuration). Time gate
+			// must deny the free path; the cost path then blocks on budget=0.
+			// Net effect: protect brand-new flapping instances from being
+			// deleted.
+			name: "freshly unhealthy (not stably): time gate denies free, cost blocks",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, false, true),
+				buildInst("s", 1, testOldRev, false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 0, inRollout: true,
+			},
+			markStablyUnhealthy: false,
+			expectNoDelet:       []string{"s-0", "s-1"},
+		},
+		{
+			// All healthy old base, no surge, maxUnav=0 → completely blocked.
+			name: "maxUnav=0 with no surge buffer blocks all healthy updates",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, true, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 0,
+				activeSurge: 0, inRollout: true,
+			},
+			expectNoDelet: []string{"s-0", "s-1"},
+		},
+		{
+			// 1 healthy + 1 stably unhealthy base, maxUnav=0, no surge.
+			// Stably unhealthy is free; healthy is cost-blocked.
+			name: "mixed: stably unhealthy proceeds free, healthy stays",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 0,
+				activeSurge: 0, inRollout: true,
+			},
+			markStablyUnhealthy: true,
+			expectedDels:        []string{"s-1"},
+			expectNoDelet:       []string{"s-0"},
+		},
+		{
+			// Mid-rollout, base instances at a superseded revision are
+			// stably unhealthy (e.g. stuck in CrashLoopBackOff). Free path
+			// recovers them so a new updateRev push can make progress
+			// without waiting for the stuck rev to "complete".
+			name: "stably unhealthy stale-rev base recovers free",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, "mid-rev", false, true),
+				buildInst("s", 1, "mid-rev", false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 0, inRollout: true,
+			},
+			markStablyUnhealthy: true,
+			expectedDels:        []string{"s-0", "s-1"},
+		},
+		{
+			// Chained rolling update. replicas=4, surge=2. Initial rollout
+			// to rev2 created 2 surge at rev2 (ord 4, 5). Before they ready,
+			// user pushes rev3. activeSurge stays 2 (need surge for rev3),
+			// endOrdinal=6, so the rev2 surge slots are NOT condemned in
+			// Phase B. progressUpdate must recycle them by including ord
+			// [replicas, endOrdinal) in targets and treating surge updates as
+			// free. Otherwise they would stay at rev2 forever.
+			name: "chained rollout: stale-rev surge in [replicas, endOrdinal) gets recycled (free)",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true),
+				buildInst("s", 3, testOldRev, true, true),
+				buildInst("s", 4, "mid-rev", false, true), // stale surge from prior rollout, still creating
+				buildInst("s", 5, "mid-rev", false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 6, surgeStart: 4,
+				replicas: 4, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 2, inRollout: true,
+			},
+			// Stale surge gets deleted (free). Base blocked by budget=0 since
+			// no rev3 surge healthy yet. Next reconcile creates fresh surge
+			// at the current updateRev.
+			expectedDels:  []string{"s-4", "s-5"},
+			expectNoDelet: []string{"s-0", "s-1", "s-2", "s-3"},
+		},
+		{
+			// Sibling of above: stale surge healthy. Still gets recycled.
+			// Surge updates do not count toward effectiveBudget so even
+			// maxUnav=0 + zero rev3-surge does not block them.
+			name: "chained rollout: stale-rev surge HEALTHY also gets recycled",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true),
+				buildInst("s", 3, testOldRev, true, true),
+				buildInst("s", 4, "mid-rev", true, true), // healthy stale surge
+				buildInst("s", 5, "mid-rev", true, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 6, surgeStart: 4,
+				replicas: 4, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 2, inRollout: true,
+			},
+			expectedDels:  []string{"s-4", "s-5"},
+			expectNoDelet: []string{"s-0", "s-1", "s-2", "s-3"},
+		},
+		{
+			// Cache-lag mislabels a fresh-flapping ready base as unhealthy.
+			// markStablyUnhealthy is FALSE so the time gate is not satisfied
+			// → free-delete denied → cost path blocks on budget=0. Net
+			// effect: ord 1 (which cache says is unhealthy but really just
+			// flapped) is NOT deleted.
+			name: "fresh cache-lag unhealthy base must NOT free-delete",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, false, true), // cache says not ready, but flap is fresh
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 0,
+				activeSurge: 0, inRollout: true,
+			},
+			markStablyUnhealthy: false,
+			expectNoDelet:       []string{"s-0", "s-1"},
+		},
+		{
+			// Same protection extends to the case where surge is in flight:
+			// surge updates remain free (always), but flapping base ord 1
+			// must not be free-deleted just because cache says so.
+			name: "fresh cache-lag protected even with surge in flight",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, false, true),
+				buildInst("s", 2, testUpdateRev, false, true),
+				buildInst("s", 3, testUpdateRev, false, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 4, surgeStart: 2,
+				replicas: 2, partition: 0, maxUnavailable: 0, maxSurge: 2,
+				activeSurge: 2, inRollout: true,
+			},
+			markStablyUnhealthy: false,
+			expectNoDelet:       []string{"s-0", "s-1"},
+		},
+		{
+			// Partition=2: ord 0,1 below partition stay; only ord 2,3 update.
+			name: "partition: instances below partition stay untouched",
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testOldRev, true, true),
+				buildInst("s", 2, testOldRev, true, true),
+				buildInst("s", 3, testOldRev, true, true),
+			},
+			topo: topology{
+				startOrdinal: 0, endOrdinal: 4, surgeStart: 4,
+				replicas: 4, partition: 2, maxUnavailable: 1, maxSurge: 0,
+				activeSurge: 0, inRollout: true,
+			},
+			expectedDels:  []string{"s-3"}, // budget=1 → only highest ord
+			expectNoDelet: []string{"s-0", "s-1", "s-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset the cross-test global time-gate map so the prior test's
+			// observations cannot leak in. Tests opt in to "stably unhealthy"
+			// via markStablyUnhealthy below.
+			instanceUnhealthySince.Range(func(k, _ interface{}) bool {
+				instanceUnhealthySince.Delete(k)
+				return true
+			})
+			if tt.markStablyUnhealthy {
+				past := time.Now().Add(-2 * stableUnhealthyDuration)
+				for _, inst := range tt.replicas {
+					if inst != nil && inst.UID != "" && !isHealthy(inst) {
+						instanceUnhealthySince.Store(inst.UID, past)
+					}
+				}
+			}
+
+			set := buildSet("s", int32(tt.topo.replicas), nil, nil)
+			fakeOM := &fakeInstanceObjectManager{}
+			recorder := record.NewFakeRecorder(64)
+			ssc := &defaultStatefulInstanceSetControl{
+				instanceControl: NewStatefulInstanceControlFromManager(fakeOM, recorder),
+				inplaceControl:  &fakeInplaceControl{},
+				recorder:        recorder,
+			}
+
+			currentRev := newStatefulRevision(testOldRev, 1)
+			updateRev := newStatefulRevision(testUpdateRev, 2)
+			revisions := []*apps.ControllerRevision{currentRev, updateRev}
+			status := &workloadsv1alpha2.RoleInstanceSetStatus{}
+
+			_, err := ssc.progressUpdate(set, status, currentRev, updateRev, revisions, tt.replicas, tt.replicas, 0, tt.topo)
+			if err != nil {
+				t.Fatalf("progressUpdate() unexpected error: %v", err)
+			}
+
+			deleted := sets.New(fakeOM.deleted...)
+			for _, name := range tt.expectedDels {
+				if !deleted.Has(name) {
+					t.Errorf("expected %q to be deleted, deleted=%v", name, fakeOM.deleted)
+				}
+			}
+			for _, name := range tt.expectNoDelet {
+				if deleted.Has(name) {
+					t.Errorf("did NOT expect %q to be deleted, deleted=%v", name, fakeOM.deleted)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldAdvanceCurrentRevision(t *testing.T) {
+	// helper: build set with given prior status fields
+	priorStatus := func(updateRev string, updatedReplicas int32) *workloadsv1alpha2.RoleInstanceSet {
+		s := buildSet("s", 2, nil, nil)
+		s.Status.UpdateRevision = updateRev
+		s.Status.UpdatedReplicas = updatedReplicas
+		return s
+	}
+	baseTopo := topology{
+		startOrdinal: 0, endOrdinal: 2, surgeStart: 2,
+		replicas: 2, partition: 0, inRollout: true,
+	}
+
+	tests := []struct {
+		name     string
+		set      *workloadsv1alpha2.RoleInstanceSet
+		replicas []*workloadsv1alpha2.RoleInstance
+		topo     topology
+		expected bool
+	}{
+		{
+			name:     "happy path: prior status concurrence + observed all green",
+			set:      priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), buildInst("s", 1, testUpdateRev, true, true)},
+			topo:     baseTopo,
+			expected: true,
+		},
+		{
+			name:     "prior status had not yet caught up (UpdatedReplicas=0) → don't advance",
+			set:      priorStatus(testUpdateRev, 0),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), buildInst("s", 1, testUpdateRev, true, true)},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name:     "prior status had different UpdateRevision → don't advance",
+			set:      priorStatus("some-other-rev", 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), buildInst("s", 1, testUpdateRev, true, true)},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name:     "observed: one base still at oldRev → don't advance",
+			set:      priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testOldRev, true, true), buildInst("s", 1, testUpdateRev, true, true)},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name:     "observed: one base unhealthy → don't advance",
+			set:      priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), buildInst("s", 1, testUpdateRev, false, true)},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name: "observed: ObservedGeneration not synced → don't advance (in-place midflight)",
+			set:  priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testUpdateRev, true, true),
+				func() *workloadsv1alpha2.RoleInstance {
+					inst := buildInst("s", 1, testUpdateRev, true, true)
+					inst.Generation = 2
+					inst.Status.ObservedGeneration = 1
+					return inst
+				}(),
+			},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name:     "observed: instance terminating → don't advance",
+			set:      priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{buildInst("s", 0, testUpdateRev, true, true), withTerminating(buildInst("s", 1, testUpdateRev, true, true))},
+			topo:     baseTopo,
+			expected: false,
+		},
+		{
+			name: "not in rollout: never advance (no-op)",
+			set:  priorStatus(testUpdateRev, 2),
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testUpdateRev, true, true),
+				buildInst("s", 1, testUpdateRev, true, true),
+			},
+			topo:     topology{startOrdinal: 0, endOrdinal: 2, surgeStart: 2, replicas: 2, partition: 0, inRollout: false},
+			expected: false,
+		},
+		{
+			// With partition > 0, the rev semantics is: currentRev = rev of
+			// ords below partition (still old), updateRev = rev of ords above.
+			// Advancing CurrentRevision to updateRev here would lie about ord
+			// 0 — and break later partition decreases (currentRev would equal
+			// updateRev so "in rollout" detection would miss them).
+			name: "partition > 0: do not advance even when ords above partition are all at updateRev",
+			set:  priorStatus(testUpdateRev, 1),
+			replicas: []*workloadsv1alpha2.RoleInstance{
+				buildInst("s", 0, testOldRev, true, true),
+				buildInst("s", 1, testUpdateRev, true, true),
+			},
+			topo:     topology{startOrdinal: 0, endOrdinal: 2, surgeStart: 2, replicas: 2, partition: 1, inRollout: true},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldAdvanceCurrentRevision(tt.set, tt.replicas, testUpdateRev, tt.topo)
+			if got != tt.expected {
+				t.Errorf("shouldAdvanceCurrentRevision() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// resetInstanceUnhealthySince clears the global time-gate map so each test
+// starts from a known empty state.
+func resetInstanceUnhealthySince() {
+	instanceUnhealthySince.Range(func(k, _ interface{}) bool {
+		instanceUnhealthySince.Delete(k)
+		return true
+	})
+}
+
+func TestObserveInstanceHealthAndIsStablyUnhealthy(t *testing.T) {
+	resetInstanceUnhealthySince()
+	defer resetInstanceUnhealthySince()
+
+	healthy := buildInst("s", 0, testOldRev, true, true)
+	unhealthy := buildInst("s", 1, testOldRev, false, true)
+
+	// First observation: nothing is "stably" unhealthy yet — even the
+	// unhealthy instance just had its timer started.
+	observeInstanceHealth([]*workloadsv1alpha2.RoleInstance{healthy, unhealthy})
+	if isStablyUnhealthy(unhealthy) {
+		t.Errorf("just-observed unhealthy must not be stably unhealthy yet")
+	}
+	if isStablyUnhealthy(healthy) {
+		t.Errorf("healthy instance must never be stably unhealthy")
+	}
+
+	// Backdate the unhealthy timer past the threshold; gate should now fire.
+	instanceUnhealthySince.Store(unhealthy.UID, time.Now().Add(-2*stableUnhealthyDuration))
+	if !isStablyUnhealthy(unhealthy) {
+		t.Errorf("unhealthy past threshold must be stably unhealthy")
+	}
+
+	// Observe instance flipping back to healthy: timer must reset.
+	healthyAgain := buildInst("s", 1, testOldRev, true, true)
+	healthyAgain.UID = unhealthy.UID
+	observeInstanceHealth([]*workloadsv1alpha2.RoleInstance{healthyAgain})
+	if isStablyUnhealthy(healthyAgain) {
+		t.Errorf("after observing healthy, gate must reset")
+	}
+	// Even if a later flip-to-unhealthy comes in, the timer is fresh.
+	stillUnhealthy := buildInst("s", 1, testOldRev, false, true)
+	stillUnhealthy.UID = unhealthy.UID
+	observeInstanceHealth([]*workloadsv1alpha2.RoleInstance{stillUnhealthy})
+	if isStablyUnhealthy(stillUnhealthy) {
+		t.Errorf("freshly re-observed unhealthy must not satisfy gate")
+	}
+
+	// Disappeared UIDs are garbage-collected from the map.
+	observeInstanceHealth(nil)
+	if _, ok := instanceUnhealthySince.Load(stillUnhealthy.UID); ok {
+		t.Errorf("UID no longer present in instances slice should be GC'd from the map")
+	}
+}
+
+func TestIsStablyUnhealthyEdgeCases(t *testing.T) {
+	resetInstanceUnhealthySince()
+	defer resetInstanceUnhealthySince()
+
+	if isStablyUnhealthy(nil) {
+		t.Errorf("nil instance must return false")
+	}
+	noUID := buildInst("s", 0, testOldRev, false, false) // created=false → no UID
+	if isStablyUnhealthy(noUID) {
+		t.Errorf("instance without UID must return false")
+	}
+	notInMap := buildInst("s", 1, testOldRev, false, true)
+	if isStablyUnhealthy(notInMap) {
+		t.Errorf("instance not yet in the map must return false")
+	}
 }

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_controller.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -62,6 +63,22 @@ var (
 
 	// global client
 	sigsruntimeClient sigsclient.Client
+
+	// instanceUnhealthySince tracks, per RoleInstance UID, the timestamp at
+	// which this controller first observed the instance in an unhealthy state.
+	// Reset to zero whenever the controller subsequently observes the same UID
+	// as healthy, so the duration only accumulates over CONSECUTIVE unhealthy
+	// observations. This is the input to the "stably unhealthy" gate (see
+	// stableUnhealthyDuration / isStablyUnhealthy in stateful_instance_set_control.go),
+	// which prevents a transient cache view that briefly mislabels a ready
+	// instance as not-ready from accumulating enough continuous unhealthy
+	// time to trigger a free-delete on an actually-ready base instance.
+	//
+	// The map is in-memory; on controller restart it resets, which is
+	// acceptable — the worst case after a restart is that a genuinely-broken
+	// instance takes one extra stableUnhealthyDuration window before it
+	// becomes eligible for cleanup.
+	instanceUnhealthySince sync.Map // map[types.UID]time.Time
 )
 
 // NewReconciler creates a new reconcile.Reconciler for external usage

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
@@ -122,22 +122,6 @@ func injectIdentityLabelsIntoComponents(instance *workloadsv1alpha2.RoleInstance
 	}
 }
 
-// getInstanceSetReplicasRange returns the start ordinal, end ordinal (exclusive), and set of reserved ordinals for a InstanceSet.
-func getInstanceSetReplicasRange(set *workloadsv1alpha2.RoleInstanceSet) (int, int, sets.Set[int]) {
-	// Default range is [0, Replicas)
-	start := 0
-	end := 0
-	if set.Spec.Replicas != nil {
-		end = int(*set.Spec.Replicas)
-	}
-	reserveOrdinals := sets.New[int]()
-
-	// Kruise InstanceSet uses different ordinal configuration approach
-	// This is a simplified version that only supports basic ordinal ranges
-
-	return start, end, reserveOrdinals
-}
-
 // getInstanceSetKey returns the key for a InstanceSet
 func getInstanceSetKey(set *workloadsv1alpha2.RoleInstanceSet) string {
 	return fmt.Sprintf("%s/%s", set.Namespace, set.Name)
@@ -234,6 +218,358 @@ func newVersionedInstance(
 	portallocator.AllocatePortsForInstance(instance, currentSet)
 
 	return instance
+}
+
+// topology captures all the rolling-update sizing decisions for a single
+// reconcile pass. It is computed once at the top of updateStatefulInstanceSet
+// and consulted by every later phase, so there is exactly one place that
+// decides the in-range ordinal window.
+type topology struct {
+	// startOrdinal, endOrdinal define the [start, end) ordinal range that is
+	// considered "in-range" this reconcile. Anything outside is condemned.
+	// During a rollout endOrdinal may exceed replicas to provide a surge
+	// buffer; outside of a rollout it equals replicas.
+	startOrdinal int
+	endOrdinal   int
+	// reserveOrdinals are ordinals within [start, end) that should be skipped
+	// when allocating slots. Always empty in the current implementation but
+	// kept for future support of ordinal reservation.
+	reserveOrdinals sets.Set[int]
+
+	// replicas is the desired replica count from spec.
+	replicas int
+	// partition: ordinals < partition stay on currentRevision, ordinals >=
+	// partition are eligible for rolling update.
+	partition int
+	// maxUnavailable is the budget for available -> unavailable transitions
+	// during rolling update. Resolved from spec (default 10%, rounded down
+	// when maxSurge > 0).
+	maxUnavailable int
+	// maxSurge is the upper bound on extra ordinals beyond replicas during a
+	// rollout. Resolved from spec (default 0, rounded up).
+	maxSurge int
+
+	// activeSurge is the number of surge slots actually allocated this
+	// reconcile. Always 0 when not in rollout. During rollout we size it as
+	//   activeSurge = min(maxSurge, max(surgeNeeded, existingValidSurge))
+	// where surgeNeeded buffers healthy-old base instances beyond
+	// maxUnavailable, and existingValidSurge keeps already-created surge at
+	// the current updateRev alive (sticky). Stale-revision surge does NOT
+	// count toward existingValidSurge — it falls outside endOrdinal and gets
+	// condemned in Phase B.
+	activeSurge int
+	// surgeStart equals replicas: surge ords occupy [surgeStart, endOrdinal).
+	surgeStart int
+
+	// inRollout is true when currentRev != updateRev and the rollout is not
+	// paused. Used to gate surge allocation and to decide whether Phase C
+	// runs at all.
+	inRollout bool
+}
+
+// computeMaxSurge resolves spec.UpdateStrategy.MaxSurge against the desired
+// replica count using the round-up convention (matching k8s Deployment).
+// Returns 0 when MaxSurge is unset or Replicas is nil.
+func computeMaxSurge(set *workloadsv1alpha2.RoleInstanceSet) (int, error) {
+	if set.Spec.UpdateStrategy.MaxSurge == nil || set.Spec.Replicas == nil {
+		return 0, nil
+	}
+	maxSurge, err := intstrutil.GetScaledValueFromIntOrPercent(
+		set.Spec.UpdateStrategy.MaxSurge, int(*set.Spec.Replicas), true)
+	if err != nil {
+		return 0, err
+	}
+	if maxSurge < 0 {
+		return 0, nil
+	}
+	return maxSurge, nil
+}
+
+// computeMaxUnavailable resolves spec.UpdateStrategy.MaxUnavailable against
+// the desired replica count. When MaxSurge > 0 we round down (matching k8s
+// Deployment when maxSurge is in play); otherwise we round up.
+//
+// As with k8s Deployment, when maxSurge == 0 the resolved maxUnavailable is
+// floored to 1, otherwise the rolling update could not make progress.
+func computeMaxUnavailable(set *workloadsv1alpha2.RoleInstanceSet, maxSurge int) (int, error) {
+	if set.Spec.Replicas == nil {
+		if set.Spec.UpdateStrategy.MaxUnavailable != nil {
+			return 0, fmt.Errorf("spec.Replicas is nil")
+		}
+		return 0, nil
+	}
+	replicas := int(*set.Spec.Replicas)
+	if set.Spec.UpdateStrategy.MaxUnavailable == nil {
+		// Default: 10% of replicas. Match Deployment's rounding rule.
+		def := intstrutil.FromString(workloadsv1alpha2.DefaultRoleInstanceSetMaxUnavailable)
+		raw, err := intstrutil.GetScaledValueFromIntOrPercent(&def, replicas, maxSurge == 0)
+		if err != nil {
+			return 0, err
+		}
+		if maxSurge == 0 && raw < 1 {
+			raw = 1
+		}
+		if raw < 0 {
+			raw = 0
+		}
+		return raw, nil
+	}
+	raw, err := intstrutil.GetScaledValueFromIntOrPercent(
+		set.Spec.UpdateStrategy.MaxUnavailable, replicas, maxSurge == 0)
+	if err != nil {
+		return 0, err
+	}
+	if maxSurge == 0 && raw < 1 {
+		raw = 1
+	}
+	if raw < 0 {
+		raw = 0
+	}
+	return raw, nil
+}
+
+// computePartition resolves spec.UpdateStrategy.Partition. Default 0 means
+// "update all instances".
+func computePartition(set *workloadsv1alpha2.RoleInstanceSet) (int, error) {
+	if set.Spec.UpdateStrategy.Partition == nil || set.Spec.Replicas == nil {
+		return 0, nil
+	}
+	p, err := intstrutil.GetValueFromIntOrPercent(
+		set.Spec.UpdateStrategy.Partition, int(*set.Spec.Replicas), false)
+	if err != nil {
+		return 0, err
+	}
+	if p < 0 {
+		return 0, nil
+	}
+	if p > int(*set.Spec.Replicas) {
+		p = int(*set.Spec.Replicas)
+	}
+	return p, nil
+}
+
+// countHealthyOldInBase counts ordinals within [partition, replicas) where
+// the instance is at the OLD revision (i.e. != updateRevision) AND currently
+// healthy AND not terminating. These are the instances that need a surge
+// buffer to be replaced without dropping availability — they are currently
+// providing service and we must not delete them faster than maxUnavailable
+// allows.
+//
+// Already-unavailable instances (unhealthy / terminating / missing) do NOT
+// need a surge buffer because they are not contributing to availability;
+// replacing them does not reduce availability further. This is the same
+// observation behind k8s Deployment's cleanupUnhealthyReplicas.
+func countHealthyOldInBase(
+	instances []*workloadsv1alpha2.RoleInstance,
+	partition int,
+	replicas int,
+	updateRevision string,
+) int {
+	if replicas <= partition {
+		return 0
+	}
+	count := 0
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		ord := getOrdinal(inst)
+		if ord < partition || ord >= replicas {
+			continue
+		}
+		if getInstanceRevision(inst) == updateRevision {
+			continue
+		}
+		if !isCreated(inst) || !isHealthy(inst) || isTerminating(inst) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// countExistingValidSurge counts ordinals in [replicas, replicas+maxSurge)
+// that hold an instance already at the CURRENT updateRevision and not
+// terminating. We use this as a stickiness floor when sizing activeSurge —
+// surge slots that have already been allocated for the current rollout
+// should stay alive even if surgeNeeded shrinks (e.g. as healthy old base
+// instances get updated).
+//
+// Critically: surge instances at a STALE revision (e.g. left over from a
+// prior rollout that the user superseded mid-flight) are NOT counted here.
+// They will fall outside endOrdinal and Phase B will condemn them — which is
+// what fixes the "mid-rollout config change does not progress" bug.
+func countExistingValidSurge(
+	instances []*workloadsv1alpha2.RoleInstance,
+	replicas int,
+	maxSurge int,
+	updateRevision string,
+) int {
+	if maxSurge <= 0 {
+		return 0
+	}
+	count := 0
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		ord := getOrdinal(inst)
+		if ord < replicas || ord >= replicas+maxSurge {
+			continue
+		}
+		if getInstanceRevision(inst) != updateRevision {
+			continue
+		}
+		if isTerminating(inst) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// allBaseAtUpdateRevHealthy reports whether every ord in [partition, replicas)
+// is fully done with respect to updateRevision: an instance exists, is at
+// updateRev, isCreated + isHealthy + !isTerminating, and its
+// ObservedGeneration has caught up to its Generation. Used as a "rollout
+// effectively complete" signal for surge sticky-floor and (combined with a
+// partition==0 guard) for advancing CurrentRevision.
+func allBaseAtUpdateRevHealthy(
+	instances []*workloadsv1alpha2.RoleInstance,
+	partition, replicas int,
+	updateRevision string,
+) bool {
+	if replicas <= partition {
+		return true
+	}
+	seen := sets.New[int]()
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		ord := getOrdinal(inst)
+		if ord < partition || ord >= replicas {
+			continue
+		}
+		if getInstanceRevision(inst) != updateRevision {
+			return false
+		}
+		if !isCreated(inst) || !isHealthy(inst) || isTerminating(inst) {
+			return false
+		}
+		if inst.Status.ObservedGeneration < inst.Generation {
+			return false
+		}
+		seen.Insert(ord)
+	}
+	// Every ord in [partition, replicas) must be present.
+	return seen.Len() == replicas-partition
+}
+
+// computeTopology is the single source of truth for ordinal range sizing
+// during a reconcile. See topology doc for field semantics. Errors only
+// occur on malformed spec (negative percentages etc.).
+//
+// Sizing rules in one place:
+//
+//   - Outside a rollout (currentRev == updateRev): activeSurge = 0,
+//     endOrdinal = replicas. Stale surge (if any from a finished rollout)
+//     falls out of range and gets condemned.
+//
+//   - Paused mid-rollout (Paused=true && currentRev != updateRev): freeze the
+//     existing surge in place. activeSurge = existingValidSurge (clamped to
+//     maxSurge). New surge is NOT allocated (no surgeNeeded delta), but
+//     in-flight surge slots stay inside endOrdinal so Phase B does not condemn
+//     them. Pod startup is expensive; throwing away surge on pause and
+//     re-creating it on unpause would waste minutes of GPU time.
+//
+//   - Inside a rollout, with work still pending in [partition, replicas):
+//     activeSurge = min(maxSurge, max(surgeNeeded, existingValidSurge)).
+//     surgeNeeded = max(0, healthyOldInBase - maxUnavailable). The max with
+//     existingValidSurge keeps already-allocated surge sticky so we don't
+//     thrash by creating surge → letting healthy-old shrink → condemning surge.
+//
+//   - Inside a rollout, but all base ords [partition, replicas) are already at
+//     updateRev healthy: surge stickiness is dropped and activeSurge collapses
+//     to surgeNeeded (which is 0 in that state). Surge slots fall out of
+//     endOrdinal and Phase B condemns them. This matters when partition > 0
+//     because CurrentRevision will not advance (per the partition>0 guard in
+//     shouldAdvanceCurrentRevision), so the next-reconcile "inRollout=false →
+//     drop surge" path would otherwise never trigger.
+func computeTopology(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	instances []*workloadsv1alpha2.RoleInstance,
+	currentRevision, updateRevision string,
+) (topology, error) {
+	t := topology{
+		startOrdinal:    0,
+		reserveOrdinals: sets.New[int](),
+	}
+	if set.Spec.Replicas != nil {
+		t.replicas = int(*set.Spec.Replicas)
+	}
+	t.surgeStart = t.replicas
+	t.endOrdinal = t.replicas
+
+	maxSurge, err := computeMaxSurge(set)
+	if err != nil {
+		return t, err
+	}
+	t.maxSurge = maxSurge
+
+	maxUnav, err := computeMaxUnavailable(set, maxSurge)
+	if err != nil {
+		return t, err
+	}
+	t.maxUnavailable = maxUnav
+
+	partition, err := computePartition(set)
+	if err != nil {
+		return t, err
+	}
+	t.partition = partition
+
+	t.inRollout = currentRevision != updateRevision && !set.Spec.UpdateStrategy.Paused
+	if maxSurge == 0 {
+		return t, nil
+	}
+	// Paused mid-rollout: preserve existing surge slots so Phase B does not
+	// condemn them. We do NOT allocate new surge here — surgeNeeded is only
+	// considered when actively rolling.
+	if !t.inRollout {
+		if set.Spec.UpdateStrategy.Paused && currentRevision != updateRevision {
+			existing := countExistingValidSurge(instances, t.replicas, maxSurge, updateRevision)
+			if existing > maxSurge {
+				existing = maxSurge
+			}
+			t.activeSurge = existing
+			t.endOrdinal = t.replicas + existing
+		}
+		return t, nil
+	}
+
+	healthyOld := countHealthyOldInBase(instances, partition, t.replicas, updateRevision)
+	surgeNeeded := healthyOld - maxUnav
+	if surgeNeeded < 0 {
+		surgeNeeded = 0
+	}
+
+	active := surgeNeeded
+	// Stickiness only applies while there is still work to do in
+	// [partition, replicas). Once that range is fully at updateRev healthy,
+	// drop the existing-surge floor so surge ramps back down.
+	if !allBaseAtUpdateRevHealthy(instances, partition, t.replicas, updateRevision) {
+		existing := countExistingValidSurge(instances, t.replicas, maxSurge, updateRevision)
+		if existing > active {
+			active = existing
+		}
+	}
+	if active > maxSurge {
+		active = maxSurge
+	}
+	t.activeSurge = active
+	t.endOrdinal = t.replicas + active
+	return t, nil
 }
 
 // isHealthy returns true if instance is healthy

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -73,6 +73,7 @@ func TestE2E(t *testing.T) {
 			testcasev1alpha2.RunDeploymentWorkloadTestCases(f)
 			testcasev1alpha2.RunStatefulSetWorkloadTestCases(f)
 			testcasev1alpha2.RunLeaderWorkerSetWorkloadTestCases(f)
+			testcasev1alpha2.RunRoleInstanceSetWorkloadTestCases(f)
 			testcasev1alpha2.RunRbgSetControllerTestCases(f)
 			testcasev1alpha2.RunRoleTemplateTestCases(f)
 			testcasev1alpha2.RunPortAllocatorTestCases(f)

--- a/test/e2e/testcase/v1alpha2/ris.go
+++ b/test/e2e/testcase/v1alpha2/ris.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/test/e2e/framework"
+	"sigs.k8s.io/rbgs/test/utils"
+	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
+)
+
+// buildPodTemplateWithStartupDelay creates a PodTemplateSpec with a startup probe
+// that uses initialDelaySeconds to keep the pod NotReady for the specified duration.
+// After the delay, the exec command "true" succeeds immediately, making the pod Ready.
+// This allows us to observe intermediate states (like surge instances) during rolling updates.
+func buildPodTemplateWithStartupDelay(delaySeconds int32, failureThreshold int32) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "nginx",
+					Image:           "nginx:latest",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					StartupProbe: &corev1.Probe{
+						InitialDelaySeconds: delaySeconds,
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/bin/true"},
+							},
+						},
+						FailureThreshold: failureThreshold,
+						PeriodSeconds:    2,
+					},
+				},
+			},
+		},
+	}
+}
+
+func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
+	// Test 1: With maxUnavailable=0 and maxSurge=2, readiness never drops below the replica count.
+	ginkgo.It("[RoleInstanceSet] surge maintains full readiness during rolling update", func() {
+		initialTemplate := buildPodTemplateWithStartupDelay(5, 5)
+
+		rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-test", f.Namespace).WithRoles(
+			[]workloadsv1alpha2.RoleSpec{
+				wrappersv2.BuildStandaloneRole("role-1").
+					WithReplicas(4).
+					WithTemplate(&initialTemplate).
+					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(2)),
+					}).Obj(),
+			}).Obj()
+
+		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+
+		// Wait for all initial pods to become Ready
+		f.ExpectRbgV2Equal(rbg)
+		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(4))
+
+		time.Sleep(2 * time.Second)
+
+		// Trigger rolling update
+		updateTemplate := buildPodTemplateWithStartupDelay(5, 3)
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].StandalonePattern.Template = &updateTemplate
+		})
+
+		// Surge should create 2 extra instances (total 6)
+		gomega.Eventually(func() int {
+			return countRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.BeNumerically(">=", 6),
+			"surge should create 2 extra instances (total 6) during rolling update")
+
+		// With maxUnavailable=0 and surge, readiness must never drop below replicas
+		gomega.Consistently(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, 20, 2).Should(gomega.BeNumerically(">=", 4),
+			"ready instance count should never drop below replicas during surge rolling update")
+
+		// Wait for rolling update to complete
+		f.ExpectRbgV2Equal(rbg)
+
+		// Surge instances should be cleaned up
+		gomega.Eventually(func() int {
+			return countRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(4),
+			"surge instances should be cleaned up after rolling update completes")
+	})
+
+	// Test 2: With maxUnavailable=2 and maxSurge=2, the controller takes down 2 base
+	// instances immediately while creating 2 surge instances. The ready count drops to 2
+	// (ordinals 0,1), then recovers to 4 after all instances are updated.
+	ginkgo.It("[RoleInstanceSet] surge with maxUnavailable allows faster update with minimum readiness", func() {
+		initialTemplate := buildPodTemplateWithStartupDelay(5, 5)
+
+		rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-test", f.Namespace).WithRoles(
+			[]workloadsv1alpha2.RoleSpec{
+				wrappersv2.BuildStandaloneRole("role-1").
+					WithReplicas(4).
+					WithTemplate(&initialTemplate).
+					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+						MaxSurge:       ptr.To(intstr.FromInt32(2)),
+					}).Obj(),
+			}).Obj()
+
+		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+
+		// Wait for all initial pods to become Ready
+		f.ExpectRbgV2Equal(rbg)
+		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(4))
+
+		time.Sleep(2 * time.Second)
+
+		// Trigger rolling update
+		updateTemplate := buildPodTemplateWithStartupDelay(5, 3)
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].StandalonePattern.Template = &updateTemplate
+		})
+
+		// Intermediate state 1: maxUnavailable=2 takes down ordinals 3,2 immediately,
+		// surge creates ordinals 4,5. Only ordinals 0,1 remain ready.
+		gomega.Eventually(func() bool {
+			total := countRoleInstances(f, rbg, "role-1")
+			ready := countReadyRoleInstances(f, rbg, "role-1")
+			readyOrds := getReadyOrdinals(f, rbg, "role-1")
+			return total == 6 && ready == 2 && readyOrds.Equal(sets.New(0, 1))
+		}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+			"after update: total=6, ready=2, only ordinals 0,1 should be ready")
+
+		// Intermediate state 2: ordinals 2,3 recover with new revision
+		gomega.Eventually(func() bool {
+			readyOrds := getReadyOrdinals(f, rbg, "role-1")
+			return readyOrds.HasAll(2, 3)
+		}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+			"ordinals 2,3 should eventually become ready after rebuild")
+
+		// Surge cleanup: instances 4,5 should be deleted
+		gomega.Eventually(func() int {
+			return countRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(4),
+			"surge instances 4,5 should be cleaned up")
+
+		// Final state: all 4 instances ready with new revision
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(4))
+	})
+
+	// Test 3: A maxSurge value larger than replicas is capped at the replicas count.
+	// With replicas=2 and maxSurge=4, at most 2 surge instances are created (total 4).
+	ginkgo.It("[RoleInstanceSet] large maxSurge is capped at replicas count", func() {
+		initialTemplate := buildPodTemplateWithStartupDelay(5, 5)
+
+		rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-test", f.Namespace).WithRoles(
+			[]workloadsv1alpha2.RoleSpec{
+				wrappersv2.BuildStandaloneRole("role-1").
+					WithReplicas(2).
+					WithTemplate(&initialTemplate).
+					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(4)),
+					}).Obj(),
+			}).Obj()
+
+		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+
+		// Wait for all initial pods to become Ready
+		f.ExpectRbgV2Equal(rbg)
+		gomega.Expect(countRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+
+		time.Sleep(2 * time.Second)
+
+		// Trigger rolling update
+		updateTemplate := buildPodTemplateWithStartupDelay(5, 3)
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].StandalonePattern.Template = &updateTemplate
+		})
+
+		// Surge should be capped at replicas (2), so total never exceeds 4
+		gomega.Consistently(func() int {
+			return countRoleInstances(f, rbg, "role-1")
+		}, 20, 1).Should(gomega.BeNumerically("<=", 4),
+			"maxSurge=4 with replicas=2 should be capped, total instances <= 4")
+
+		// Wait for rolling update to complete
+		f.ExpectRbgV2Equal(rbg)
+
+		// Surge instances should be cleaned up
+		gomega.Eventually(func() int {
+			return countRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2),
+			"surge instances should be cleaned up after rolling update completes")
+		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+	})
+
+	// Test 4: Decreasing partition step-by-step must continue to roll the
+	// newly-exposed ordinals. With replicas=2 and partition=1, only ord 1
+	// updates while ord 0 stays at the original revision. Then the user
+	// lowers partition to 0, which must trigger ord 0 to update too.
+	// Surge is intentionally 0 here — this test focuses on partition
+	// progression, not surge sizing.
+	ginkgo.It("[RoleInstanceSet] partition decrease progressively rolls more ordinals", func() {
+		initialTemplate := buildPodTemplateWithStartupDelay(5, 5)
+
+		rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-test", f.Namespace).WithRoles(
+			[]workloadsv1alpha2.RoleSpec{
+				wrappersv2.BuildStandaloneRole("role-1").
+					WithReplicas(2).
+					WithTemplate(&initialTemplate).
+					WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						MaxSurge:       ptr.To(intstr.FromInt32(0)),
+						Partition:      ptr.To(intstr.FromInt32(1)),
+					}).Obj(),
+			}).Obj()
+
+		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+
+		// Wait for both initial pods to become Ready.
+		f.ExpectRbgV2Equal(rbg)
+		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+
+		time.Sleep(2 * time.Second)
+
+		// Record the initial revision from ord 0.
+		initialRevision := getRoleInstanceRevision(f, rbg, "role-1", 0)
+		gomega.Expect(initialRevision).ShouldNot(gomega.BeEmpty())
+
+		// Trigger a template change. With partition=1, only ord 1 should roll.
+		updateTemplate := buildPodTemplateWithStartupDelay(5, 3)
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].StandalonePattern.Template = &updateTemplate
+		})
+
+		// Wait for ord 1 to land on the new revision.
+		gomega.Eventually(func() bool {
+			rev := getRoleInstanceRevision(f, rbg, "role-1", 1)
+			return rev != "" && rev != initialRevision
+		}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+			"ord 1 should be updated to the new revision under partition=1")
+
+		// ord 0 must remain on the original revision throughout — the
+		// partition contract is that anything below partition stays put.
+		gomega.Consistently(func() string {
+			return getRoleInstanceRevision(f, rbg, "role-1", 0)
+		}, 10, 1).Should(gomega.Equal(initialRevision),
+			"ord 0 (below partition) must keep the original revision while partition=1")
+
+		// Total instance count stays at 2 throughout (surge=0).
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2))
+		gomega.Expect(countRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+
+		updatedRevision := getRoleInstanceRevision(f, rbg, "role-1", 1)
+		gomega.Expect(updatedRevision).ShouldNot(gomega.Equal(initialRevision))
+
+		time.Sleep(2 * time.Second)
+
+		// Now lower partition to 0. ord 0 must pick up the new revision.
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].RolloutStrategy.RollingUpdate.Partition = ptr.To(intstr.FromInt32(0))
+		})
+
+		gomega.Eventually(func() string {
+			return getRoleInstanceRevision(f, rbg, "role-1", 0)
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(updatedRevision),
+			"ord 0 should be updated to the new revision after partition is lowered to 0")
+
+		// Final state: 2 instances, both at the new revision, both ready.
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2))
+		gomega.Expect(countRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+		gomega.Expect(getRoleInstanceRevision(f, rbg, "role-1", 0)).Should(gomega.Equal(updatedRevision))
+		gomega.Expect(getRoleInstanceRevision(f, rbg, "role-1", 1)).Should(gomega.Equal(updatedRevision))
+	})
+}
+
+// listRoleInstances returns all RoleInstances for the given RBG and role.
+func listRoleInstances(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) []workloadsv1alpha2.RoleInstance {
+	riList := &workloadsv1alpha2.RoleInstanceList{}
+	err := f.Client.List(f.Ctx, riList,
+		client.InNamespace(rbg.Namespace),
+		client.MatchingLabels{
+			constants.GroupNameLabelKey: rbg.Name,
+			constants.RoleNameLabelKey:  roleName,
+		},
+	)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	return riList.Items
+}
+
+// countRoleInstances returns the total number of RoleInstances for the given RBG and role.
+func countRoleInstances(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) int {
+	return len(listRoleInstances(f, rbg, roleName))
+}
+
+// countReadyRoleInstances returns the number of Ready RoleInstances for the given RBG and role.
+func countReadyRoleInstances(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) int {
+	instances := listRoleInstances(f, rbg, roleName)
+	ready := 0
+	for _, ri := range instances {
+		for _, cond := range ri.Status.Conditions {
+			if cond.Type == workloadsv1alpha2.RoleInstanceAllPodsReady && cond.Status == corev1.ConditionTrue {
+				ready++
+				break
+			}
+		}
+	}
+	klog.Infof("ready instance: %v/%v", ready, len(instances))
+	return ready
+}
+
+// getReadyOrdinals returns the set of ordinal indices for Ready RoleInstances.
+func getReadyOrdinals(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) sets.Set[int] {
+	instances := listRoleInstances(f, rbg, roleName)
+	result := sets.New[int]()
+	for _, ri := range instances {
+		isReady := false
+		for _, cond := range ri.Status.Conditions {
+			if cond.Type == workloadsv1alpha2.RoleInstanceAllPodsReady && cond.Status == corev1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+		if isReady {
+			ordStr := ri.Labels[constants.RoleInstanceIndexLabelKey]
+			if ord, err := strconv.Atoi(ordStr); err == nil {
+				result.Insert(ord)
+			}
+		}
+	}
+	return result
+}
+
+// getRoleInstanceRevision returns the controller-revision-hash label value for
+// the RoleInstance at the given ordinal index.
+func getRoleInstanceRevision(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string, ordinal int) string {
+	instances := listRoleInstances(f, rbg, roleName)
+	for _, ri := range instances {
+		if ri.Labels[constants.RoleInstanceIndexLabelKey] == fmt.Sprintf("%d", ordinal) {
+			return ri.Labels["controller-revision-hash"]
+		}
+	}
+	return ""
+}

--- a/test/wrappers/v1alpha2/role_wrapper.go
+++ b/test/wrappers/v1alpha2/role_wrapper.go
@@ -220,8 +220,9 @@ func BuildBasicPodTemplateSpec() corev1.PodTemplateSpec {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "nginx",
-					Image: utils.DefaultImage,
+					Name:            "nginx",
+					Image:           utils.DefaultImage,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation

`RoleInstanceSet` (stateful mode) supports `maxUnavailable` and `partition` in its rolling-update strategy, but `maxSurge` is silently ignored — every rollout proceeds in lock-step with `maxUnavailable` and never provisions an availability buffer. This PR implements `maxSurge` for stateful rolling updates, aligned with K8s native semantics.

It also closes three correctness gaps in the existing rolling-update loop:

- A rollout where every base instance is unhealthy still allocated surge slots, wasting expensive GPU capacity to "buffer" instances that are not contributing to availability.
- Pushing a new template while a previous rollout was still in flight left stale-revision surge slots that were never recycled.
- Triggering a rolling update very shortly after creation could cascade into all base instances being deleted and recreated, momentarily breaking the `replicas` invariant.

### Ⅱ. Modifications

The stateful rolling-update loop is restructured into a four-phase pipeline that shares a single `topology` value as the source of truth for ordinal-range, surge sizing, partition, and budget decisions:

| Phase | Responsibility |
|---|---|
| A. observe | resolve `currentRevision` / `updateRevision`, `ApplyRevision`, build `topology`, refresh the per-UID unhealthy-since map |
| B. scale & identity | partition into in-range + condemned, fill empty slots, `processReplica` (create) and `processCondemned` (delete) |
| C. progress update | rolling update with a `free-vs-costly` budget, runs only when `topology.inRollout` |
| D. status & advance | recompute counts, run multi-layer guard before advancing `status.CurrentRevision` |

**Topology computation** (`stateful_instance_set_utils.go`):

```
healthyOldInBase            = healthy old-rev base ords [partition, replicas)
existingValidSurge          = surge ords [replicas, replicas+maxSurge) at the current updateRev
                              (stale-rev surge from a superseded rollout is excluded
                               so it falls outside endOrdinal and gets condemned)
allBaseAtUpdateRevHealthy   = every ord [partition, replicas) is at updateRev,
                              isCreated, isHealthy, !isTerminating, ObservedGen synced
surgeNeeded                 = max(0, healthyOldInBase - maxUnavailable)
activeSurge                 = surgeNeeded
                              if !allBaseAtUpdateRevHealthy && existingValidSurge > activeSurge:
                                  activeSurge = existingValidSurge   // sticky during rollout
                              clamp to maxSurge
endOrdinal                  = replicas + activeSurge
```

`surgeNeeded` only counts healthy old instances — instances that are not currently contributing to availability do not need a surge buffer to be replaced. `existingValidSurge` provides a stickiness floor so already-allocated surge does not thrash as healthy-old shrinks during a rollout. The stickiness is dropped once the partition range is fully at updateRev healthy, so surge ramps back down (this matters when `partition>0`, where `CurrentRevision` does not advance and the next-reconcile "inRollout=false → drop surge" cleanup path is otherwise never reached).

**Progress update** (`progressUpdate` in `stateful_instance_set_control.go`):

```
effectiveBudget    = maxUnavailable + availableSurge
                     (availableSurge = surge ords at updateRev that are healthy & non-terminating)
initialBaseUnavail = base ords currently counted as unavailable

target ord ∈ [partition, endOrdinal)   // includes surge ords so stale-rev
                                       // surge slots get recycled

isFree =  isSurgeSlot                  // surge is extra capacity, not part
                                       // of the maxUnavailable contract
       || isTerminating
       || isStablyUnhealthy(target)    // see "stable-unhealthy gate" below

if !isFree && initialBaseUnavail + newlyUnavail >= effectiveBudget: stop
```

Targets are processed in descending ordinal order, so surge ords are recycled before the controller chips at base. A healthy base instance is never deleted faster than `maxUnavailable + availableSurge` allows.

**Stable-unhealthy gate** (`observeInstanceHealth` / `isStablyUnhealthy` in `stateful_instance_set_control.go`):

The "free-delete unhealthy target" path (the `cleanupUnhealthyReplicas` analogue from K8s Deployment) is gated on a per-instance, per-UID timestamp recorded in an in-memory `sync.Map` keyed by `RoleInstance.UID`:

- Phase A calls `observeInstanceHealth` once per reconcile. For every observed instance: record the first time the controller sees it unhealthy; clear the entry the next time the same UID is observed healthy. UIDs no longer in the input slice are evicted.
- `isStablyUnhealthy(inst)` returns true only when `time.Since(firstUnhealthyObservation) >= stableUnhealthyDuration` (10s).

The map resets on controller restart; the worst case after a restart is that a genuinely-broken instance takes one extra `stableUnhealthyDuration` window before becoming eligible for free-delete. Because the timestamp resets on any healthy observation, transient cache flap (Ready toggling on the order of milliseconds because the informer briefly lags the API) cannot accumulate enough continuous unhealthy time to satisfy the gate, so it cannot trigger a free-delete on an actually-ready base instance. A genuinely broken instance accrues continuously and becomes eligible after the window. 10s is well above typical informer cache lag while keeping the recovery delay for genuinely broken pods small enough to avoid wasting GPU resources for too long.

**Advance guard** (`shouldAdvanceCurrentRevision`) — every layer is required:

1. We are in a rollout (`topology.inRollout`).
2. `partition == 0`. With `partition > 0` the ords below partition are pinned at the "old" revision, so advancing `CurrentRevision` to `updateRev` would lie about their state and break later partition decreases (which rely on `currentRev != updateRev` to be recognized as in-rollout).
3. `set.Status.UpdateRevision == updateRev` AND `set.Status.UpdatedReplicas >= replicas - partition` from the previously persisted status. This forces the "all base updated" observation to survive at least one full reconcile.
4. `updateExpectations` are satisfied (no in-flight in-place updates pending API ack).
5. Observed snapshot for every base ord `[partition, replicas)`: at `updateRev`, `isCreated`, `isHealthy`, `!isTerminating`, and `inst.Status.ObservedGeneration >= inst.Generation`.

`inPlaceUpdateInstance` deliberately does not mutate the in-memory revision label after a successful patch — keeping the snapshot honest is what lets the advance guard rely on it.

**Files touched**

- `pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go` — adds `topology`, `computeTopology`, `computeMaxSurge`, `computeMaxUnavailable`, `computePartition`, `countHealthyOldInBase`, `countExistingValidSurge`, `allBaseAtUpdateRevHealthy`.
- `pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go` — `updateStatefulInstanceSet` reshaped into Phase A–D; `progressUpdate`, `countAvailableSurge`, `collectBaseUnavailable`, `buildUpdateTargets`, `applyTargetUpdate`, `countUnhealthy`, `shouldAdvanceCurrentRevision`, `observeInstanceHealth`, `isStablyUnhealthy` introduced; `rollingUpdateInstances`, `updateInstancesInSequence`, `getMaxUnavailable` (method), `collectUnavailableInstances`, `sortInstancesToUpdate` removed; in-memory revision-label write in `inPlaceUpdateInstance` removed.
- `pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_controller.go` — adds the global `instanceUnhealthySince sync.Map` backing the stable-unhealthy gate.
- `test/wrappers/v1alpha2/role_wrapper.go` — adds `WithRollingUpdate` helper used by e2e tests.
- `test/e2e/testcase/v1alpha2/ris.go` and `test/e2e/e2e_test.go` — registers the new e2e specs.


### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Unit tests in `stateful_instance_set_control_test.go`:

- `TestComputeTopology` — table-driven; covers no-rollout, paused, surge sizing under healthy-old base, all-unhealthy base (`activeSurge=0`), `maxUnavailable` partially / fully covering `surgeNeeded`, partition, stale-rev surge condemnation, surge stickiness across reconciles, partition rollout completion (sticky surge dropped so it can be condemned), and partition decrease (newly-exposed ord triggers surge allocation).
- `TestProgressUpdateBudget` — uses an in-package `fakeInstanceObjectManager` and `fakeInplaceControl` to assert which instances get deleted; covers free-vs-costly budgeting under each combination of `maxUnavailable`, `availableSurge`, and `partition`, plus chained rollout with stale-rev surge slots inside `[replicas, endOrdinal)` (Pending and Healthy variants), and the stable-unhealthy gate (a fresh-unhealthy instance is NOT free-deleted; one that has been seeded as stably-unhealthy IS).
- `TestShouldAdvanceCurrentRevision` — exercises each guard layer individually plus the happy path; covers `partition>0` (must not advance), `ObservedGeneration` lag, terminating instances, and prior-status concurrence.
- `TestObserveInstanceHealthAndIsStablyUnhealthy` and `TestIsStablyUnhealthyEdgeCases` — verify the per-UID timestamp lifecycle: unhealthy is recorded on first observation, cleared on healthy observation, evicted when the UID disappears, and the gate only fires once `stableUnhealthyDuration` has elapsed.

E2E tests in `test/e2e/testcase/v1alpha2/ris.go`:

- **`[RoleInstanceSet] surge maintains full readiness during rolling update`** — `replicas=4, maxSurge=2, maxUnavailable=0`; trigger a rolling update and assert ready count never drops below `replicas` during the entire rollout, surge instances are created and then cleaned up, final total returns to 4.
- **`[RoleInstanceSet] surge with maxUnavailable allows faster update with minimum readiness`** — `replicas=4, maxSurge=2, maxUnavailable=2`; observe the expected intermediate state (`total=6, ready=2`, only ords 0,1 ready), then progress to all-ready and surge cleanup.
- **`[RoleInstanceSet] large maxSurge is capped at replicas count`** — `replicas=2, maxSurge=4`; assert total instance count never exceeds `replicas + replicas = 4` (the sizing cap kicks in when `maxSurge > replicas`).
- **`[RoleInstanceSet] partition decrease progressively rolls more ordinals`** — `replicas=2, maxSurge=0, maxUnavailable=1, partition=1`; trigger a template change → only ord 1 rolls, ord 0 stays at the original revision throughout (`Consistently` for 20s); then lower partition to 0 → ord 0 picks up the new revision. Total instance count stays at 2 the entire time (no surge involved).


### Ⅴ. Describe how to verify it
1. Deploy the latest RBG controller.
2. Create any RBG with a role that has `replicas=4`, `maxSurge=2`, `maxUnavailable=0`, and a pod startup probe with at least 5s `initialDelaySeconds` so that pods stay NotReady long enough to observe intermediate states.
3. Wait for all pods to become Ready.
4. Update the role (e.g. change the startup probe delay or any pod template field) to trigger a rolling update.
5. Observe that:
    - Surge instances are created during the rolling update (instance count = replicas + surge = 6).
    - The number of Ready instances never drops below `replicas` (stays = 4 when maxUnavailable=0).
    - After the update completes, surge instances are cleaned up and the instance count returns to replicas.
6. Verify partition behavior: set `partition=2` and observe that:
    - Only ordinals >= 2 are updated; ordinals 0,1 keep old revision and stay ready throughout.
    - Surge instances are created for the partition range and cleaned up once partition-range instances are stable.
    - Final state: ordinals 0,1 on old revision, ordinals 2,3 on new revision, no surge instances.


### VI. Special notes for reviews


## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
