### PR TITLE
docs: add Model Express integration to Dynamo SGLang examples

### DIFF
--- a/examples/inference/ecosystem/dynamo/agg-multi-nodes.yaml
+++ b/examples/inference/ecosystem/dynamo/agg-multi-nodes.yaml
@@ -20,6 +20,15 @@
 #   - GPU nodes with CUDA support
 #   - ETCD and NATS services deployed (required for Dynamo runtime)
 #   - Model weights mounted at /models or use HuggingFace download
+#   - (Optional) Model Express server for accelerated model distribution.
+#     Model Express (https://github.com/ai-dynamo/modelexpress) is a standalone
+#     service that coordinates P2P model weight transfers across nodes.
+#     Deploy MX Server via one of:
+#       1. Dynamo Helm chart: --set "global.model-express.enabled=true"
+#       2. Manual: docker run -d --name redis -p 6379:6379 redis:8-alpine
+#                  MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
+#     Then set MODEL_EXPRESS_URL below to the MX gRPC endpoint.
+#     If not deployed, workers fall back to direct HuggingFace download.
 
 ---
 apiVersion: workloads.x-k8s.io/v1alpha2
@@ -52,6 +61,14 @@ spec:
                   value: http://etcd:2379
                 - name: NATS_SERVER
                   value: nats://nats:4222
+                # Model Express (https://github.com/ai-dynamo/modelexpress):
+                # Accelerated model distribution via gRPC. Workers download model
+                # weights through the MX Server, which coordinates P2P transfers
+                # (GPU-to-GPU via NIXL RDMA) across nodes.
+                # Falls back to direct HuggingFace download if MX Server is unavailable.
+                # To disable, remove or leave empty.
+                - name: MODEL_EXPRESS_URL
+                  value: model-express-server:8001
 
   roles:
     # Processor: Dynamo frontend for request routing and HTTP API

--- a/examples/inference/ecosystem/dynamo/agg.yaml
+++ b/examples/inference/ecosystem/dynamo/agg.yaml
@@ -25,6 +25,15 @@
 #   - GPU nodes with CUDA support
 #   - ETCD and NATS services deployed (required for Dynamo runtime)
 #   - Model weights mounted at /models or use HuggingFace download
+#   - (Optional) Model Express server for accelerated model distribution.
+#     Model Express (https://github.com/ai-dynamo/modelexpress) is a standalone
+#     service that coordinates P2P model weight transfers across nodes.
+#     Deploy MX Server via one of:
+#       1. Dynamo Helm chart: --set "global.model-express.enabled=true"
+#       2. Manual: docker run -d --name redis -p 6379:6379 redis:8-alpine
+#                  MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
+#     Then set MODEL_EXPRESS_URL below to the MX gRPC endpoint.
+#     If not deployed, workers fall back to direct HuggingFace download.
 
 ---
 apiVersion: workloads.x-k8s.io/v1alpha2
@@ -57,6 +66,14 @@ spec:
                   value: http://etcd:2379
                 - name: NATS_SERVER
                   value: nats://nats:4222
+                # Model Express (https://github.com/ai-dynamo/modelexpress):
+                # Accelerated model distribution via gRPC. Workers download model
+                # weights through the MX Server, which coordinates P2P transfers
+                # (GPU-to-GPU via NIXL RDMA) across nodes.
+                # Falls back to direct HuggingFace download if MX Server is unavailable.
+                # To disable, remove or leave empty.
+                - name: MODEL_EXPRESS_URL
+                  value: model-express-server:8001
 
   roles:
     # Processor: Dynamo frontend for request routing and HTTP API

--- a/examples/inference/ecosystem/dynamo/pd-disagg-multi-nodes.yaml
+++ b/examples/inference/ecosystem/dynamo/pd-disagg-multi-nodes.yaml
@@ -20,6 +20,15 @@
 #   - NVIDIA Dynamo SGLang runtime image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.1
 #   - GPU nodes with CUDA support
 #   - ETCD and NATS services deployed (required for Dynamo runtime)
