### PR TITLE
fix(controller): clean up stale RoleInstances on stateful/stateless pattern switch

### DIFF
--- a/internal/controller/workloads/roleinstanceset_controller.go
+++ b/internal/controller/workloads/roleinstanceset_controller.go
@@ -19,10 +19,13 @@ package workloads
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -73,6 +76,13 @@ func (r *RoleInstanceSetReconciler) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{}, err
 	}
 
+	// Clean up RoleInstances that belong to a different pattern than the current one.
+	// This handles the case where the pattern annotation is changed (stateful ↔ stateless),
+	// leaving behind instances from the old pattern that the new reconciler won't manage.
+	if requeue, err := r.cleanupStaleInstances(ctx, set); err != nil || requeue {
+		return reconcile.Result{Requeue: requeue}, err
+	}
+
 	// Dispatch based on the role instance pattern annotation
 	pattern := constants.InstancePatternType(set.Annotations[constants.RoleInstancePatternKey])
 	switch pattern {
@@ -85,6 +95,59 @@ func (r *RoleInstanceSetReconciler) Reconcile(ctx context.Context, request recon
 		err := fmt.Errorf("unknown role instance pattern %q", pattern)
 		r.recorder.Event(set, corev1.EventTypeWarning, "UnknownRoleInstancePattern", err.Error())
 		return reconcile.Result{}, err
+	}
+}
+
+// cleanupStaleInstances lists all RoleInstances owned by the set and deletes those
+// that don't belong to the current pattern. Returns true if any instance was deleted
+// (caller should requeue to wait for deletion and let the new reconciler create fresh instances).
+func (r *RoleInstanceSetReconciler) cleanupStaleInstances(ctx context.Context, set *v1alpha2.RoleInstanceSet) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
+	if err != nil {
+		return false, err
+	}
+
+	instanceList := &v1alpha2.RoleInstanceList{}
+	if err := r.client.List(ctx, instanceList,
+		client.InNamespace(set.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return false, err
+	}
+
+	pattern := constants.InstancePatternType(set.Annotations[constants.RoleInstancePatternKey])
+	var deleted bool
+	for i := range instanceList.Items {
+		instance := &instanceList.Items[i]
+		if !metav1.IsControlledBy(instance, set) {
+			continue
+		}
+		if instanceBelongsToPattern(instance, set, pattern) {
+			continue
+		}
+		klog.InfoS("Deleting stale RoleInstance from different pattern", "instanceSet", klog.KObj(set), "instance", klog.KObj(instance), "currentPattern", pattern)
+		if err := r.client.Delete(ctx, instance); err != nil && !errors.IsNotFound(err) {
+			return false, err
+		}
+		deleted = true
+	}
+	return deleted, nil
+}
+
+// statefulInstanceNameRegex extracts the parent name and ordinal from a stateful instance name.
+var statefulInstanceNameRegex = regexp.MustCompile(`^(.*)-(\d+)$`)
+
+// instanceBelongsToPattern returns true if the instance was created by the given pattern.
+func instanceBelongsToPattern(instance *v1alpha2.RoleInstance, set *v1alpha2.RoleInstanceSet, pattern constants.InstancePatternType) bool {
+	switch pattern {
+	case constants.StatelessPattern:
+		return instance.Labels[constants.RoleInstanceOwnerLabelKey] == string(set.UID)
+	case constants.StatefulPattern, "":
+		// Stateful instances follow the ordinal naming pattern: {setName}-{ordinal}
+		subMatch := statefulInstanceNameRegex.FindStringSubmatch(instance.Name)
+		return len(subMatch) == 3 && subMatch[1] == set.Name
+	default:
+		return true
 	}
 }
 

