### PR TITLE
feat: add --enable-pprof flag for runtime profiling

### DIFF
--- a/cmd/rbgs/main.go
+++ b/cmd/rbgs/main.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -441,12 +442,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx := ctrl.SetupSignalHandler()
+
 	if enablePprof {
-		startPprofServer(pprofAddr)
+		if err := startPprofServer(ctx, pprofAddr); err != nil {
+			setupLog.Error(err, "unable to start pprof server")
+			os.Exit(1)
+		}
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
@@ -550,9 +556,7 @@ func setupWebhookCertController(mgr ctrl.Manager, result *webhookBootstrapResult
 	return webhookCertReconciler.SetupWithManager(mgr, options)
 }
 
-func startPprofServer(pprofAddr string) {
-	setupLog.Info("Enabling pprof", "addr", pprofAddr)
-
+func startPprofServer(ctx context.Context, pprofAddr string) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -560,31 +564,34 @@ func startPprofServer(pprofAddr string) {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
+	listener, err := net.Listen("tcp", pprofAddr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", pprofAddr, err)
+	}
+
 	pprofServer := http.Server{
-		Addr:              pprofAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	setupLog.Info("Starting pprof HTTP server", "addr", pprofServer.Addr)
+	setupLog.Info("Starting pprof HTTP server", "addr", pprofAddr)
 
 	go func() {
-		go func() {
-			ctx := context.Background()
-			<-ctx.Done()
-
-			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), 60*time.Second)
-			defer cancelFunc()
-
-			if err := pprofServer.Shutdown(shutdownCtx); err != nil {
-				setupLog.Error(err, "Failed to shutdown pprof HTTP server")
-			}
-		}()
-
-		if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			setupLog.Error(err, "Failed to start pprof HTTP server")
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "Failed to shutdown pprof HTTP server")
 		}
 	}()
