### PR TITLE
fix(rbg): resolve RestartInProgress condition stuck due to SSA race

### DIFF
--- a/internal/controller/workloads/pod_controller.go
+++ b/internal/controller/workloads/pod_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -128,43 +127,38 @@ func (r *PodReconciler) restartRBG(ctx context.Context, rbg *workloadsv1alpha2.R
 func (r *PodReconciler) setRestartCondition(
 	ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup, restartCompleted bool,
 ) error {
-	var restartCondition metav1.Condition
+	var condStatus metav1.ConditionStatus
+	var reason, message string
 	if restartCompleted {
-		restartCondition = metav1.Condition{
-			Type:               string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
-			Status:             metav1.ConditionStatus(corev1.ConditionFalse),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "RBGRestartCompleted",
-			Message:            "RBG Restart Completed",
-		}
+		condStatus = metav1.ConditionFalse
+		reason = "RBGRestartCompleted"
+		message = "RBG Restart Completed"
 	} else {
-		restartCondition = metav1.Condition{
-			Type:               string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
-			Status:             metav1.ConditionStatus(corev1.ConditionTrue),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "RBGRestart",
-			Message:            "RBG Restart in progress",
-		}
+		condStatus = metav1.ConditionTrue
+		reason = "RBGRestart"
+		message = "RBG Restart in progress"
 	}
-	restartCondition.ObservedGeneration = rbg.Generation
 
-	// Use RetryOnConflict + UpdateStatus to avoid SSA field-manager ownership conflicts.
-	// RoleBasedGroupStatus.Conditions is an atomic list in SSA, so two field managers cannot
-	// safely manage different entries. Instead, we use a standard UpdateStatus with optimistic
-	// locking: re-fetch the latest RBG from the API server (NOT the informer cache), merge
-	// the RestartInProgress condition, then update.
-	// IMPORTANT: We use apiReader (non-caching) to read the latest RBG from the API server.
-	// Using the caching client would risk a read-modify-write race: if the informer cache is
-	// stale, we would overwrite status fields (e.g. RoleStatuses, Ready condition) that were
-	// updated by the RBG controller but not yet reflected in the cache.
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		latest := &workloadsv1alpha2.RoleBasedGroup{}
-		if err := r.apiReader.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latest); err != nil {
-			return err
-		}
-		meta.SetStatusCondition(&latest.Status.Conditions, restartCondition)
-		return r.client.Status().Update(ctx, latest)
-	})
+	// Use SSA with PodControllerFieldManager to set the RestartInProgress condition.
+	// Since conditions is a listType=map (keyed by type), each field manager owns its own entries.
+	// This eliminates the race condition where the RBG controller's Force=true SSA patch could
+	// overwrite our Status().Update() — now both controllers use SSA with separate field managers,
+	// and each only touches the condition entries it owns.
+	now := metav1.Now()
+	gvk := utils.GetRbgGVK()
+	rbgApplyConfig := applyconfiguration.RoleBasedGroup(rbg.Name, rbg.Namespace).
+		WithKind(gvk.Kind).
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithStatus(applyconfiguration.RoleBasedGroupStatus().
+			WithConditions(metav1ac.Condition().
+				WithType(string(workloadsv1alpha2.RoleBasedGroupRestartInProgress)).
+				WithStatus(condStatus).
+				WithLastTransitionTime(now).
+				WithReason(reason).
+				WithMessage(message).
+				WithObservedGeneration(rbg.Generation)))
+
+	return utils.PatchStatusWithFieldManager(ctx, r.client, rbgApplyConfig, utils.PodControllerFieldManager)
 }
 
 func restartConditionTrue(status workloadsv1alpha2.RoleBasedGroupStatus) bool {

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -31,7 +31,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -754,44 +753,41 @@ func (r *RoleBasedGroupReconciler) updateRBGStatus(
 		}
 	}
 
