### PR TITLE
docs: update README release notes and add ecosystem projects

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -22,9 +22,7 @@
 
 | 日期 | 版本 | 亮点 |
 |:----:|:----:|:-----|
-| 2026-04-22 | [v0.7.0-alpha.3](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.3) | `v1alpha2` 转换 webhook、CLI 多节点 LLM 服务 |
-| 2026-03-31 | [v0.7.0-alpha.2](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.2) | Pod 端口分配器、CLI 基础功能 |
-| 2026-03-18 | [v0.7.0-alpha.1](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.1) | `v1alpha2` API、协同策略、gang 调度 |
+| 2026-06-11 | [v0.7.0](https://github.com/sgl-project/rbg/releases/tag/v0.7.0) | `v1alpha2` API 正式发布、转换 webhook、CLI 多节点 LLM 服务、Pod 端口分配器、协同策略、gang 调度 |
 | 2026-02-18 | [v0.6.0](https://github.com/sgl-project/rbg/releases/tag/v0.6.0) | 协同伸缩、有状态 InstanceSet |
 | 2025-12-03 | [v0.5.0](https://github.com/sgl-project/rbg/releases/tag/v0.5.0) | 原生 InstanceSet、原地更新、Mooncake 集成 |
 | 2025-09-23 | [v0.4.0](https://github.com/sgl-project/rbg/releases/tag/v0.4.0) | RBGS 伸缩、Volcano podgroup 支持 |
@@ -268,10 +266,23 @@ RBG 集成生态组件用于生产级 LLM 推理：
 
 | RBG 版本 | Kubernetes | LeaderWorkerSet |
 |:---------|:----------:|:---------------:|
-| main / v0.7.0-alpha.x | >=v1.22.x | 不依赖 |
+| v0.7.0 | >=v1.22.x | 不依赖 |
 | v0.6.0 | >=v1.28.x | >=v0.7.0 |
 | v0.5.0 | >=v1.28.x | >=v0.6.0 |
 | v0.4.0 | >=v1.28.x | >=v0.7.0 |
+
+---
+
+## 🌐 生态项目
+
+[rolebasedgroup](https://github.com/rolebasedgroup) GitHub 组织托管了一系列配套项目，为 RBG 提供自动伸缩、CLI 工具、AI Agent 集成和文档支持：
+
+| 项目 | 说明 |
+|:-----|:-----|
+| [**rbg-planner**](https://github.com/rolebasedgroup/rbg-planner) | 引擎无关的 SLA 驱动 LLM 推理自动伸缩器。通过可插拔指标适配器支持 SGLang、vLLM、NVIDIA Dynamo，基于 ARIMA 负载预测和自动 SLA 画像，扩缩 prefill/decode 角色以满足 TTFT/ITL 延迟目标。 |
+| [**inference-ext-cli**](https://github.com/rolebasedgroup/inference-ext-cli) | RBG CLI 扩展（`llmctl`），用于 LLM 推理工作负载管理。提供服务/模型管理、基准测试编排、自动参数搜索（Optuna）、收敛分析及实验可视化 Web 面板。 |
+| [**rbg-agent-guide**](https://github.com/rolebasedgroup/rbg-agent-guide) | RBG 运维 AI Agent 技能指南。为 AI 编程助手（如 Claude Code）提供部署技能，帮助用户通过 RBG CRD 和 CLI 将 LLM 模型部署到 Kubernetes。 |
+| [**rolebasedgroup.github.io**](https://github.com/rolebasedgroup/rolebasedgroup.github.io) | RBG 官方文档网站，基于 Docusaurus 构建，部署于 [rolebasedgroup.github.io](https://rolebasedgroup.github.io)。 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ English | [简体中文](./README-zh_CN.md)
 
 | Date | Release | Highlights |
 |:----:|:-------:|:-----------|
-| 2026-04-22 | [v0.7.0-alpha.3](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.3) | `v1alpha2` conversion webhooks, CLI multi-node LLM serving |
-| 2026-03-31 | [v0.7.0-alpha.2](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.2) | Pod port allocator, CLI foundations |
-| 2026-03-18 | [v0.7.0-alpha.1](https://github.com/sgl-project/rbg/releases/tag/v0.7.0-alpha.1) | `v1alpha2` API, coordinated policies, gang scheduling |
+| 2026-06-11 | [v0.7.0](https://github.com/sgl-project/rbg/releases/tag/v0.7.0) | `v1alpha2` API stable release, conversion webhooks, CLI multi-node LLM serving, pod port allocator, coordinated policies, gang scheduling |
 | 2026-02-18 | [v0.6.0](https://github.com/sgl-project/rbg/releases/tag/v0.6.0) | Coordinated scaling, stateful InstanceSet |
 | 2025-12-03 | [v0.5.0](https://github.com/sgl-project/rbg/releases/tag/v0.5.0) | Native InstanceSet, in-place updates, Mooncake integration |
 | 2025-09-23 | [v0.4.0](https://github.com/sgl-project/rbg/releases/tag/v0.4.0) | RBGS scaling, Volcano podgroup support |
@@ -268,10 +266,23 @@ RBG integrates with ecosystem components for production LLM inference:
 
 | RBG Version | Kubernetes | LeaderWorkerSet |
 |:------------|:----------:|:---------------:|
-| main / v0.7.0-alpha.x | >=v1.22.x | Not Required |
+| v0.7.0 | >=v1.22.x | Not Required |
 | v0.6.0 | >=v1.28.x | >=v0.7.0 |
 | v0.5.0 | >=v1.28.x | >=v0.6.0 |
 | v0.4.0 | >=v1.28.x | >=v0.7.0 |
+
+---
+
+## 🌐 Ecosystem Projects
+
+The [rolebasedgroup](https://github.com/rolebasedgroup) GitHub organization hosts companion projects that extend RBG with autoscaling, CLI tooling, AI agent integration, and documentation:
+
+| Project | Description |
+|:--------|:------------|
+| [**rbg-planner**](https://github.com/rolebasedgroup/rbg-planner) | Engine-agnostic, SLA-driven autoscaler for LLM inference on Kubernetes. Supports SGLang, vLLM, NVIDIA Dynamo via pluggable metrics adapters. Uses ARIMA-based load prediction and automatic SLA profiling to scale prefill/decode roles to meet TTFT/ITL latency targets. |
+| [**inference-ext-cli**](https://github.com/rolebasedgroup/inference-ext-cli) | RBG CLI extension (`llmctl`) for LLM inference workload management. Provides service/model management, benchmark orchestration, automated parameter search (Optuna), convergence analysis, and web dashboards for experiment visualization. |
+| [**rbg-agent-guide**](https://github.com/rolebasedgroup/rbg-agent-guide) | AI agent skill guides for RBG operations. Provides deployment skills for AI coding assistants (e.g., Claude Code) to help users deploy LLM models to Kubernetes using RBG CRD and CLI. |
+| [**rolebasedgroup.github.io**](https://github.com/rolebasedgroup/rolebasedgroup.github.io) | Official RBG documentation website built with Docusaurus, deployed at [rolebasedgroup.github.io](https://rolebasedgroup.github.io). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace v0.7.0 alpha release notes (alpha.1, alpha.2, alpha.3) with stable v0.7.0 release entry in both English and Chinese READMEs
- Update version compatibility table to reference v0.7.0 instead of `main / v0.7.0-alpha.x`
- Add new "Ecosystem Projects" section listing the [rolebasedgroup](https://github.com/rolebasedgroup) GitHub org companion projects:
  - **rbg-planner** — SLA-driven autoscaler for LLM inference
  - **inference-ext-cli** — CLI extension (`llmctl`) for workload management
  - **rbg-agent-guide** — AI agent skill guides for RBG operations
  - **rolebasedgroup.github.io** — Official documentation website

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify Chinese README renders correctly on GitHub
- [ ] Check all ecosystem project links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)