+#   - (Optional) Model Express server for accelerated model distribution.
+#     Model Express (https://github.com/ai-dynamo/modelexpress) is a standalone
+#     service that coordinates P2P model weight transfers across nodes.
+#     Deploy MX Server via one of:
+#       1. Dynamo Helm chart: --set "global.model-express.enabled=true"
+#       2. Manual: docker run -d --name redis -p 6379:6379 redis:8-alpine
+#                  MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
+#     Then set MODEL_EXPRESS_URL below to the MX gRPC endpoint.
+#     If not deployed, workers fall back to direct HuggingFace download.
 ---
 apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
@@ -51,6 +60,14 @@ spec:
                   value: http://etcd:2379
                 - name: NATS_SERVER
                   value: nats://nats:4222
+                # Model Express (https://github.com/ai-dynamo/modelexpress):
+                # Accelerated model distribution via gRPC. Workers download model
+                # weights through the MX Server, which coordinates P2P transfers
+                # (GPU-to-GPU via NIXL RDMA) across nodes.
+                # Falls back to direct HuggingFace download if MX Server is unavailable.
+                # To disable, remove or leave empty.
+                - name: MODEL_EXPRESS_URL
+                  value: model-express-server:8001
   roles:
     # Processor: Dynamo frontend for request routing and HTTP API
     - name: processor

--- a/examples/inference/ecosystem/dynamo/pd-disagg.yaml
+++ b/examples/inference/ecosystem/dynamo/pd-disagg.yaml
@@ -20,6 +20,15 @@
 #   - GPU nodes with CUDA support
 #   - ETCD and NATS services deployed (required for Dynamo runtime)
 #   - Model weights mounted at /models or use HuggingFace download
+#   - (Optional) Model Express server for accelerated model distribution.
+#     Model Express (https://github.com/ai-dynamo/modelexpress) is a standalone
+#     service that coordinates P2P model weight transfers across nodes.
+#     Deploy MX Server via one of:
+#       1. Dynamo Helm chart: --set "global.model-express.enabled=true"
+#       2. Manual: docker run -d --name redis -p 6379:6379 redis:8-alpine
+#                  MX_METADATA_BACKEND=redis cargo run --bin modelexpress-server
+#     Then set MODEL_EXPRESS_URL below to the MX gRPC endpoint.
+#     If not deployed, workers fall back to direct HuggingFace download.
 
 ---
 apiVersion: workloads.x-k8s.io/v1alpha2
@@ -52,6 +61,14 @@ spec:
                   value: http://etcd:2379
                 - name: NATS_SERVER
                   value: nats://nats:4222
+                # Model Express (https://github.com/ai-dynamo/modelexpress):
+                # Accelerated model distribution via gRPC. Workers download model
+                # weights through the MX Server, which coordinates P2P transfers
+                # (GPU-to-GPU via NIXL RDMA) across nodes.
+                # Falls back to direct HuggingFace download if MX Server is unavailable.
+                # To disable, remove or leave empty.
+                - name: MODEL_EXPRESS_URL
+                  value: model-express-server:8001
 
   roles:
     # Processor: Dynamo frontend for request routing and HTTP API


### PR DESCRIPTION
## Summary

- Add `MODEL_EXPRESS_URL` environment variable to all 4 Dynamo inference examples (`agg.yaml`, `agg-multi-nodes.yaml`, `pd-disagg.yaml`, `pd-disagg-multi-nodes.yaml`)
- Add Model Express server deployment instructions (Helm chart and manual) to the prerequisites section of each example
- Add inline comments explaining Model Express functionality, fallback behavior, and project link

## Context

[Model Express](https://github.com/ai-dynamo/modelexpress) is Dynamo's accelerated model distribution service that coordinates P2P model weight transfers (GPU-to-GPU via NIXL RDMA) across nodes. When using the Dynamo Operator, `MODEL_EXPRESS_URL` is automatically injected into all pods. However, RBG deployments bypass the Dynamo Operator, so users need to configure this manually in their RBG YAML files.

## Test plan

- [ ] Verify YAML syntax is valid for all 4 modified example files
- [ ] Confirm examples deploy correctly with and without Model Express server

🤖 Generated with [Claude Code](https://claude.com/claude-code)