### PR TITLE
feat: add ua for every controller

### DIFF
--- a/cmd/rbgs/main.go
+++ b/cmd/rbgs/main.go
@@ -61,6 +61,7 @@ import (
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadscontroller "sigs.k8s.io/rbgs/internal/controller/workloads"
 	"sigs.k8s.io/rbgs/pkg/scheduler"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
 	rbgwebhook "sigs.k8s.io/rbgs/pkg/webhook"
 	"sigs.k8s.io/rbgs/version"
@@ -548,7 +549,7 @@ func bootstrapWebhookCerts(mgr ctrl.Manager) (*webhookBootstrapResult, error) {
 // the conversion-webhook CRDs and keeps caBundle in sync with the self-signed CA certificate.
 func setupWebhookCertController(mgr ctrl.Manager, result *webhookBootstrapResult, options controller.Options) error {
 	webhookCertReconciler := &workloadscontroller.WebhookCertReconciler{
-		Client:      mgr.GetClient(),
+		Client:      utilclient.NewClientWithUserAgent(mgr, "webhook-cert"),
 		CertManager: result.certMgr,
 		CACert:      result.caCert,
 		CRDNames:    rbgwebhook.ConversionWebhookCRDs(),

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -63,6 +63,7 @@ import (
 	"sigs.k8s.io/rbgs/pkg/scale"
 	"sigs.k8s.io/rbgs/pkg/scheduler"
 	"sigs.k8s.io/rbgs/pkg/utils"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 	schev1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	volcanoschedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
@@ -88,12 +89,13 @@ type RoleBasedGroupReconciler struct {
 }
 
 func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType) (*RoleBasedGroupReconciler, error) {
-	podGroupManager, err := scheduler.NewPodGroupManager(schedulerName, mgr.GetClient())
+	c := utilclient.NewClientWithUserAgent(mgr, "rolebasedgroup")
+	podGroupManager, err := scheduler.NewPodGroupManager(schedulerName, c)
 	if err != nil {
 		return nil, err
 	}
 	return &RoleBasedGroupReconciler{
-		client:             mgr.GetClient(),
+		client:             c,
 		apiReader:          mgr.GetAPIReader(),
 		scheme:             mgr.GetScheme(),
 		recorder:           mgr.GetEventRecorderFor("RoleBasedGroup"),

--- a/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
+++ b/internal/controller/workloads/rolebasedgroupscalingadapter_controller.go
@@ -48,6 +48,7 @@ import (
 	applyconfiguration "sigs.k8s.io/rbgs/client-go/applyconfiguration/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/scale"
 	"sigs.k8s.io/rbgs/pkg/utils"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 )
 
 // RoleBasedGroupScalingAdapterReconciler reconciles a RoleBasedGroupScalingAdapter object
@@ -60,7 +61,7 @@ type RoleBasedGroupScalingAdapterReconciler struct {
 
 func NewRoleBasedGroupScalingAdapterReconciler(mgr ctrl.Manager) *RoleBasedGroupScalingAdapterReconciler {
 	return &RoleBasedGroupScalingAdapterReconciler{
-		client:    mgr.GetClient(),
+		client:    utilclient.NewClientWithUserAgent(mgr, "rolebasedgroupscalingadapter"),
 		apiReader: mgr.GetAPIReader(),
 		scheme:    mgr.GetScheme(),
 		recorder:  mgr.GetEventRecorderFor("RoleBasedGroupScalingAdapter"),

--- a/internal/controller/workloads/rolebasedgroupset_controller.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/utils"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 )
 
 // RoleBasedGroupSetReconciler reconciles a RoleBasedGroupSet object
@@ -52,7 +53,7 @@ type RoleBasedGroupSetReconciler struct {
 
 func NewRoleBasedGroupSetReconciler(mgr ctrl.Manager) *RoleBasedGroupSetReconciler {
 	return &RoleBasedGroupSetReconciler{
-		client:    mgr.GetClient(),
+		client:    utilclient.NewClientWithUserAgent(mgr, "rolebasedgroupset"),
 		apiReader: mgr.GetAPIReader(),
 		scheme:    mgr.GetScheme(),
 		recorder:  mgr.GetEventRecorderFor("rbgset-controller"),

--- a/pkg/reconciler/roleinstance/instance_reconciler.go
+++ b/pkg/reconciler/roleinstance/instance_reconciler.go
@@ -43,19 +43,21 @@ import (
 	revisioncontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/revision"
 	synccontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	instanceutil "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/utils"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
 )
 
 func NewReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 	recorder := mgr.GetEventRecorderFor("instance-controller")
+	c := utilclient.NewClientWithUserAgent(mgr, "roleinstance")
 	return &reconciler{
-		Client:            mgr.GetClient(),
+		Client:            c,
 		scheme:            mgr.GetScheme(),
 		recorder:          recorder,
-		controllerHistory: historyutil.NewHistory(mgr.GetClient()),
-		statusUpdater:     newStatusUpdater(mgr.GetClient()),
+		controllerHistory: historyutil.NewHistory(c),
+		statusUpdater:     newStatusUpdater(c),
 		revisionControl:   revisioncontrol.NewRevisionControl(),
-		syncControl:       synccontrol.New(mgr.GetClient(), mgr.GetAPIReader(), recorder),
+		syncControl:       synccontrol.New(c, mgr.GetAPIReader(), recorder),
 	}
 }
 

--- a/pkg/reconciler/roleinstanceset/statelessmode/reconciler.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/reconciler.go
@@ -41,18 +41,20 @@ import (
 	revisioncontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/revision"
 	synccontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/sync"
 	"sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/utils"
+	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 )
 
 func NewReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 	recorder := mgr.GetEventRecorderFor("instanceset-controller")
+	c := utilclient.NewClientWithUserAgent(mgr, "roleinstanceset")
 	return &ReconcileInstanceSet{
-		Client:            mgr.GetClient(),
+		Client:            c,
 		scheme:            mgr.GetScheme(),
 		recorder:          recorder,
-		controllerHistory: historyutil.NewHistory(mgr.GetClient()),
-		statusUpdater:     newStatusUpdater(mgr.GetClient()),
+		controllerHistory: historyutil.NewHistory(c),
+		statusUpdater:     newStatusUpdater(c),
 		revisionControl:   revisioncontrol.NewRevisionControl(),
-		syncControl:       synccontrol.New(mgr.GetClient(), recorder),
+		syncControl:       synccontrol.New(c, recorder),
 	}
 }
 

--- a/pkg/utils/client/client.go
+++ b/pkg/utils/client/client.go
@@ -18,10 +18,15 @@ package client
 
 import (
 	"fmt"
+	"runtime"
+	"strings"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	"sigs.k8s.io/rbgs/version"
 )
 
 func NewClientFromManager(mgr manager.Manager, name string) client.Client {
@@ -35,4 +40,45 @@ func NewClientFromManager(mgr manager.Manager, name string) client.Client {
 		},
 	})
 	return delegatingClient
+}
+
+func NewClientWithUserAgent(mgr manager.Manager, name string) client.Client {
+	cfg := rest.CopyConfig(mgr.GetConfig())
+	cfg.UserAgent = buildUserAgent(name)
+
+	delegatingClient, _ := client.New(cfg, client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+		Cache: &client.CacheOptions{
+			Reader: mgr.GetCache(),
+		},
+	})
+	return delegatingClient
+}
+
+func buildUserAgent(name string) string {
+	return fmt.Sprintf("%s/%s (%s/%s) %s/%s",
+		name,
+		adjustVersion(version.Version),
+		runtime.GOOS,
+		runtime.GOARCH,
+		constants.ControllerName,
+		adjustCommit(version.GitCommit))
+}
+
+func adjustVersion(v string) string {
+	if len(v) == 0 {
+		return "unknown"
+	}
+	return strings.SplitN(v, "-", 2)[0]
+}
+
+func adjustCommit(c string) string {
+	if len(c) == 0 {
+		return "unknown"
+	}
+	if len(c) > 7 {
+		return c[:7]
+	}
+	return c
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

All controllers used `mgr.GetClient()` directly, so their API requests could not be distinguished by controller in apiserver audit logs.

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

Added `NewClientWithUserAgent(mgr, name)` in `pkg/utils/client/client.go`, which returns a cache-backed client tagged with a per-controller UserAgent. The UA follows the client-go `DefaultKubernetesUserAgent` convention: `<name>/<version> (<os>/<arch>) rbg-controller/<commit>` (version/commit from the `version` package).

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

NONE

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new tests. This is a pure observability change.

### Ⅴ. Describe how to verify it

Run the controller against a cluster and check the apiserver audit log.

### VI. Special notes for reviews

## Checklist

- [x] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