+
+	go func() {
+		if err := pprofServer.Serve(listener); !errors.Is(err, http.ErrServerClosed) {
+			setupLog.Error(err, "pprof HTTP server error")
+		}
+	}()
+
+	return nil
 }
 
 func cacheOptions() cache.Options {

--- a/cmd/rbgs/main.go
+++ b/cmd/rbgs/main.go
@@ -19,8 +19,11 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
@@ -140,6 +143,9 @@ func main() {
 		kubeAPIBurst int
 		// Gang scheduling scheduler name: scheduler-plugins or volcano
 		schedulerName string
+		// Pprof profiling
+		enablePprof bool
+		pprofAddr   string
 	)
 	flag.StringVar(
 		&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -196,6 +202,8 @@ func main() {
 		"Maximum burst for throttle from this controller to the Kubernetes API server. "+
 			"Should be set higher than --kube-api-qps.",
 	)
+	flag.BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof profiling server for performance debugging.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", ":6060", "The address the pprof endpoint binds to.")
 
 	// Register logger flags before Parse so that zap flags (--zap-log-level etc.) are recognized.
 	opts := zap.Options{
@@ -433,6 +441,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if enablePprof {
+		startPprofServer(pprofAddr)
+	}
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
@@ -536,6 +548,43 @@ func setupWebhookCertController(mgr ctrl.Manager, result *webhookBootstrapResult
 		CRDNames:    rbgwebhook.ConversionWebhookCRDs(),
 	}
 	return webhookCertReconciler.SetupWithManager(mgr, options)
+}
+
+func startPprofServer(pprofAddr string) {
+	setupLog.Info("Enabling pprof", "addr", pprofAddr)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	pprofServer := http.Server{
+		Addr:              pprofAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	setupLog.Info("Starting pprof HTTP server", "addr", pprofServer.Addr)
+
+	go func() {
+		go func() {
+			ctx := context.Background()
+			<-ctx.Done()
+
+			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancelFunc()
+
+			if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+				setupLog.Error(err, "Failed to shutdown pprof HTTP server")
+			}
+		}()
+
+		if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			setupLog.Error(err, "Failed to start pprof HTTP server")
+		}
+	}()
 }
 
 func cacheOptions() cache.Options {

--- a/deploy/helm/rbgs/templates/manager.yaml
+++ b/deploy/helm/rbgs/templates/manager.yaml
@@ -44,6 +44,10 @@ spec:
             - --port-range={{ .Values.portAllocator.portRange | default 5000 }}
             {{- end }}
             - --scheduler-name={{ .Values.schedulerName | default "scheduler-plugins" }}
+            {{- if .Values.pprof.enabled }}
+            - --enable-pprof=true
+            - --pprof-bind-address=:{{ .Values.pprof.port | default 6060 }}
+            {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -55,6 +59,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.pprof.enabled }}
+          ports:
+            - name: pprof
+              containerPort: {{ .Values.pprof.port | default 6060 }}
+              protocol: TCP
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/rbgs/templates/manager.yaml
+++ b/deploy/helm/rbgs/templates/manager.yaml
@@ -46,7 +46,7 @@ spec:
             - --scheduler-name={{ .Values.schedulerName | default "scheduler-plugins" }}
             {{- if .Values.pprof.enabled }}
             - --enable-pprof=true
-            - --pprof-bind-address=:{{ .Values.pprof.port | default 6060 }}
+            - --pprof-bind-address={{ .Values.pprof.bindAddress | default ":6060" }}
             {{- end }}
           env:
             - name: POD_NAMESPACE
@@ -62,7 +62,7 @@ spec:
           {{- if .Values.pprof.enabled }}
           ports:
             - name: pprof
-              containerPort: {{ .Values.pprof.port | default 6060 }}
+              containerPort: {{ .Values.pprof.containerPort | default 6060 }}
               protocol: TCP
           {{- end }}
           resources:

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -50,6 +50,12 @@ controllerTuning:
   # Should be set higher than kubeApiQPS.
   kubeApiBurst: 30
 
+# Pprof profiling server configuration.
+# When enabled, exposes pprof endpoints for performance debugging.
+pprof:
+  enabled: false
+  port: 6060
+
 crdUpgrade:
   # Whether to enable CRD Upgrader Job (runs before install/upgrade)
   enabled: true

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -54,7 +54,10 @@ controllerTuning:
 # When enabled, exposes pprof endpoints for performance debugging.
 pprof:
   enabled: false
-  port: 6060
+  # The address the pprof endpoint binds to.
+  bindAddress: ":6060"
+  # The container port exposed for pprof (used in pod spec).
+  containerPort: 6060
 
 crdUpgrade:
   # Whether to enable CRD Upgrader Job (runs before install/upgrade)

--- a/doc/dev/how_to_develop.md
+++ b/doc/dev/how_to_develop.md
@@ -274,6 +274,78 @@ The RGB controller supports local operation or debugging. Before running the con
     $ ./bin/manager --development=true --health-probe-bind-address=:8082
     ```
 
+### Profiling with pprof
+
+The controller has a built-in pprof server that can be enabled for performance debugging and stress testing.
+
+#### Running Locally with pprof
+
+```shell
+# Build and run with pprof enabled
+make build
+./bin/manager --enable-webhooks=none --enable-pprof=true --pprof-bind-address=:6060
+```
+
+#### Deploying with pprof via Helm
+
+Set `pprof.enabled=true` in your Helm values:
+
+```shell
+helm upgrade --install rbgs deploy/helm/rbgs \
+    --namespace rbgs-system \
+    --set pprof.enabled=true \
+    --set pprof.port=6060
+```
+
+Or in `values.yaml`:
+
+```yaml
+pprof:
+  enabled: true
+  port: 6060
+```
+
+#### Collecting Profiles
+
+Once the pprof server is running, collect profiles with:
+
+```shell
+# If running locally
+PPROF_ADDR=localhost:6060
+
+# If deployed in cluster, port-forward first
+kubectl port-forward -n rbgs-system deploy/rbgs-controller-manager 6060:6060 &
+PPROF_ADDR=localhost:6060
+
+# Heap (memory) profile
+curl -s http://${PPROF_ADDR}/debug/pprof/heap > heap.prof
+go tool pprof -top heap.prof
+
+# CPU profile (30 seconds sampling)
+curl -s "http://${PPROF_ADDR}/debug/pprof/profile?seconds=30" > cpu.prof
+go tool pprof -top cpu.prof
+
+# Goroutine profile
+curl -s http://${PPROF_ADDR}/debug/pprof/goroutine > goroutine.prof
+go tool pprof -top goroutine.prof
+
+# Allocation profile
+curl -s http://${PPROF_ADDR}/debug/pprof/allocs > allocs.prof
+go tool pprof -top allocs.prof
+
+# Interactive analysis
+go tool pprof -http=:8888 cpu.prof
+```
+
+#### Available Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable-pprof` | `false` | Enable pprof profiling server |
+| `--pprof-bind-address` | `:6060` | Address the pprof endpoint binds to |
+
+> **Note**: pprof exposes runtime internals. Do not enable in production unless behind a network policy or firewall.
+
 ### Debugging RGB Controller
 
 The RBG controller component supports local operation or debugging. Before running the controller component locally, it is necessary to configure kubeconfig in advance in the local environment (configured through the `KUBECONFIG` environment variable or through the `$HOME/.kube/config` file) and be able to access a Kubernetes cluster normally.


### PR DESCRIPTION
## Summary
- Add `--enable-pprof` flag (default `false`) and `--pprof-bind-address` flag (default `:6060`) to the controller
- When enabled, starts a pprof HTTP server for CPU/memory profiling via `go tool pprof`
- Useful for performance debugging and stress testing scenarios

## Usage

```bash
# Run controller with pprof enabled
bin/manager --enable-webhooks=none --enable-pprof=true --pprof-bind-address=:6060

# Collect profiles
curl http://localhost:6060/debug/pprof/heap > heap.prof
curl http://localhost:6060/debug/pprof/profile?seconds=30 > cpu.prof
go tool pprof heap.prof
```

## Test plan
- [x] `make build` succeeds
- [x] `make lint` passes
- [ ] Run controller with `--enable-pprof=true`, verify `curl localhost:6060/debug/pprof/` returns pprof index
- [ ] Run controller without the flag, verify no pprof server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)