### PR TITLE
fix: add RestartPolicy to StandalonePattern for consistency with other patterns

### DIFF
--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -270,7 +270,7 @@ func (r *RoleSpec) GetWorkerTemplatePatch() *runtime.RawExtension {
 }
 
 // GetRestartPolicy returns the effective restart policy for this role based on its pattern.
-// StandalonePattern always returns None (single pod, no instance-level restart).
+// StandalonePattern defaults to None.
 // LeaderWorkerPattern and CustomComponentsPattern default to RecreateRoleInstanceOnPodRestart.
 func (r *RoleSpec) GetRestartPolicy() RestartPolicyType {
 	if r.LeaderWorkerPattern != nil {
@@ -285,7 +285,11 @@ func (r *RoleSpec) GetRestartPolicy() RestartPolicyType {
 		}
 		return RecreateRoleInstanceOnPodRestart
 	}
-	// StandalonePattern or no pattern: single pod, no instance-level restart
+	if r.StandalonePattern != nil {
+		if r.StandalonePattern.RestartPolicy != "" {
+			return r.StandalonePattern.RestartPolicy
+		}
+	}
 	return RestartPolicyNone
 }
 

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -302,6 +302,12 @@ type StandalonePattern struct {
 	// TemplateSource defines the Pod template source, either inline or via reference.
 	// +optional
 	TemplateSource `json:",inline"`
+
+	// RestartPolicy defines the restart policy when pod failures happen.
+	// Default is None.
+	// +kubebuilder:validation:Enum={None,RecreateRoleInstanceOnPodRestart}
+	// +optional
+	RestartPolicy RestartPolicyType `json:"restartPolicy,omitempty"`
 }
 
 // LeaderWorkerPattern defines the leader-worker deployment pattern (multiple pods per replica).

--- a/client-go/applyconfiguration/workloads/v1alpha2/standalonepattern.go
+++ b/client-go/applyconfiguration/workloads/v1alpha2/standalonepattern.go
@@ -19,12 +19,14 @@ package v1alpha2
 
 import (
 	v1 "k8s.io/client-go/applyconfigurations/core/v1"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 )
 
 // StandalonePatternApplyConfiguration represents a declarative configuration of the StandalonePattern type for use
 // with apply.
 type StandalonePatternApplyConfiguration struct {
 	TemplateSourceApplyConfiguration `json:",inline"`
+	RestartPolicy                    *workloadsv1alpha2.RestartPolicyType `json:"restartPolicy,omitempty"`
 }
 
 // StandalonePatternApplyConfiguration constructs a declarative configuration of the StandalonePattern type for use with
@@ -46,5 +48,13 @@ func (b *StandalonePatternApplyConfiguration) WithTemplate(value *v1.PodTemplate
 // If called multiple times, the TemplateRef field is set to the value of the last call.
 func (b *StandalonePatternApplyConfiguration) WithTemplateRef(value *TemplateRefApplyConfiguration) *StandalonePatternApplyConfiguration {
 	b.TemplateSourceApplyConfiguration.TemplateRef = value
+	return b
+}
+
+// WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RestartPolicy field is set to the value of the last call.
+func (b *StandalonePatternApplyConfiguration) WithRestartPolicy(value workloadsv1alpha2.RestartPolicyType) *StandalonePatternApplyConfiguration {
+	b.RestartPolicy = &value
 	return b
 }

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -32980,6 +32980,14 @@ spec:
                     standalonePattern:
                       description: StandalonePattern defines a single-pod pattern.
                       properties:
+                        restartPolicy:
+                          description: |-
+                            RestartPolicy defines the restart policy when pod failures happen.
+                            Default is None.
+                          enum:
+                          - None
+                          - RecreateRoleInstanceOnPodRestart
+                          type: string
                         template:
                           description: Template defines the Pod template specification
                             inline.

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -33797,6 +33797,14 @@ spec:
                               description: StandalonePattern defines a single-pod
                                 pattern.
                               properties:
+                                restartPolicy:
+                                  description: |-
+                                    RestartPolicy defines the restart policy when pod failures happen.
+                                    Default is None.
+                                  enum:
+                                  - None
+                                  - RecreateRoleInstanceOnPodRestart
+                                  type: string
                                 template:
                                   description: Template defines the Pod template specification
                                     inline.

--- a/test/wrappers/v1alpha2/role_wrapper.go
+++ b/test/wrappers/v1alpha2/role_wrapper.go
@@ -66,6 +66,11 @@ func (rw *StandaloneRoleWrapper) WithRollingUpdate(ru workloadsv1alpha2.RollingU
 	return rw
 }
 
+func (rw *StandaloneRoleWrapper) WithRestartPolicy(rp workloadsv1alpha2.RestartPolicyType) *StandaloneRoleWrapper {
+	rw.StandalonePattern.RestartPolicy = rp
+	return rw
+}
+
 func (rw *StandaloneRoleWrapper) WithWorkload(apiVersion, kind string) *StandaloneRoleWrapper {
 	if rw.Annotations == nil {
 		rw.Annotations = make(map[string]string)


### PR DESCRIPTION
## Summary
- PR #357 moved `RestartPolicy` from `RoleSpec` to pattern types but only added it to `LeaderWorkerPattern` and `CustomComponentsPattern`, missing `StandalonePattern`
- This caused compilation errors in the envtest `restart_policy` tests (9 call sites) that set `RestartPolicy` on standalone roles, breaking lint/unit-test/envtest CI checks on PR #358
- Added `RestartPolicy` field to `StandalonePattern` (default `None`), updated `GetRestartPolicy()` helper to check it, and added `WithRestartPolicy` method to `StandaloneRoleWrapper`

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` — all unit tests pass
- [x] `make test-envtest` — all 10 restart_policy specs pass
- [x] `make generate manifests` — CRDs and generated code up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)