### PR TITLE
fix(rbg): use status.Replicas instead of spec.Replicas for RBG role s…

### DIFF
--- a/pkg/reconciler/deploy_reconciler.go
+++ b/pkg/reconciler/deploy_reconciler.go
@@ -228,7 +228,7 @@ func (r *DeploymentReconciler) ConstructRoleStatus(
 	}
 
 	return ConstructWorkloadRoleStatus(ctx, rbg, role,
-		*deploy.Spec.Replicas, deploy.Status.ReadyReplicas, deploy.Status.UpdatedReplicas,
+		deploy.Status.Replicas, deploy.Status.ReadyReplicas, deploy.Status.UpdatedReplicas,
 		deploy.Generation, deploy.Status.ObservedGeneration), nil
 }
 

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -434,7 +434,7 @@ func (r *RoleInstanceSetReconciler) ConstructRoleStatus(
 		return workloadsv1alpha2.RoleStatus{Name: role.Name}, err
 	}
 	return ConstructWorkloadRoleStatus(ctx, rbg, role,
-		*roleInstanceSet.Spec.Replicas, roleInstanceSet.Status.ReadyReplicas, roleInstanceSet.Status.UpdatedReplicas,
+		roleInstanceSet.Status.Replicas, roleInstanceSet.Status.ReadyReplicas, roleInstanceSet.Status.UpdatedReplicas,
 		roleInstanceSet.Generation, roleInstanceSet.Status.ObservedGeneration), nil
 }
 

--- a/pkg/reconciler/sts_reconciler.go
+++ b/pkg/reconciler/sts_reconciler.go
@@ -517,7 +517,7 @@ func (r *StatefulSetReconciler) ConstructRoleStatus(
 		return workloadsv1alpha2.RoleStatus{Name: role.Name}, err
 	}
 	return ConstructWorkloadRoleStatus(ctx, rbg, role,
-		*sts.Spec.Replicas, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas,
+		sts.Status.Replicas, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas,
 		sts.Generation, sts.Status.ObservedGeneration), nil
 }
 


### PR DESCRIPTION
…tatus

ConstructRoleStatus was reading spec.Replicas (desired) rather than status.Replicas (actual) when reporting RBG role status, causing inconsistent status during scaling or partial pod creation.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