--- a/internal/controller/workloads/roleinstanceset_controller_test.go
+++ b/internal/controller/workloads/roleinstanceset_controller_test.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = workloadsv1alpha2.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return scheme
+}
+
+func TestInstanceBelongsToPattern(t *testing.T) {
+	setUID := types.UID("test-set-uid-1234")
+	set := &workloadsv1alpha2.RoleInstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-prefill",
+			UID:  setUID,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		instance *workloadsv1alpha2.RoleInstance
+		pattern  constants.InstancePatternType
+		want     bool
+	}{
+		{
+			name: "stateless instance matches StatelessPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-prefill-7jj4f",
+					Labels: map[string]string{
+						constants.RoleInstanceOwnerLabelKey: string(setUID),
+					},
+				},
+			},
+			pattern: constants.StatelessPattern,
+			want:    true,
+		},
+		{
+			name: "stateless instance missing owner label does not match StatelessPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-prefill-7jj4f",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: constants.StatelessPattern,
+			want:    false,
+		},
+		{
+			name: "stateless instance with wrong UID does not match StatelessPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-prefill-7jj4f",
+					Labels: map[string]string{
+						constants.RoleInstanceOwnerLabelKey: "wrong-uid",
+					},
+				},
+			},
+			pattern: constants.StatelessPattern,
+			want:    false,
+		},
+		{
+			name: "stateful instance with ordinal matches StatefulPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-prefill-0",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: constants.StatefulPattern,
+			want:    true,
+		},
+		{
+			name: "stateful instance with ordinal matches empty pattern (default stateful)",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-prefill-1",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: "",
+			want:    true,
+		},
+		{
+			name: "random-ID instance does not match StatefulPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-prefill-7jj4f",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: constants.StatefulPattern,
+			want:    false,
+		},
+		{
+			name: "stateful instance with wrong parent name does not match StatefulPattern",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "other-set-0",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: constants.StatefulPattern,
+			want:    false,
+		},
+		{
+			name: "unknown pattern always matches",
+			instance: &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "anything",
+					Labels: map[string]string{},
+				},
+			},
+			pattern: "Unknown",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := instanceBelongsToPattern(tt.instance, set, tt.pattern)
+			if got != tt.want {
+				t.Errorf("instanceBelongsToPattern() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanupStaleInstances(t *testing.T) {
+	setUID := types.UID("test-set-uid-1234")
+	matchLabels := map[string]string{
+		"app": "test-prefill",
+	}
+
+	newTestSet := func(pattern string) *workloadsv1alpha2.RoleInstanceSet {
+		return &workloadsv1alpha2.RoleInstanceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-prefill",
+				Namespace:   "default",
+				UID:         setUID,
+				Annotations: map[string]string{constants.RoleInstancePatternKey: pattern},
+			},
+			Spec: workloadsv1alpha2.RoleInstanceSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: matchLabels},
+				Replicas: ptr.To(int32(2)),
+			},
+		}
+	}
+
+	// stateful instance: ordinal name, no RoleInstanceOwnerLabelKey
+	newStatefulInstance := func(name string) *workloadsv1alpha2.RoleInstance {
+		return &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    matchLabels,
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(newTestSet("Stateful"), workloadsv1alpha2.GroupVersion.WithKind("RoleInstanceSet")),
+				},
+			},
+		}
+	}
+
+	// stateless instance: random-ID name, has RoleInstanceOwnerLabelKey
+	newStatelessInstance := func(name string) *workloadsv1alpha2.RoleInstance {
+		return &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: func() map[string]string {
+					l := map[string]string{
+						constants.RoleInstanceOwnerLabelKey: string(setUID),
+					}
+					for k, v := range matchLabels {
+						l[k] = v
+					}
+					return l
+				}(),
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(newTestSet("Stateless"), workloadsv1alpha2.GroupVersion.WithKind("RoleInstanceSet")),
+				},
+			},
+		}
+	}
+
+	// instance owned by another set (not controlled by our set)
+	newForeignInstance := func(name string) *workloadsv1alpha2.RoleInstance {
+		return &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    matchLabels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "workloads.x-k8s.io/v1alpha2",
+						Kind:       "RoleInstanceSet",
+						Name:       "other-set",
+						UID:        "other-uid",
+						Controller: ptr.To(true),
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		setPattern       string
+		initialInstances []*workloadsv1alpha2.RoleInstance
+		wantRequeue      bool
+		wantRemaining    int // expected number of instances remaining after cleanup
+		wantDeletedNames []string
+	}{
+		{
+			name:       "stateful set with matching instances: no cleanup needed",
+			setPattern: string(constants.StatefulPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatefulInstance("test-prefill-0"),
+				newStatefulInstance("test-prefill-1"),
+			},
+			wantRequeue:   false,
+			wantRemaining: 2,
+		},
+		{
+			name:       "stateless set with matching instances: no cleanup needed",
+			setPattern: string(constants.StatelessPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatelessInstance("test-prefill-7jj4f"),
+				newStatelessInstance("test-prefill-jdggk"),
+			},
+			wantRequeue:   false,
+			wantRemaining: 2,
+		},
+		{
+			name:       "switch from stateful to stateless: stale stateful instances deleted",
+			setPattern: string(constants.StatelessPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatefulInstance("test-prefill-0"),
+				newStatefulInstance("test-prefill-1"),
+			},
+			wantRequeue:      true,
+			wantRemaining:    0,
+			wantDeletedNames: []string{"test-prefill-0", "test-prefill-1"},
+		},
+		{
+			name:       "switch from stateless to stateful: stale stateless instances deleted",
+			setPattern: string(constants.StatefulPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatelessInstance("test-prefill-7jj4f"),
+				newStatelessInstance("test-prefill-jdggk"),
+			},
+			wantRequeue:      true,
+			wantRemaining:    0,
+			wantDeletedNames: []string{"test-prefill-7jj4f", "test-prefill-jdggk"},
+		},
+		{
+			name:       "mixed instances with stateless pattern: only stale stateful instances deleted",
+			setPattern: string(constants.StatelessPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatelessInstance("test-prefill-7jj4f"),
+				newStatefulInstance("test-prefill-0"),
+			},
+			wantRequeue:      true,
+			wantRemaining:    1,
+			wantDeletedNames: []string{"test-prefill-0"},
+		},
+		{
+			name:       "mixed instances with stateful pattern: only stale stateless instances deleted",
+			setPattern: string(constants.StatefulPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatefulInstance("test-prefill-0"),
+				newStatelessInstance("test-prefill-7jj4f"),
+			},
+			wantRequeue:      true,
+			wantRemaining:    1,
+			wantDeletedNames: []string{"test-prefill-7jj4f"},
+		},
+		{
+			name:       "foreign instances are not deleted",
+			setPattern: string(constants.StatefulPattern),
+			initialInstances: []*workloadsv1alpha2.RoleInstance{
+				newStatefulInstance("test-prefill-0"),
+				newForeignInstance("test-prefill-abc"),
+			},
+			wantRequeue:   false,
+			wantRemaining: 2,
+		},
+		{
+			name:             "no instances: no cleanup needed",
+			setPattern:       string(constants.StatefulPattern),
+			initialInstances: nil,
+			wantRequeue:      false,
+			wantRemaining:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			set := newTestSet(tt.setPattern)
+
+			objs := []runtime.Object{set}
+			for _, inst := range tt.initialInstances {
+				objs = append(objs, inst)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+			r := &RoleInstanceSetReconciler{
+				client:   c,
+				recorder: record.NewFakeRecorder(0),
+			}
+
+			requeue, err := r.cleanupStaleInstances(context.Background(), set)
+			if err != nil {
+				t.Fatalf("cleanupStaleInstances() error = %v", err)
+			}
+			if requeue != tt.wantRequeue {
+				t.Errorf("cleanupStaleInstances() requeue = %v, want %v", requeue, tt.wantRequeue)
+			}
+
+			// Verify remaining instances
+			instanceList := &workloadsv1alpha2.RoleInstanceList{}
+			if err := c.List(context.Background(), instanceList); err != nil {
+				t.Fatalf("List instances error = %v", err)
+			}
+			if len(instanceList.Items) != tt.wantRemaining {
+				t.Errorf("remaining instances = %d, want %d", len(instanceList.Items), tt.wantRemaining)
+			}
+
+			// Verify specific deletions
+			if len(tt.wantDeletedNames) > 0 {
+				remainingNames := map[string]bool{}
+				for _, inst := range instanceList.Items {
+					remainingNames[inst.Name] = true
+				}
+				for _, name := range tt.wantDeletedNames {
+					if remainingNames[name] {
+						t.Errorf("instance %s should have been deleted but still exists", name)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation

When a RoleInstanceSet switches between stateful and stateless patterns (by changing the `rbg.workloads.x-k8s.io/role-instance-pattern` annotation), only the annotation on the RoleInstanceSet is updated while existing RoleInstances from the old pattern are not cleaned up. This results in stale instances (and their Pods) remaining running alongside newly created ones, effectively doubling the number of running Pods.

**Root cause:**
- **Stateful → Stateless**: Stateful instances lack the `RoleInstanceOwnerLabelKey` label that the stateless selector relies on, so the stateless reconciler cannot see them and creates new instances alongside.
- **Stateless → Stateful**: Stateless instances have random-ID names (e.g., `test-prefill-7jj4f`) that don't match the ordinal naming pattern (`test-prefill-{N}`), so the stateful reconciler's `isMemberOf` filter rejects them — releasing their OwnerReference but not deleting them.

Example of the issue:
```
kubectl get po
test-prefill-0-leader-0       1/1     Running   0          2m42s   # stale (stateful)
test-prefill-0-worker-0       1/1     Running   0          2m42s   # stale (stateful)
test-prefill-1-leader-0       1/1     Running   0          2m42s   # stale (stateful)
test-prefill-1-worker-0       1/1     Running   0          2m42s   # stale (stateful)
test-prefill-7jj4f-leader-0   1/1     Running   0          119s    # new (stateless)
test-prefill-7jj4f-worker-0   1/1     Running   0          119s    # new (stateless)
test-prefill-jdggk-leader-0   1/1     Running   0          119s    # new (stateless)
test-prefill-jdggk-worker-0   1/1     Running   0          119s    # new (stateless)
```

### Ⅱ. Modifications

- **`internal/controller/workloads/roleinstanceset_controller.go`**: Added `cleanupStaleInstances` and `instanceBelongsToPattern` functions in the dispatch reconciler. Before dispatching to the mode-specific reconciler, the dispatch layer now lists all RoleInstances owned by the set (via `spec.selector.matchLabels` which both stateful and stateless instances carry) and deletes any that don't belong to the current pattern:
  - **Stateless pattern**: instance must have `RoleInstanceOwnerLabelKey: UID` label
  - **Stateful pattern**: instance name must match `{setName}-{ordinal}` pattern
  - If any stale instances are deleted, the reconciler requeues to allow deletions to complete before the new mode reconciler creates fresh instances.
- **`internal/controller/workloads/roleinstanceset_controller_test.go`**: Added unit tests covering 16 scenarios for `instanceBelongsToPattern` (8 cases) and `cleanupStaleInstances` (8 cases), including both switch directions, mixed instances, foreign instances, and no-op cases.

No new annotations, API fields, or CRD changes are required.

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

**`TestInstanceBelongsToPattern`** — 8 cases:
- Stateless instance with matching `RoleInstanceOwnerLabelKey` label → true
- Stateless instance missing the label → false
- Stateless instance with wrong UID label → false
- Stateful instance with ordinal name matching set name → true
- Stateful instance with ordinal name under empty pattern (default stateful) → true
- Random-ID instance under StatefulPattern → false
- Stateful instance with wrong parent name → false
- Unknown pattern → true (safe default)

**`TestCleanupStaleInstances`** — 8 cases:
- Stateful set with matching instances → no deletion, no requeue
- Stateless set with matching instances → no deletion, no requeue
- Stateful → Stateless switch → stale stateful instances deleted, requeue
- Stateless → Stateful switch → stale stateless instances deleted, requeue
- Mixed instances under StatelessPattern → only stale stateful instances deleted
- Mixed instances under StatefulPattern → only stale stateless instances deleted
- Foreign instances (owned by another set) → not deleted
- No instances → no-op

### Ⅴ. Describe how to verify it

1. Create an RBG with a role that defaults to Stateful pattern
2. Wait for RoleInstances to be created with ordinal names (e.g., `test-prefill-0`, `test-prefill-1`)
3. Change the `rbg.workloads.x-k8s.io/role-instance-pattern` annotation to `Stateless`
4. Verify that the old stateful RoleInstances are deleted and new stateless instances are created
5. Verify the total number of RoleInstances equals `spec.replicas` (no duplicates)
6. Repeat the test in the reverse direction (Stateless → Stateful)

### VI. Special notes for reviews

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