-	// CRITICAL: Preserve the RestartInProgress condition managed by the pod controller.
-	// This condition is written by PodReconciler via RetryOnConflict+UpdateStatus (not SSA),
-	// so the informer cache may be stale. Always read from the API server to get the
-	// authoritative value and avoid overwriting a False→True transition back to True.
-	latestRBG := &workloadsv1alpha2.RoleBasedGroup{}
-	if err := r.apiReader.Get(ctx, types.NamespacedName{Name: rbg.Name, Namespace: rbg.Namespace}, latestRBG); err != nil {
-		logger := log.FromContext(ctx)
-		logger.Error(err, "Failed to get latest RBG from API server, falling back to cache for RestartInProgress")
-		// Fall back to cached condition if API server is unavailable
-		restartCond := apimeta.FindStatusCondition(
-			rbg.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
-		)
-		if restartCond != nil {
-			apimeta.SetStatusCondition(&rbg.Status.Conditions, *restartCond)
-		}
-	} else {
-		restartCond := apimeta.FindStatusCondition(
-			latestRBG.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupRestartInProgress),
-		)
-		if restartCond != nil {
-			apimeta.SetStatusCondition(&rbg.Status.Conditions, *restartCond)
+	// Filter out RestartInProgress from conditions before SSA patch.
+	// RestartInProgress is exclusively owned by the pod controller (via PodControllerFieldManager SSA).
+	// Since conditions is a listType=map (keyed by type), each field manager owns its own entries.
+	// The RBG controller must NOT include RestartInProgress in its patch to avoid overwriting
+	// the pod controller's updates due to race conditions between the two controllers.
+	ownedConditions := make([]metav1.Condition, 0, len(rbg.Status.Conditions))
+	for _, c := range rbg.Status.Conditions {
+		if c.Type != string(workloadsv1alpha2.RoleBasedGroupRestartInProgress) {
+			ownedConditions = append(ownedConditions, c)
 		}
 	}
 
 	// Skip SSA patch if status hasn't changed. This avoids unnecessary API calls
 	// and reduces load on the API server, especially important now that
 	// constructAndUpdateRoleStatuses calls this method on every reconcile.
-	if reflect.DeepEqual(oldStatus, rbg.Status) {
+	// Compare only the fields we own (excluding RestartInProgress).
+	oldOwnedConditions := make([]metav1.Condition, 0, len(oldStatus.Conditions))
+	for _, c := range oldStatus.Conditions {
+		if c.Type != string(workloadsv1alpha2.RoleBasedGroupRestartInProgress) {
+			oldOwnedConditions = append(oldOwnedConditions, c)
+		}
+	}
+	oldStatusForCompare := oldStatus
+	oldStatusForCompare.Conditions = oldOwnedConditions
+	newStatusForCompare := *rbg.Status.DeepCopy()
+	newStatusForCompare.Conditions = ownedConditions
+	if reflect.DeepEqual(oldStatusForCompare, newStatusForCompare) {
 		log.FromContext(ctx).V(2).Info("RBG status unchanged, skipping SSA patch")
 		return nil
 	}
 
-	// update rbg status using SSA patch.
-	// IMPORTANT: We must preserve the RestartInProgress condition managed by pod controller.
-	// The above code fetches the latest RBG from API server (bypassing informer cache) and
-	// preserves any RestartInProgress condition. This prevents SSA with Force=true from
-	// overwriting conditions set by other controllers due to informer cache latency.
-	rbgApplyConfig := ToRBGApplyConfigurationForStatus(rbg)
+	// Update rbg status using SSA patch with only conditions owned by the RBG controller.
+	// RestartInProgress is managed by the pod controller with its own field manager,
+	// so SSA map-type list semantics ensure the two controllers cannot interfere.
+	rbgApplyConfig := ToRBGApplyConfigurationForStatusWithConditions(rbg, ownedConditions)
 
 	return utils.PatchObjectApplyConfiguration(ctx, r.client, rbgApplyConfig, utils.PatchStatus)
 


### PR DESCRIPTION
The RestartInProgress condition could get permanently stuck at True because of a race between the RBG controller's Force=true SSA patch and the Pod controller's Status().Update(). When the RBG controller read the condition before the Pod controller's update was visible, the SSA patch would overwrite False back to True with no subsequent event to correct it.

Fix: use separate SSA field managers for each controller. The RBG controller now excludes RestartInProgress from its SSA patch, and the Pod controller uses SSA with PodControllerFieldManager. Since conditions is listType=map, each field manager owns its entries independently, eliminating the race entirely.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
