### PR TITLE
feat(rbg): support inplace scheduling

### DIFF
--- a/api/workloads/constants/annotation.go
+++ b/api/workloads/constants/annotation.go
@@ -163,3 +163,54 @@ const (
 	// whose failures should not cascade to the main workload.
 	RestartTriggerPolicyIgnore = "Ignore"
 )
+
+// Inplace scheduling annotations and values.
+const (
+	// RoleInplaceSchedulingAnnotationKey enables in-place scheduling for a role.
+	// When set, recreated Pods (due to rolling upgrade or failure recovery) are
+	// injected with nodeAffinity to prefer or require scheduling to nodes where
+	// the same component type has previously run, enabling reuse of node-local
+	// cached resources.
+	// Valid values:
+	//   - "Preferred": inject preferredDuringSchedulingIgnoredDuringExecution with weight 100.
+	//   - "Required": inject requiredDuringSchedulingIgnoredDuringExecution.
+	// When not set, no in-place scheduling affinity is injected.
+	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling: "Preferred"
+	RoleInplaceSchedulingAnnotationKey = RBGPrefix + "role-inplace-scheduling"
+
+	// InplaceSchedulingPreferred injects preferredDuringSchedulingIgnoredDuringExecution
+	// nodeAffinity with weight 100, steering recreated Pods toward historical nodes
+	// while allowing fallback to any available node.
+	InplaceSchedulingPreferred = "Preferred"
+
+	// InplaceSchedulingRequired injects requiredDuringSchedulingIgnoredDuringExecution
+	// nodeAffinity, requiring recreated Pods to land on a historical node.
+	// If no historical node is available, the Pod remains Pending.
+	InplaceSchedulingRequired = "Required"
+
+	// RoleInplaceSchedulingGranularityAnnotationKey controls the binding granularity
+	// for in-place scheduling. When not set, the default is auto-detected:
+	//   - Stateful mode → Pod
+	//   - Stateless mode → Component
+	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling-granularity: "Component"
+	RoleInplaceSchedulingGranularityAnnotationKey = RBGPrefix + "role-inplace-scheduling-granularity"
+
+	// InplaceSchedulingGranularityPod uses per-Pod binding: each Pod returns to
+	// its own historical node. Key: {rbgUID}/{podName} → single node.
+	InplaceSchedulingGranularityPod = "Pod"
+
+	// InplaceSchedulingGranularityComponent uses component-level binding: Pod
+	// prefers any node that has hosted the same component type.
+	// Key: {rbgUID}/{roleName}-{componentName} → node set.
+	InplaceSchedulingGranularityComponent = "Component"
+
+	// RoleInplaceSchedulingAvoidAnnotationKey specifies a node label key. When set,
+	// a RequiredDuringSchedulingIgnoredDuringExecution term with DoesNotExist
+	// operator is injected into the Pod's nodeAffinity, hard-excluding nodes
+	// that carry this label.
+	// This is useful to steer Pods away from nodes with certain characteristics
+	// (e.g., nodes running other heavy workloads).
+	// The annotation value is the label key to match against.
+	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling-avoid: "workloads.x-k8s.io/heavy-tenant"
+	RoleInplaceSchedulingAvoidAnnotationKey = RBGPrefix + "role-inplace-scheduling-avoid"
+)

--- a/api/workloads/constants/annotation.go
+++ b/api/workloads/constants/annotation.go
@@ -175,6 +175,12 @@ const (
 	//   - "Preferred": inject preferredDuringSchedulingIgnoredDuringExecution with weight 100.
 	//   - "Required": inject requiredDuringSchedulingIgnoredDuringExecution.
 	// When not set, no in-place scheduling affinity is injected.
+	//
+	// Note: when adding to an existing RBG, old RoleInstances lack the label so
+	// they are unaffected. New RoleInstances start recording bindings,
+	// but no affinity is injected on the first recreation (empty binding).
+	// Affinity takes effect on subsequent recreations.
+	//
 	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling: "Preferred"
 	RoleInplaceSchedulingAnnotationKey = RBGPrefix + "role-inplace-scheduling"
 
@@ -185,7 +191,9 @@ const (
 
 	// InplaceSchedulingRequired injects requiredDuringSchedulingIgnoredDuringExecution
 	// nodeAffinity, requiring recreated Pods to land on a historical node.
-	// If no historical node is available, the Pod remains Pending.
+	// If a binding exists but no historical node is healthy, the Pod remains Pending.
+	// On cold start (empty binding store, e.g. after controller restart), no
+	// affinity is injected until RecordNodeBindings reseeds the store.
 	InplaceSchedulingRequired = "Required"
 
 	// RoleInplaceSchedulingGranularityAnnotationKey controls the binding granularity
@@ -204,13 +212,11 @@ const (
 	// Key: {rbgUID}/{roleName}-{componentName} → node set.
 	InplaceSchedulingGranularityComponent = "Component"
 
-	// RoleInplaceSchedulingAvoidAnnotationKey specifies a node label key. When set,
-	// a RequiredDuringSchedulingIgnoredDuringExecution term with DoesNotExist
-	// operator is injected into the Pod's nodeAffinity, hard-excluding nodes
-	// that carry this label.
-	// This is useful to steer Pods away from nodes with certain characteristics
-	// (e.g., nodes running other heavy workloads).
-	// The annotation value is the label key to match against.
-	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling-avoid: "workloads.x-k8s.io/heavy-tenant"
+	// RoleInplaceSchedulingAvoidAnnotationKey specifies one or more node label
+	// keys. When set, a RequiredDuringSchedulingIgnoredDuringExecution term
+	// with DoesNotExist operator is injected for each key, hard-excluding nodes
+	// that carry any of these labels.
+	// The annotation value is a single label key or a comma-separated list.
+	// Example: rbg.workloads.x-k8s.io/role-inplace-scheduling-avoid: "key1,key2"
 	RoleInplaceSchedulingAvoidAnnotationKey = RBGPrefix + "role-inplace-scheduling-avoid"
 )

--- a/api/workloads/constants/label.go
+++ b/api/workloads/constants/label.go
@@ -37,6 +37,13 @@ const (
 	// Used as the match label for topology affinity.
 	GroupUIDLabelKey = RBGPrefix + "group-uid"
 
+	// RBGOwnerUIDLabelKey carries the real Kubernetes UID of the owning
+	// RoleBasedGroup. Unlike GroupUIDLabelKey (which is a deterministic hash
+	// of namespace/name), this UID is globally unique and changes when the
+	// RBG is deleted and recreated. Used by in-place scheduling to isolate
+	// node bindings across RBG lifecycles.
+	RBGOwnerUIDLabelKey = RBGPrefix + "rbg-owner-uid"
+
 	// GroupRevisionLabelKey is the labels key used to store the revision hash of the
 	// RoleBasedGroup Roles's template.
 	GroupRevisionLabelKey = RBGPrefix + "group-revision"

--- a/cmd/rbgs/main.go
+++ b/cmd/rbgs/main.go
@@ -60,6 +60,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadscontroller "sigs.k8s.io/rbgs/internal/controller/workloads"
+	instancesync "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	"sigs.k8s.io/rbgs/pkg/scheduler"
 	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
@@ -346,7 +347,12 @@ func main() {
 		setupLog.Info("Webhooks are disabled: cert bootstrap, conversion and admission webhooks will not be started")
 	}
 
-	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.SchedulerPluginType(schedulerName))
+	// Create the in-place scheduling binding store once and inject into both
+	// the RBG controller (for delete-time eviction) and the RoleInstance
+	// controller (for recording and injection during reconcile).
+	nodeBindings := instancesync.NewNodeBindingStore()
+
+	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.SchedulerPluginType(schedulerName), nodeBindings)
 	if err != nil {
 		setupLog.Error(err, "unable to create rbg controller", "controller", "RoleBasedGroup")
 		os.Exit(1)
@@ -382,7 +388,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	roleInstanceReconciler := workloadscontroller.NewRoleInstanceReconciler(mgr)
+	roleInstanceReconciler := workloadscontroller.NewRoleInstanceReconciler(mgr, nodeBindings)
 	if err = roleInstanceReconciler.CheckCrdExists(); err != nil {
 		setupLog.Error(err, "unable to create roleinstance controller", "controller", "RoleInstance")
 		os.Exit(1)

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -42,6 +42,7 @@ import (
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,6 +50,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -60,6 +62,7 @@ import (
 	"sigs.k8s.io/rbgs/pkg/dependency"
 	"sigs.k8s.io/rbgs/pkg/discovery"
 	"sigs.k8s.io/rbgs/pkg/reconciler"
+	instancesync "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	"sigs.k8s.io/rbgs/pkg/scale"
 	"sigs.k8s.io/rbgs/pkg/scheduler"
 	"sigs.k8s.io/rbgs/pkg/utils"
@@ -1013,6 +1016,19 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 		Owns(&workloadsv1alpha2.RoleInstanceSet{}, builder.WithPredicates(WorkloadPredicate())).
 		Owns(&corev1.Service{}).
 		Owns(&workloadsv1alpha2.RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner, builder.WithPredicates(RBGScalingAdapterPredicate())).
+		Watches(&workloadsv1alpha2.RoleBasedGroup{}, handler.Funcs{
+			// Clean up in-place scheduling bindings when an RBG is deleted.
+			// We don't enqueue a reconcile here — .For() already does that.
+			// This handler exists purely for the side-effect of freeing
+			// in-memory bindings using the UID (which is only available
+			// from the delete event, not from a subsequent Get).
+			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				if e.Object != nil {
+					uid := string(e.Object.GetUID())
+					instancesync.EvictNodeBindings(uid)
+				}
+			},
+		}).
 		Named("workloads-rolebasedgroup")
 
 	err := utils.CheckCrdExists(r.apiReader, utils.LwsCrdName)

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -89,9 +89,13 @@ type RoleBasedGroupReconciler struct {
 	workloadReconciler map[string]reconciler.WorkloadReconciler
 	reconcilerMu       sync.RWMutex
 	podGroupManager    scheduler.PodGroupManager
+	// NodeBindings is the in-place scheduling binding store, shared with
+	// the RoleInstance reconciler. Injected at wire-up time so both consumers
+	// operate on the same instance.
+	NodeBindings *instancesync.NodeBindingStore
 }
 
-func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType) (*RoleBasedGroupReconciler, error) {
+func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType, bindings *instancesync.NodeBindingStore) (*RoleBasedGroupReconciler, error) {
 	c := utilclient.NewClientWithUserAgent(mgr, "rolebasedgroup")
 	podGroupManager, err := scheduler.NewPodGroupManager(schedulerName, c)
 	if err != nil {
@@ -104,6 +108,7 @@ func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.Sched
 		recorder:           mgr.GetEventRecorderFor("RoleBasedGroup"),
 		workloadReconciler: make(map[string]reconciler.WorkloadReconciler),
 		podGroupManager:    podGroupManager,
+		NodeBindings:       bindings,
 	}, nil
 }
 
@@ -1027,9 +1032,9 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 			// in-memory bindings using the UID (which is only available
 			// from the delete event, not from a subsequent Get).
 			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-				if e.Object != nil {
+				if e.Object != nil && r.NodeBindings != nil {
 					uid := string(e.Object.GetUID())
-					instancesync.EvictNodeBindings(uid)
+					r.NodeBindings.EvictByUID(uid)
 				}
 			},
 		}).

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -1017,6 +1017,10 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 		Owns(&corev1.Service{}).
 		Owns(&workloadsv1alpha2.RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner, builder.WithPredicates(RBGScalingAdapterPredicate())).
 		Watches(&workloadsv1alpha2.RoleBasedGroup{}, handler.Funcs{
+			// CreateFunc, UpdateFunc, GenericFunc are intentionally nil (no-op).
+			// .For() already handles reconcile enqueue for those event types.
+			// This Watches exists solely for the DeleteFunc side-effect below.
+			//
 			// Clean up in-place scheduling bindings when an RBG is deleted.
 			// We don't enqueue a reconcile here — .For() already does that.
 			// This handler exists purely for the side-effect of freeing

--- a/internal/controller/workloads/roleinstance_controller.go
+++ b/internal/controller/workloads/roleinstance_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/reconciler/roleinstance"
+	synccontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	"sigs.k8s.io/rbgs/pkg/utils"
 )
 
@@ -34,8 +35,8 @@ type RoleInstanceReconciler struct {
 	apiReader     client.Reader
 }
 
-func NewRoleInstanceReconciler(mgr ctrl.Manager) *RoleInstanceReconciler {
-	reconciler := roleinstance.NewReconciler(mgr)
+func NewRoleInstanceReconciler(mgr ctrl.Manager, bindings *synccontrol.NodeBindingStore) *RoleInstanceReconciler {
+	reconciler := roleinstance.NewReconciler(mgr, bindings)
 	return &RoleInstanceReconciler{
 		reconcileFunc: reconciler.Reconcile,
 		apiReader:     mgr.GetAPIReader(),

--- a/pkg/reconciler/roleinstance/instance_reconciler.go
+++ b/pkg/reconciler/roleinstance/instance_reconciler.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
 )
 
-func NewReconciler(mgr ctrl.Manager) reconcile.Reconciler {
+func NewReconciler(mgr ctrl.Manager, bindings *synccontrol.NodeBindingStore) reconcile.Reconciler {
 	recorder := mgr.GetEventRecorderFor("instance-controller")
 	c := utilclient.NewClientWithUserAgent(mgr, "roleinstance")
 	return &reconciler{
@@ -57,7 +57,7 @@ func NewReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 		controllerHistory: historyutil.NewHistory(c),
 		statusUpdater:     newStatusUpdater(c),
 		revisionControl:   revisioncontrol.NewRevisionControl(),
-		syncControl:       synccontrol.New(c, mgr.GetAPIReader(), recorder),
+		syncControl:       synccontrol.New(c, mgr.GetAPIReader(), recorder, bindings),
 	}
 }
 

--- a/pkg/reconciler/roleinstance/sync/api.go
+++ b/pkg/reconciler/roleinstance/sync/api.go
@@ -44,33 +44,22 @@ type Interface interface {
 // informer cache catching up with the latest status write.
 var restartingCache sync.Map
 
-// nodeBindings is the package-level node binding store shared across all
-// RoleInstance reconcile loops. It uses a two-level map keyed by RBG UID,
-// enabling O(1) eviction of all bindings when an RBG is deleted via
-// EvictByUID (called from the RBG delete event handler).
-var nodeBindings = NewNodeBindingStore()
-
 type realControl struct {
 	client.Client
 	apiReader        client.Reader
 	inplaceControl   inplaceupdate.Interface
 	recorder         record.EventRecorder
 	lifecycleControl lifecycle.Interface
+	bindings         *NodeBindingStore
 }
 
-// EvictNodeBindings removes all in-place scheduling bindings for the
-// given RBG UID. Intended to be called from the RBG delete event handler
-// so that bindings are cleaned up immediately when an RBG is deleted.
-func EvictNodeBindings(uid string) {
-	nodeBindings.EvictByUID(uid)
-}
-
-func New(c client.Client, apiReader client.Reader, recorder record.EventRecorder) Interface {
+func New(c client.Client, apiReader client.Reader, recorder record.EventRecorder, bindings *NodeBindingStore) Interface {
 	return &realControl{
 		Client:           c,
 		apiReader:        apiReader,
 		inplaceControl:   inplaceupdate.New(c),
 		lifecycleControl: lifecycle.New(c),
 		recorder:         recorder,
+		bindings:         bindings,
 	}
 }

--- a/pkg/reconciler/roleinstance/sync/api.go
+++ b/pkg/reconciler/roleinstance/sync/api.go
@@ -45,9 +45,9 @@ type Interface interface {
 var restartingCache sync.Map
 
 // nodeBindings is the package-level node binding store shared across all
-// RoleInstance reconcile loops. It uses a unified map[string]sets.Set[string]
-// structure for both Pod-level and Component-level in-place scheduling
-// granularities; the difference is determined by the key format.
+// RoleInstance reconcile loops. It uses a two-level map keyed by RBG UID,
+// enabling O(1) eviction of all bindings when an RBG is deleted via
+// EvictByUID (called from the RBG delete event handler).
 var nodeBindings = NewNodeBindingStore()
 
 type realControl struct {
@@ -56,6 +56,13 @@ type realControl struct {
 	inplaceControl   inplaceupdate.Interface
 	recorder         record.EventRecorder
 	lifecycleControl lifecycle.Interface
+}
+
+// EvictNodeBindings removes all in-place scheduling bindings for the
+// given RBG UID. Intended to be called from the RBG delete event handler
+// so that bindings are cleaned up immediately when an RBG is deleted.
+func EvictNodeBindings(uid string) {
+	nodeBindings.EvictByUID(uid)
 }
 
 func New(c client.Client, apiReader client.Reader, recorder record.EventRecorder) Interface {

--- a/pkg/reconciler/roleinstance/sync/api.go
+++ b/pkg/reconciler/roleinstance/sync/api.go
@@ -44,6 +44,12 @@ type Interface interface {
 // informer cache catching up with the latest status write.
 var restartingCache sync.Map
 
+// nodeBindings is the package-level node binding store shared across all
+// RoleInstance reconcile loops. It uses a unified map[string]sets.Set[string]
+// structure for both Pod-level and Component-level in-place scheduling
+// granularities; the difference is determined by the key format.
+var nodeBindings = NewNodeBindingStore()
+
 type realControl struct {
 	client.Client
 	apiReader        client.Reader

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -44,6 +44,10 @@ const (
 
 func (c *realControl) Scale(ctx context.Context, updateInstance *workloadsv1alpha2.RoleInstance, currentRevision, updateRevision *apps.ControllerRevision,
 	revisions []*apps.ControllerRevision, pods []*v1.Pod, inactivePods []*v1.Pod) (bool, error) {
+	// Record node bindings for in-place scheduling.
+	// Piggybacks on the already-fetched pods — no additional API calls.
+	RecordNodeBindings(nodeBindings, updateInstance, pods)
+
 	diffRes, err := c.calculateDiffsWithExpectation(ctx, updateInstance, currentRevision, updateRevision, revisions, pods, inactivePods)
 	if err != nil {
 		return true, err
@@ -249,6 +253,9 @@ func (c *realControl) createPods(ctx context.Context, updateInstance *workloadsv
 				return false, fmt.Errorf("failed to inject component discovery into pod %s: %w", p.Name, err)
 			}
 		}
+
+		// Handle in-place scheduling: inject nodeAffinity to prefer historical nodes
+		InjectInPlaceScheduling(p, updateInstance, nodeBindings)
 
 		toCreatePodNum++
 		podsCreationChan <- p

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -46,7 +46,7 @@ func (c *realControl) Scale(ctx context.Context, updateInstance *workloadsv1alph
 	revisions []*apps.ControllerRevision, pods []*v1.Pod, inactivePods []*v1.Pod) (bool, error) {
 	// Record node bindings for in-place scheduling.
 	// Piggybacks on the already-fetched pods — no additional API calls.
-	RecordNodeBindings(nodeBindings, updateInstance, pods)
+	RecordNodeBindings(c.bindings, updateInstance, pods)
 
 	diffRes, err := c.calculateDiffsWithExpectation(ctx, updateInstance, currentRevision, updateRevision, revisions, pods, inactivePods)
 	if err != nil {
@@ -255,7 +255,7 @@ func (c *realControl) createPods(ctx context.Context, updateInstance *workloadsv
 		}
 
 		// Handle in-place scheduling: inject nodeAffinity to prefer historical nodes
-		InjectInPlaceScheduling(p, updateInstance, nodeBindings)
+		InjectInPlaceScheduling(p, updateInstance, c.bindings)
 
 		toCreatePodNum++
 		podsCreationChan <- p

--- a/pkg/reconciler/roleinstance/sync/node_binding.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding.go
@@ -115,6 +115,9 @@ func (s *NodeBindingStore) Load(key string) sets.Set[string] {
 // EvictByUID removes all bindings for the given RBG UID in O(1).
 // Intended to be called from an RBG delete event handler so that
 // bindings are cleaned up immediately when an RBG is deleted.
+//
+// NOTE: A small race window exists if RecordNodeBindings runs concurrently
+// with eviction. Persisting bindings in a CRD would eliminate this.
 func (s *NodeBindingStore) EvictByUID(uid string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -173,6 +176,9 @@ func buildKey(granularity string, instance *workloadsv1alpha2.RoleInstance, pod 
 		return fmt.Sprintf("%s/%s-%s", rbgUID, roleName, componentName)
 
 	default:
+		klog.InfoS("in-place scheduling: unrecognized granularity, skipping injection",
+			"instance", klog.KObj(instance), "granularity", granularity,
+			"validValues", fmt.Sprintf("%q or %q", constants.InplaceSchedulingGranularityPod, constants.InplaceSchedulingGranularityComponent))
 		return ""
 	}
 }
@@ -220,6 +226,9 @@ func RecordNodeBindings(store *NodeBindingStore, instance *workloadsv1alpha2.Rol
 
 		// Log when a key is first recorded — helps operators debug scheduling
 		// decisions without noise at default log levels.
+		// NOTE: TOCTOU race between Load and Add — concurrent reconciles on the
+		// same key may both log "new binding". Benign: Add is idempotent, and the
+		// log is informational only.
 		if store.Load(key) == nil {
 			klog.V(4).InfoS("in-place scheduling: recording new node binding",
 				"key", key, "node", pod.Spec.NodeName,
@@ -281,16 +290,24 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		return
 	}
 
-	// 3. Build avoid expression if configured (used in step 6).
-	// In Required mode, this expression is merged into the same NodeSelectorTerm
-	// as the in-place hostname constraint (AND semantics within a single term).
-	// In Preferred mode (or when no binding exists), it is injected as a
-	// standalone required term — the scheduler ANDs required and preferred types.
-	var avoidExpr *v1.NodeSelectorRequirement
-	if avoidLabelKey := instance.Annotations[constants.RoleInplaceSchedulingAvoidAnnotationKey]; avoidLabelKey != "" {
-		avoidExpr = &v1.NodeSelectorRequirement{
-			Key:      avoidLabelKey,
-			Operator: v1.NodeSelectorOpDoesNotExist,
+	// 3. Build avoid expressions if configured (used in steps 6 and 7).
+	// The avoid annotation value may be a single label key or a comma-separated
+	// list (e.g. "key1,key2"). Each key generates a DoesNotExist expression.
+	// In Required mode, these are merged into the same NodeSelectorTerm as the
+	// in-place hostname constraint (AND semantics within a single term).
+	// In Preferred mode (or when no binding exists), they are folded into every
+	// existing required term to preserve AND semantics across all constraints.
+	var avoidExprs []v1.NodeSelectorRequirement
+	if raw := instance.Annotations[constants.RoleInplaceSchedulingAvoidAnnotationKey]; raw != "" {
+		for _, key := range strings.Split(raw, ",") {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			avoidExprs = append(avoidExprs, v1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: v1.NodeSelectorOpDoesNotExist,
+			})
 		}
 	}
 
@@ -301,43 +318,28 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		return
 	}
 
-	// 5. Load binding
+	// 5. Ensure node affinity exists (needed for both binding and avoid injection).
+	ensureNodeAffinity(pod)
+
+	// 6. Load binding
 	nodes := store.Load(key)
 	if len(nodes) == 0 {
-		// No binding — if avoid is configured, inject it as a standalone
-		// hard constraint so the pod still avoids labelled nodes.
-		if avoidExpr != nil {
-			ensureNodeAffinity(pod)
-			na := pod.Spec.Affinity.NodeAffinity
-			if na.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-				na.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
-			}
-			na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-				na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-				v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{*avoidExpr}},
-			)
+		// No binding — if avoid is configured, fold it into every existing
+		// required term (AND semantics). If no required terms exist, add it
+		// as a standalone term.
+		if len(avoidExprs) > 0 {
+			foldIntoRequired(pod.Spec.Affinity.NodeAffinity, avoidExprs)
 		}
 		return
 	}
 
-	// 6. Inject affinity
-	ensureNodeAffinity(pod)
+	// 7. Inject affinity
 	nodeAffinity := pod.Spec.Affinity.NodeAffinity
 	values := sets.List(nodes) // sorted for deterministic output
 
 	switch mode {
 	case constants.InplaceSchedulingPreferred:
-		// In Preferred mode, avoid (if any) is a separate required term.
-		// The scheduler ANDs required and preferred affinity types.
-		if avoidExpr != nil {
-			if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
-			}
-			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-				v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{*avoidExpr}},
-			)
-		}
+		// In Preferred mode, inject a preferred term for historical nodes.
 		term := v1.PreferredSchedulingTerm{
 			Weight: 100,
 			Preference: v1.NodeSelectorTerm{
@@ -353,27 +355,30 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
 			nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
 
+		// Fold avoid into every required term (AND semantics). If no
+		// required terms exist, a standalone avoid term is created.
+		// This ensures the avoid constraint is never weakened by OR
+		// semantics when the user has pre-existing required terms.
+		if len(avoidExprs) > 0 {
+			foldIntoRequired(nodeAffinity, avoidExprs)
+		}
+
 	case constants.InplaceSchedulingRequired:
-		// In Required mode, merge avoid into the SAME NodeSelectorTerm as the
-		// hostname constraint. Within a single term, MatchExpressions are ANDed.
-		// Separate terms would be ORed, which is semantically wrong here.
-		expressions := []v1.NodeSelectorRequirement{
+		// In Required mode, ALL our expressions (hostname affinity + avoid
+		// anti-affinity) must be folded into every existing required term.
+		// Within a single term, MatchExpressions are ANDed. Appending as a
+		// separate term would create OR semantics, allowing the scheduler to
+		// bypass both the hostname constraint (Required mode degraded) and
+		// the avoid constraint (avoid weakened).
+		inPlaceExprs := []v1.NodeSelectorRequirement{
 			{
 				Key:      hostnameLabelKey,
 				Operator: v1.NodeSelectorOpIn,
 				Values:   values,
 			},
 		}
-		if avoidExpr != nil {
-			expressions = append(expressions, *avoidExpr)
-		}
-		if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
-		}
-		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			v1.NodeSelectorTerm{MatchExpressions: expressions},
-		)
+		inPlaceExprs = append(inPlaceExprs, avoidExprs...)
+		foldIntoRequired(nodeAffinity, inPlaceExprs)
 	}
 }
 
@@ -384,5 +389,27 @@ func ensureNodeAffinity(pod *v1.Pod) {
 	}
 	if pod.Spec.Affinity.NodeAffinity == nil {
 		pod.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+}
+
+// foldIntoRequired folds the given expressions into every existing required
+// NodeSelectorTerm (AND semantics within a term). If no required terms exist,
+// it creates a single new term containing only the given expressions.
+//
+// This prevents the OR semantics of separate NodeSelectorTerms from weakening
+// constraints when the user has pre-existing required nodeAffinity.
+func foldIntoRequired(na *v1.NodeAffinity, exprs []v1.NodeSelectorRequirement) {
+	if na.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		na.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+	}
+	terms := na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) == 0 {
+		na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{
+			{MatchExpressions: exprs},
+		}
+		return
+	}
+	for i := range terms {
+		terms[i].MatchExpressions = append(terms[i].MatchExpressions, exprs...)
 	}
 }

--- a/pkg/reconciler/roleinstance/sync/node_binding.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding.go
@@ -18,6 +18,7 @@ package sync
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,47 +29,117 @@ import (
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 )
 
-// NodeBindingStore is an in-memory store that maps binding keys to sets of
-// node names. A single unified structure handles both granularities; the
-// difference is determined entirely by the key format:
+// NodeBindingStore is a two-level in-memory store that maps binding keys to
+// sets of node names. The outer key is the RBG UID, enabling O(1) eviction
+// of all bindings for a deleted RBG via EvictByUID.
 //
-//   - Pod-level:       {rbgUID}/{podName}              → set of size 1
-//   - Component-level: {rbgUID}/{roleName}-{component} → set of all nodes
-//     that have hosted the same component type
+// Inner structure per UID:
+//
+//	Pod-level:       {podName}              → set of size 1
+//	Component-level: {roleName}-{component} → set of all nodes that have
+//	                                         hosted the same component type
 //
 // Using the RBG's real Kubernetes object UID (RBGOwnerUIDLabelKey) ensures
 // that when an RBG is deleted and recreated with the same name, the new RBG
 // gets a different UID and does not inherit stale bindings.
 //
-// The store is naturally bounded and self-correcting after controller restart.
+// Concurrency: a single sync.RWMutex protects both map levels. All operations
+// (Add, Load, EvictByUID) hold the lock for very short durations (map lookups
+// and set inserts), so contention is negligible in practice.
 type NodeBindingStore struct {
 	mu       sync.RWMutex
-	bindings map[string]sets.Set[string]
+	bindings map[string]*rbgBindings
+}
+
+// rbgBindings holds all node bindings for a single RBG, keyed by sub-key
+// (pod name or role-component name). Each RBG's bindings are isolated so
+// that EvictByUID can remove them all in O(1).
+type rbgBindings struct {
+	keys map[string]sets.Set[string]
 }
 
 // NewNodeBindingStore creates a new empty NodeBindingStore.
 func NewNodeBindingStore() *NodeBindingStore {
 	return &NodeBindingStore{
-		bindings: make(map[string]sets.Set[string]),
+		bindings: make(map[string]*rbgBindings),
 	}
 }
 
-// Add inserts nodeName into the set for key. Idempotent — calling it
-// repeatedly with the same (key, node) pair is a no-op.
+// Add inserts nodeName into the set for key. The key format is
+// "{rbgUID}/{subKey}". Idempotent — calling it repeatedly with the same
+// (key, node) pair is a no-op.
 func (s *NodeBindingStore) Add(key, nodeName string) {
+	uid, subKey, ok := splitKey(key)
+	if !ok {
+		return
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.bindings[key] == nil {
-		s.bindings[key] = sets.New[string]()
+
+	rb := s.bindings[uid]
+	if rb == nil {
+		rb = &rbgBindings{keys: make(map[string]sets.Set[string])}
+		s.bindings[uid] = rb
 	}
-	s.bindings[key].Insert(nodeName)
+	if rb.keys[subKey] == nil {
+		rb.keys[subKey] = sets.New[string]()
+	}
+	rb.keys[subKey].Insert(nodeName)
 }
 
-// Load returns the set of node names for key. Returns nil if no binding exists.
+// Load returns a clone of the node name set for key. Returns nil if no
+// binding exists. The returned set is a snapshot safe for concurrent
+// iteration — callers do not need to hold any lock.
+// The key format is "{rbgUID}/{subKey}".
 func (s *NodeBindingStore) Load(key string) sets.Set[string] {
+	uid, subKey, ok := splitKey(key)
+	if !ok {
+		return nil
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.bindings[key]
+
+	rb := s.bindings[uid]
+	if rb == nil {
+		return nil
+	}
+	v := rb.keys[subKey]
+	if v == nil {
+		return nil
+	}
+	return v.Clone()
+}
+
+// EvictByUID removes all bindings for the given RBG UID in O(1).
+// Intended to be called from an RBG delete event handler so that
+// bindings are cleaned up immediately when an RBG is deleted.
+func (s *NodeBindingStore) EvictByUID(uid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, existed := s.bindings[uid]; existed {
+		klog.InfoS("in-place scheduling: evicted all node bindings for RBG", "uid", uid)
+		delete(s.bindings, uid)
+	}
+}
+
+// Len returns the number of RBG UIDs tracked in the store.
+// Exposed primarily for testing and debugging.
+func (s *NodeBindingStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.bindings)
+}
+
+// splitKey splits a "{uid}/{subKey}" string into its components.
+// Returns ("", "", false) if the key does not contain a "/".
+func splitKey(key string) (uid, subKey string, ok bool) {
+	uid, subKey, ok = strings.Cut(key, "/")
+	if !ok || uid == "" || subKey == "" {
+		return "", "", false
+	}
+	return uid, subKey, true
 }
 
 // buildKey constructs the binding store key based on the given granularity.

--- a/pkg/reconciler/roleinstance/sync/node_binding.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+// NodeBindingStore is an in-memory store that maps binding keys to sets of
+// node names. A single unified structure handles both granularities; the
+// difference is determined entirely by the key format:
+//
+//   - Pod-level:       {rbgUID}/{podName}              → set of size 1
+//   - Component-level: {rbgUID}/{roleName}-{component} → set of all nodes
+//     that have hosted the same component type
+//
+// Using the RBG's real Kubernetes object UID (RBGOwnerUIDLabelKey) ensures
+// that when an RBG is deleted and recreated with the same name, the new RBG
+// gets a different UID and does not inherit stale bindings.
+//
+// The store is naturally bounded and self-correcting after controller restart.
+type NodeBindingStore struct {
+	mu       sync.RWMutex
+	bindings map[string]sets.Set[string]
+}
+
+// NewNodeBindingStore creates a new empty NodeBindingStore.
+func NewNodeBindingStore() *NodeBindingStore {
+	return &NodeBindingStore{
+		bindings: make(map[string]sets.Set[string]),
+	}
+}
+
+// Add inserts nodeName into the set for key. Idempotent — calling it
+// repeatedly with the same (key, node) pair is a no-op.
+func (s *NodeBindingStore) Add(key, nodeName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bindings[key] == nil {
+		s.bindings[key] = sets.New[string]()
+	}
+	s.bindings[key].Insert(nodeName)
+}
+
+// Load returns the set of node names for key. Returns nil if no binding exists.
+func (s *NodeBindingStore) Load(key string) sets.Set[string] {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.bindings[key]
+}
+
+// buildKey constructs the binding store key based on the given granularity.
+//
+// Pod-level key: {rbgUID}/{podName}
+//
+//	Each Pod has a unique key; the set always contains exactly one node.
+//
+// Component-level key: {rbgUID}/{roleName}-{componentName}
+//
+//	Multiple Pods of the same component type share the same key, so their
+//	nodes accumulate into a set.
+//
+// Returns an empty string if the RBG UID cannot be determined.
+func buildKey(granularity string, instance *workloadsv1alpha2.RoleInstance, pod *v1.Pod) string {
+	rbgUID := instance.Labels[constants.RBGOwnerUIDLabelKey]
+	if rbgUID == "" {
+		return ""
+	}
+
+	switch granularity {
+	case constants.InplaceSchedulingGranularityPod:
+		return fmt.Sprintf("%s/%s", rbgUID, pod.Name)
+
+	case constants.InplaceSchedulingGranularityComponent:
+		roleName := instance.Labels[constants.RoleNameLabelKey]
+		componentName := pod.Labels[constants.ComponentNameLabelKey]
+		if roleName == "" || componentName == "" {
+			return ""
+		}
+		return fmt.Sprintf("%s/%s-%s", rbgUID, roleName, componentName)
+
+	default:
+		return ""
+	}
+}
+
+// resolveGranularity determines the binding granularity from the instance.
+// When the granularity annotation is not set, it auto-detects:
+//   - Stateless mode (no role-instance-index label) → Component
+//   - Stateful mode  (has role-instance-index label) → Pod
+func resolveGranularity(instance *workloadsv1alpha2.RoleInstance) string {
+	if g := instance.Annotations[constants.RoleInplaceSchedulingGranularityAnnotationKey]; g != "" {
+		return g
+	}
+	// Stateful RoleInstances carry the role-instance-index label;
+	// Stateless ones do not. Use this to distinguish the two modes.
+	if _, ok := instance.Labels[constants.RoleInstanceIndexLabelKey]; !ok {
+		return constants.InplaceSchedulingGranularityComponent
+	}
+	return constants.InplaceSchedulingGranularityPod
+}
+
+// RecordNodeBindings iterates over the given pods and records node assignments
+// into the binding store for pods that are Running and Ready.
+//
+// The granularity is auto-detected from the instance annotations (or explicitly
+// configured). The same Add API is used for both granularities — the key format
+// determines whether the binding is per-Pod or per-Component.
+//
+// This is designed to piggyback on the existing getOwnedPods result — no
+// additional API calls.
+func RecordNodeBindings(store *NodeBindingStore, instance *workloadsv1alpha2.RoleInstance, pods []*v1.Pod) {
+	granularity := resolveGranularity(instance)
+
+	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		if !isPodRunningAndReady(pod) {
+			continue
+		}
+
+		key := buildKey(granularity, instance, pod)
+		if key == "" {
+			continue
+		}
+
+		// Log when a key is first recorded — helps operators debug scheduling
+		// decisions without noise at default log levels.
+		if store.Load(key) == nil {
+			klog.V(4).InfoS("in-place scheduling: recording new node binding",
+				"key", key, "node", pod.Spec.NodeName,
+				"granularity", granularity,
+				"pod", klog.KObj(pod))
+		}
+		store.Add(key, pod.Spec.NodeName)
+	}
+}
+
+// isPodRunningAndReady reports whether the pod is in Running phase and has
+// the Ready condition set to True.
+func isPodRunningAndReady(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady {
+			return cond.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+const hostnameLabelKey = "kubernetes.io/hostname"
+
+// InjectInPlaceScheduling injects nodeAffinity into the pod based on the
+// in-place scheduling annotation and the node binding store. It is called
+// during pod creation in createPods.
+//
+// The granularity is auto-detected (or explicitly configured). For Pod-level,
+// the affinity targets a single node; for Component-level, it targets all
+// nodes that have hosted the same component type.
+//
+// In Preferred mode, a preferred scheduling term (weight 100) is injected.
+// In Required mode, a hard constraint is injected.
+//
+// The injection is skipped when:
+//   - The in-place scheduling annotation is not set on the instance.
+//   - The annotation mode is not "Preferred" or "Required" (with a warning).
+//   - The pod has exclusive topology affinity (to avoid conflicts).
+//   - No node binding exists for this Pod (initial creation or controller just restarted).
+//   - The granularity is Component but the Pod has no component-name label.
+func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstance, store *NodeBindingStore) {
+	// 1. Check annotation and validate mode
+	mode := instance.Annotations[constants.RoleInplaceSchedulingAnnotationKey]
+	if mode == "" {
+		return
+	}
+	if mode != constants.InplaceSchedulingPreferred && mode != constants.InplaceSchedulingRequired {
+		klog.InfoS("in-place scheduling: unrecognized mode, skipping injection",
+			"instance", klog.KObj(instance), "mode", mode,
+			"validValues", fmt.Sprintf("%q or %q", constants.InplaceSchedulingPreferred, constants.InplaceSchedulingRequired))
+		return
+	}
+
+	// 2. Check exclusive topology conflict
+	if pod.Annotations[constants.GroupExclusiveTopologyKey] != "" {
+		return
+	}
+
+	// 3. Build avoid expression if configured (used in step 6).
+	// In Required mode, this expression is merged into the same NodeSelectorTerm
+	// as the in-place hostname constraint (AND semantics within a single term).
+	// In Preferred mode (or when no binding exists), it is injected as a
+	// standalone required term — the scheduler ANDs required and preferred types.
+	var avoidExpr *v1.NodeSelectorRequirement
+	if avoidLabelKey := instance.Annotations[constants.RoleInplaceSchedulingAvoidAnnotationKey]; avoidLabelKey != "" {
+		avoidExpr = &v1.NodeSelectorRequirement{
+			Key:      avoidLabelKey,
+			Operator: v1.NodeSelectorOpDoesNotExist,
+		}
+	}
+
+	// 4. Determine granularity and build key
+	granularity := resolveGranularity(instance)
+	key := buildKey(granularity, instance, pod)
+	if key == "" {
+		return
+	}
+
+	// 5. Load binding
+	nodes := store.Load(key)
+	if len(nodes) == 0 {
+		// No binding — if avoid is configured, inject it as a standalone
+		// hard constraint so the pod still avoids labelled nodes.
+		if avoidExpr != nil {
+			ensureNodeAffinity(pod)
+			na := pod.Spec.Affinity.NodeAffinity
+			if na.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+				na.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+			}
+			na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+				na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+				v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{*avoidExpr}},
+			)
+		}
+		return
+	}
+
+	// 6. Inject affinity
+	ensureNodeAffinity(pod)
+	nodeAffinity := pod.Spec.Affinity.NodeAffinity
+	values := sets.List(nodes) // sorted for deterministic output
+
+	switch mode {
+	case constants.InplaceSchedulingPreferred:
+		// In Preferred mode, avoid (if any) is a separate required term.
+		// The scheduler ANDs required and preferred affinity types.
+		if avoidExpr != nil {
+			if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+			}
+			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+				v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{*avoidExpr}},
+			)
+		}
+		term := v1.PreferredSchedulingTerm{
+			Weight: 100,
+			Preference: v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{
+						Key:      hostnameLabelKey,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   values,
+					},
+				},
+			},
+		}
+		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
+
+	case constants.InplaceSchedulingRequired:
+		// In Required mode, merge avoid into the SAME NodeSelectorTerm as the
+		// hostname constraint. Within a single term, MatchExpressions are ANDed.
+		// Separate terms would be ORed, which is semantically wrong here.
+		expressions := []v1.NodeSelectorRequirement{
+			{
+				Key:      hostnameLabelKey,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   values,
+			},
+		}
+		if avoidExpr != nil {
+			expressions = append(expressions, *avoidExpr)
+		}
+		if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+		}
+		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+			v1.NodeSelectorTerm{MatchExpressions: expressions},
+		)
+	}
+}
+
+// ensureNodeAffinity initializes the Affinity and NodeAffinity structs if nil.
+func ensureNodeAffinity(pod *v1.Pod) {
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &v1.Affinity{}
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		pod.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+}

--- a/pkg/reconciler/roleinstance/sync/node_binding.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/rbgs/api/workloads/constants"
@@ -287,6 +288,8 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 
 	// 2. Check exclusive topology conflict
 	if pod.Annotations[constants.GroupExclusiveTopologyKey] != "" {
+		klog.V(4).InfoS("in-place scheduling: skipped due to exclusive topology, no affinity injected",
+			"pod", klog.KObj(pod), "instance", klog.KObj(instance))
 		return
 	}
 
@@ -302,6 +305,11 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		for _, key := range strings.Split(raw, ",") {
 			key = strings.TrimSpace(key)
 			if key == "" {
+				continue
+			}
+			if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+				klog.InfoS("in-place scheduling: invalid avoid label key, skipping",
+					"key", key, "instance", klog.KObj(instance), "errors", errs)
 				continue
 			}
 			avoidExprs = append(avoidExprs, v1.NodeSelectorRequirement{

--- a/pkg/reconciler/roleinstance/sync/node_binding_test.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding_test.go
@@ -1,0 +1,940 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+// ---------------------------------------------------------------------------
+// NodeBindingStore
+// ---------------------------------------------------------------------------
+
+func TestNodeBindingStore_AddAndLoad(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	store.Add("uid/prefill-0", "node-A")
+
+	got := store.Load("uid/prefill-0")
+	assert.Equal(t, []string{"node-A"}, got.UnsortedList())
+}
+
+func TestNodeBindingStore_AddIdempotent(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	store.Add("uid/prefill-0", "node-A")
+	store.Add("uid/prefill-0", "node-A") // duplicate
+
+	got := store.Load("uid/prefill-0")
+	assert.Len(t, got, 1)
+	assert.Equal(t, []string{"node-A"}, got.UnsortedList())
+}
+
+func TestNodeBindingStore_AddMultipleNodes(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	// Component-level: multiple Pods add different nodes under the same key
+	store.Add("uid/prefill-Prefill", "node-A")
+	store.Add("uid/prefill-Prefill", "node-B")
+	store.Add("uid/prefill-Prefill", "node-C")
+
+	got := store.Load("uid/prefill-Prefill")
+	assert.Len(t, got, 3)
+	assert.ElementsMatch(t, []string{"node-A", "node-B", "node-C"}, got.UnsortedList())
+}
+
+func TestNodeBindingStore_LoadMissing(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	got := store.Load("uid/nonexistent")
+	assert.Nil(t, got)
+	assert.Len(t, got, 0) // nil set has len 0
+}
+
+// ---------------------------------------------------------------------------
+// buildKey
+// ---------------------------------------------------------------------------
+
+func TestBuildKey_Pod(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: "uid-123",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rbg-prefill-0"},
+	}
+
+	key := buildKey(constants.InplaceSchedulingGranularityPod, instance, pod)
+	assert.Equal(t, "uid-123/my-rbg-prefill-0", key)
+}
+
+func TestBuildKey_Component(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: "uid-123",
+				constants.RoleNameLabelKey:    "prefill",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	key := buildKey(constants.InplaceSchedulingGranularityComponent, instance, pod)
+	assert.Equal(t, "uid-123/prefill-Prefill", key)
+}
+
+func TestBuildKey_MissingRBGUID(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0"},
+	}
+
+	key := buildKey(constants.InplaceSchedulingGranularityPod, instance, pod)
+	assert.Equal(t, "", key)
+}
+
+func TestBuildKey_ComponentMissingRoleName(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: "uid-123",
+				// RoleNameLabelKey missing
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	key := buildKey(constants.InplaceSchedulingGranularityComponent, instance, pod)
+	assert.Equal(t, "", key)
+}
+
+func TestBuildKey_ComponentMissingComponentName(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: "uid-123",
+				constants.RoleNameLabelKey:    "prefill",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				// ComponentNameLabelKey missing
+			},
+		},
+	}
+
+	key := buildKey(constants.InplaceSchedulingGranularityComponent, instance, pod)
+	assert.Equal(t, "", key)
+}
+
+func TestBuildKey_UnknownGranularity(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: "uid-123",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0"},
+	}
+
+	key := buildKey("InvalidGranularity", instance, pod)
+	assert.Equal(t, "", key)
+}
+
+// ---------------------------------------------------------------------------
+// resolveGranularity
+// ---------------------------------------------------------------------------
+
+func TestResolveGranularity_ExplicitAnnotation(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.RoleInplaceSchedulingGranularityAnnotationKey: constants.InplaceSchedulingGranularityComponent,
+			},
+			Labels: map[string]string{
+				// Has index label (Stateful), but explicit annotation overrides
+				constants.RoleInstanceIndexLabelKey: "0",
+			},
+		},
+	}
+
+	g := resolveGranularity(instance)
+	assert.Equal(t, constants.InplaceSchedulingGranularityComponent, g)
+}
+
+func TestResolveGranularity_StatefulDefaultsToPod(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RoleInstanceIndexLabelKey: "0",
+			},
+		},
+	}
+
+	g := resolveGranularity(instance)
+	assert.Equal(t, constants.InplaceSchedulingGranularityPod, g)
+}
+
+func TestResolveGranularity_StatelessDefaultsToComponent(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				// No RoleInstanceIndexLabelKey → Stateless
+			},
+		},
+	}
+
+	g := resolveGranularity(instance)
+	assert.Equal(t, constants.InplaceSchedulingGranularityComponent, g)
+}
+
+// ---------------------------------------------------------------------------
+// isPodRunningAndReady
+// ---------------------------------------------------------------------------
+
+func TestIsPodRunningAndReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "Running and Ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Running but Not Ready",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Pending phase",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			expected: false,
+		},
+		{
+			name: "Failed phase",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+			},
+			expected: false,
+		},
+		{
+			name: "Running but no Ready condition",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:      corev1.PodRunning,
+					Conditions: []corev1.PodCondition{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isPodRunningAndReady(tt.pod))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordNodeBindings
+// ---------------------------------------------------------------------------
+
+func makeRunningReadyPod(name, nodeName, componentName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: componentName,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func statefulInstance(rbgUID, roleName string) *workloadsv1alpha2.RoleInstance {
+	return &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey:       rbgUID,
+				constants.RoleNameLabelKey:          roleName,
+				constants.RoleInstanceIndexLabelKey: "0",
+			},
+		},
+	}
+}
+
+func statelessInstance(rbgUID, roleName string) *workloadsv1alpha2.RoleInstance {
+	return &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.RBGOwnerUIDLabelKey: rbgUID,
+				constants.RoleNameLabelKey:    roleName,
+				// No RoleInstanceIndexLabelKey → Stateless
+			},
+		},
+	}
+}
+
+func TestRecordNodeBindings_Stateful_PodGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := statefulInstance("uid-1", "prefill")
+
+	pods := []*corev1.Pod{
+		makeRunningReadyPod("prefill-0", "node-A", "Prefill"),
+		makeRunningReadyPod("prefill-1", "node-B", "Prefill"),
+	}
+
+	RecordNodeBindings(store, instance, pods)
+
+	// Pod-level keys
+	got0 := store.Load("uid-1/prefill-0")
+	assert.Equal(t, []string{"node-A"}, got0.UnsortedList())
+
+	got1 := store.Load("uid-1/prefill-1")
+	assert.Equal(t, []string{"node-B"}, got1.UnsortedList())
+}
+
+func TestRecordNodeBindings_Stateless_ComponentGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := statelessInstance("uid-1", "prefill")
+
+	pods := []*corev1.Pod{
+		makeRunningReadyPod("abc-Prefill-0", "node-A", "Prefill"),
+		makeRunningReadyPod("abc-Prefill-1", "node-B", "Prefill"),
+	}
+
+	RecordNodeBindings(store, instance, pods)
+
+	// Component-level key: both Pods accumulate under the same key
+	got := store.Load("uid-1/prefill-Prefill")
+	assert.Len(t, got, 2)
+	assert.ElementsMatch(t, []string{"node-A", "node-B"}, got.UnsortedList())
+}
+
+func TestRecordNodeBindings_SkipsNonReadyPods(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := statefulInstance("uid-1", "prefill")
+
+	pods := []*corev1.Pod{
+		makeRunningReadyPod("prefill-0", "node-A", "Prefill"),
+		// Running but NOT Ready
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "prefill-1",
+				Labels: map[string]string{constants.ComponentNameLabelKey: "Prefill"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-B"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+				},
+			},
+		},
+		// No NodeName (unscheduled)
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "prefill-2",
+				Labels: map[string]string{constants.ComponentNameLabelKey: "Prefill"},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodPending},
+		},
+	}
+
+	RecordNodeBindings(store, instance, pods)
+
+	// Only prefill-0 should be recorded
+	got0 := store.Load("uid-1/prefill-0")
+	assert.Equal(t, []string{"node-A"}, got0.UnsortedList())
+
+	assert.Nil(t, store.Load("uid-1/prefill-1"))
+	assert.Nil(t, store.Load("uid-1/prefill-2"))
+}
+
+func TestRecordNodeBindings_SkipsWhenNoRBGUID(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				// RBGOwnerUIDLabelKey missing
+				constants.RoleInstanceIndexLabelKey: "0",
+			},
+		},
+	}
+
+	pods := []*corev1.Pod{
+		makeRunningReadyPod("prefill-0", "node-A", "Prefill"),
+	}
+
+	RecordNodeBindings(store, instance, pods)
+	assert.Nil(t, store.Load("prefill-0"))
+}
+
+// ---------------------------------------------------------------------------
+// InjectInPlaceScheduling
+// ---------------------------------------------------------------------------
+
+func TestInjectInPlaceScheduling_Preferred_PodGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	assert.NotNil(t, pod.Spec.Affinity)
+	assert.NotNil(t, pod.Spec.Affinity.NodeAffinity)
+	terms := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 1)
+	assert.Equal(t, int32(100), terms[0].Weight)
+	assert.Equal(t, hostnameLabelKey, terms[0].Preference.MatchExpressions[0].Key)
+	assert.Equal(t, []string{"node-A"}, terms[0].Preference.MatchExpressions[0].Values)
+	// Required should NOT be set
+	assert.Nil(t, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+}
+
+func TestInjectInPlaceScheduling_Required_PodGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingRequired,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	assert.NotNil(t, pod.Spec.Affinity)
+	// Preferred should NOT be set
+	assert.Empty(t, pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	// Required should be set
+	req := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	assert.Equal(t, hostnameLabelKey, req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+	assert.Equal(t, []string{"node-A"}, req.NodeSelectorTerms[0].MatchExpressions[0].Values)
+}
+
+func TestInjectInPlaceScheduling_Preferred_ComponentGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-Prefill", "node-A")
+	store.Add("uid-1/prefill-Prefill", "node-B")
+
+	instance := statelessInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "def-Prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	assert.NotNil(t, pod.Spec.Affinity)
+	terms := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 1)
+	// Both nodes should be in the values (sorted)
+	assert.Equal(t, []string{"node-A", "node-B"}, terms[0].Preference.MatchExpressions[0].Values)
+}
+
+func TestInjectInPlaceScheduling_NoAnnotation(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	// No RoleInplaceSchedulingAnnotationKey
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "prefill-0"},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_InvalidMode(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: "InvalidMode",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "prefill-0"},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_ExclusiveTopologySkips(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Annotations: map[string]string{
+				constants.GroupExclusiveTopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_NoBinding(t *testing.T) {
+	store := NewNodeBindingStore()
+	// Empty store — no bindings
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_ComponentMissingLabel(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-Prefill", "node-A")
+
+	instance := statelessInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "def-Prefill-0",
+			Labels: map[string]string{
+				// ComponentNameLabelKey missing → buildKey returns ""
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_PreservesExistingAffinity(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: 50,
+							Preference: corev1.NodeSelectorTerm{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "gpu-type",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"A100"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	// Original term should be preserved
+	terms := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 2)
+	assert.Equal(t, int32(50), terms[0].Weight)
+	assert.Equal(t, "gpu-type", terms[0].Preference.MatchExpressions[0].Key)
+	// Injected term
+	assert.Equal(t, int32(100), terms[1].Weight)
+	assert.Equal(t, hostnameLabelKey, terms[1].Preference.MatchExpressions[0].Key)
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: Record then Inject (integration-style)
+// ---------------------------------------------------------------------------
+
+func TestRecordAndInject_Stateful_PodGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	// Phase 1: Record bindings from running Pods
+	oldPods := []*corev1.Pod{
+		makeRunningReadyPod("prefill-0", "node-A", "Prefill"),
+		makeRunningReadyPod("prefill-1", "node-B", "Prefill"),
+	}
+	RecordNodeBindings(store, instance, oldPods)
+
+	// Phase 2: Inject into a new Pod with the same name
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+	InjectInPlaceScheduling(newPod, instance, store)
+
+	// Should target node-A
+	terms := newPod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 1)
+	assert.Equal(t, []string{"node-A"}, terms[0].Preference.MatchExpressions[0].Values)
+}
+
+func TestRecordAndInject_Stateless_ComponentGranularity(t *testing.T) {
+	store := NewNodeBindingStore()
+	instance := statelessInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+	}
+
+	// Phase 1: Record bindings from old Pods (abc prefix)
+	oldPods := []*corev1.Pod{
+		makeRunningReadyPod("abc-Prefill-0", "node-A", "Prefill"),
+		makeRunningReadyPod("abc-Prefill-1", "node-B", "Prefill"),
+	}
+	RecordNodeBindings(store, instance, oldPods)
+
+	// Phase 2: Inject into a surge Pod (def prefix — different name!)
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "def-Prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+	InjectInPlaceScheduling(newPod, instance, store)
+
+	// Should target both node-A and node-B (component-level)
+	terms := newPod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 1)
+	assert.Equal(t, []string{"node-A", "node-B"}, terms[0].Preference.MatchExpressions[0].Values)
+}
+
+// ---------------------------------------------------------------------------
+// Avoid annotation (anti-affinity)
+// ---------------------------------------------------------------------------
+
+func TestInjectInPlaceScheduling_AvoidAnnotation(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+
+	// Avoid term: Required + DoesNotExist
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, req.NodeSelectorTerms[0].MatchExpressions[0].Operator)
+	assert.Empty(t, req.NodeSelectorTerms[0].MatchExpressions[0].Values)
+
+	// Inplace affinity term: Preferred weight 100
+	prefTerms := na.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, prefTerms, 1)
+	assert.Equal(t, int32(100), prefTerms[0].Weight)
+	assert.Equal(t, hostnameLabelKey, prefTerms[0].Preference.MatchExpressions[0].Key)
+}
+
+func TestInjectInPlaceScheduling_AvoidWithoutBinding(t *testing.T) {
+	store := NewNodeBindingStore()
+	// Empty store — no bindings
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	// Avoid term should still be injected even without binding
+	assert.NotNil(t, pod.Spec.Affinity)
+	req := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, req.NodeSelectorTerms[0].MatchExpressions[0].Operator)
+
+	// No preferred term (binding was empty, so affinity injection was skipped)
+	assert.Empty(t, pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+}
+
+func TestInjectInPlaceScheduling_NoAvoidAnnotation(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+		// No avoid annotation
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	// Only the inplace affinity term (Preferred), no avoid term (Required)
+	terms := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, terms, 1)
+	assert.Equal(t, int32(100), terms[0].Weight)
+	assert.Nil(t, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+}
+
+func TestInjectInPlaceScheduling_AvoidSkippedByExclusiveTopology(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Annotations: map[string]string{
+				constants.GroupExclusiveTopologyKey: "kubernetes.io/hostname",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	// Exclusive topology takes precedence — nothing injected (not even avoid)
+	assert.Nil(t, pod.Spec.Affinity)
+}
+
+// TestInjectInPlaceScheduling_RequiredWithAvoid verifies that in Required mode,
+// the avoid MatchExpression is merged into the SAME NodeSelectorTerm as the
+// hostname constraint. This is critical: separate NodeSelectorTerms are ORed,
+// but we need AND semantics (historical node AND no avoid label).
+func TestInjectInPlaceScheduling_RequiredWithAvoid(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingRequired,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+
+	// No preferred terms — Required mode does not inject preferred affinity.
+	assert.Empty(t, na.PreferredDuringSchedulingIgnoredDuringExecution)
+
+	// Exactly ONE NodeSelectorTerm containing TWO MatchExpressions (AND semantics).
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1,
+		"avoid and hostname must be in the SAME term (AND), not separate terms (OR)")
+
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	assert.Len(t, exprs, 2)
+
+	// First expression: hostname In [node-A]
+	assert.Equal(t, hostnameLabelKey, exprs[0].Key)
+	assert.Equal(t, corev1.NodeSelectorOpIn, exprs[0].Operator)
+	assert.Equal(t, []string{"node-A"}, exprs[0].Values)
+
+	// Second expression: avoid label DoesNotExist
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", exprs[1].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[1].Operator)
+}
+
+func TestInjectInPlaceScheduling_AvoidSkippedWhenNoMode(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		// No RoleInplaceSchedulingAnnotationKey
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "prefill-0"},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+	// No mode annotation → entire injection skipped (including avoid)
+	assert.Nil(t, pod.Spec.Affinity)
+}

--- a/pkg/reconciler/roleinstance/sync/node_binding_test.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding_test.go
@@ -684,7 +684,14 @@ func TestInjectInPlaceScheduling_NoBinding(t *testing.T) {
 	}
 
 	InjectInPlaceScheduling(pod, instance, store)
-	assert.Nil(t, pod.Spec.Affinity)
+	// No binding and no avoid → no affinity terms injected.
+	// ensureNodeAffinity is called early, so Affinity may be non-nil,
+	// but it must contain no scheduling terms.
+	if pod.Spec.Affinity != nil && pod.Spec.Affinity.NodeAffinity != nil {
+		na := pod.Spec.Affinity.NodeAffinity
+		assert.Nil(t, na.RequiredDuringSchedulingIgnoredDuringExecution)
+		assert.Empty(t, na.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
 }
 
 func TestInjectInPlaceScheduling_ComponentMissingLabel(t *testing.T) {
@@ -1016,4 +1023,326 @@ func TestInjectInPlaceScheduling_AvoidSkippedWhenNoMode(t *testing.T) {
 	InjectInPlaceScheduling(pod, instance, store)
 	// No mode annotation → entire injection skipped (including avoid)
 	assert.Nil(t, pod.Spec.Affinity)
+}
+
+func TestInjectInPlaceScheduling_AvoidFoldWithPreExistingRequired_NoBinding(t *testing.T) {
+	store := NewNodeBindingStore()
+	// Empty store — no bindings
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "topology.kubernetes.io/zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-east-1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	// Avoid is folded into the pre-existing required term (AND semantics).
+	assert.Len(t, req.NodeSelectorTerms, 1,
+		"avoid must be folded into existing term, not appended as a separate OR'd term")
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	assert.Len(t, exprs, 2,
+		"term should have zone (original) + avoid (folded)")
+	assert.Equal(t, "topology.kubernetes.io/zone", exprs[0].Key)
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", exprs[1].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[1].Operator)
+}
+
+func TestInjectInPlaceScheduling_AvoidFoldWithPreExistingRequired_Preferred(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "workloads.x-k8s.io/heavy-tenant",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "topology.kubernetes.io/zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-east-1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+
+	// Preferred term is injected
+	assert.Len(t, na.PreferredDuringSchedulingIgnoredDuringExecution, 1)
+	assert.Equal(t, int32(100), na.PreferredDuringSchedulingIgnoredDuringExecution[0].Weight)
+
+	// Avoid is folded into the pre-existing required term (AND semantics).
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1,
+		"avoid must be folded into existing term, not appended as a separate OR'd term")
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	assert.Len(t, exprs, 2,
+		"term should have zone (original) + avoid (folded)")
+	assert.Equal(t, "topology.kubernetes.io/zone", exprs[0].Key)
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", exprs[1].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[1].Operator)
+}
+
+func TestFoldAvoidIntoRequired_NoExistingTerms(t *testing.T) {
+	na := &corev1.NodeAffinity{}
+	avoidExprs := []corev1.NodeSelectorRequirement{
+		{
+			Key:      "workloads.x-k8s.io/heavy-tenant",
+			Operator: corev1.NodeSelectorOpDoesNotExist,
+		},
+	}
+
+	foldIntoRequired(na, avoidExprs)
+
+	// When no required terms exist, a standalone avoid term is created.
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	assert.Len(t, req.NodeSelectorTerms[0].MatchExpressions, 1)
+	assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+}
+
+func TestFoldAvoidIntoRequired_WithExistingTerms(t *testing.T) {
+	na := &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-west-2"}},
+					},
+				},
+			},
+		},
+	}
+	avoidExprs := []corev1.NodeSelectorRequirement{
+		{
+			Key:      "workloads.x-k8s.io/heavy-tenant",
+			Operator: corev1.NodeSelectorOpDoesNotExist,
+		},
+	}
+
+	foldIntoRequired(na, avoidExprs)
+
+	// Avoid is folded into EACH existing term (AND semantics).
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, req.NodeSelectorTerms, 2)
+	for i, term := range req.NodeSelectorTerms {
+		assert.Len(t, term.MatchExpressions, 2, "term %d should have zone + avoid", i)
+		assert.Equal(t, "zone", term.MatchExpressions[0].Key)
+		assert.Equal(t, "workloads.x-k8s.io/heavy-tenant", term.MatchExpressions[1].Key)
+		assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, term.MatchExpressions[1].Operator)
+	}
+}
+
+func TestInjectInPlaceScheduling_MultiKeyAvoid_Preferred(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "key1, key2,key3",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+
+	// Preferred term: hostname affinity
+	assert.Len(t, na.PreferredDuringSchedulingIgnoredDuringExecution, 1)
+
+	// Required terms: all 3 avoid keys folded in
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	assert.Len(t, exprs, 3)
+	for i, want := range []string{"key1", "key2", "key3"} {
+		assert.Equal(t, want, exprs[i].Key)
+		assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[i].Operator)
+	}
+}
+
+func TestInjectInPlaceScheduling_MultiKeyAvoid_Required(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingRequired,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "key1,key2",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	// hostname + 2 avoid keys = 3 expressions in a single term (AND)
+	assert.Len(t, exprs, 3)
+	assert.Equal(t, hostnameLabelKey, exprs[0].Key)
+	assert.Equal(t, "key1", exprs[1].Key)
+	assert.Equal(t, "key2", exprs[2].Key)
+}
+
+func TestFoldAvoidIntoRequired_MultiKey(t *testing.T) {
+	na := &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+					},
+				},
+			},
+		},
+	}
+	avoidExprs := []corev1.NodeSelectorRequirement{
+		{Key: "avoid-a", Operator: corev1.NodeSelectorOpDoesNotExist},
+		{Key: "avoid-b", Operator: corev1.NodeSelectorOpDoesNotExist},
+	}
+
+	foldIntoRequired(na, avoidExprs)
+
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	// zone + avoid-a + avoid-b = 3 expressions
+	assert.Len(t, exprs, 3)
+	assert.Equal(t, "zone", exprs[0].Key)
+	assert.Equal(t, "avoid-a", exprs[1].Key)
+	assert.Equal(t, "avoid-b", exprs[2].Key)
+}
+
+func TestInjectInPlaceScheduling_RequiredAvoidFoldWithPreExistingTerms(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingRequired,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "avoid-key",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	req := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	// All expressions folded into the user's existing term (AND semantics).
+	// No separate term is appended — that would create OR semantics.
+	assert.Len(t, req.NodeSelectorTerms, 1,
+		"hostname + avoid must be folded into existing term, not appended as a separate OR'd term")
+
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	// zone (original) + hostname (in-place affinity) + avoid (anti-affinity) = 3
+	assert.Len(t, exprs, 3)
+	assert.Equal(t, "zone", exprs[0].Key)
+	assert.Equal(t, hostnameLabelKey, exprs[1].Key)
+	assert.Equal(t, corev1.NodeSelectorOpIn, exprs[1].Operator)
+	assert.Equal(t, "avoid-key", exprs[2].Key)
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[2].Operator)
 }

--- a/pkg/reconciler/roleinstance/sync/node_binding_test.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding_test.go
@@ -72,6 +72,85 @@ func TestNodeBindingStore_LoadMissing(t *testing.T) {
 	assert.Len(t, got, 0) // nil set has len 0
 }
 
+func TestNodeBindingStore_EvictByUID(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	// Two UIDs with multiple sub-keys each.
+	store.Add("uid-1/prefill-0", "node-A")
+	store.Add("uid-1/prefill-1", "node-B")
+	store.Add("uid-2/decode-0", "node-C")
+
+	// Evict uid-1 — should remove all its bindings.
+	store.EvictByUID("uid-1")
+	assert.Nil(t, store.Load("uid-1/prefill-0"))
+	assert.Nil(t, store.Load("uid-1/prefill-1"))
+
+	// uid-2 should be unaffected.
+	got := store.Load("uid-2/decode-0")
+	assert.Equal(t, []string{"node-C"}, got.UnsortedList())
+}
+
+func TestNodeBindingStore_EvictByUID_NonExistent(t *testing.T) {
+	store := NewNodeBindingStore()
+	// Should not panic.
+	store.EvictByUID("nonexistent")
+}
+
+func TestNodeBindingStore_EvictByUID_AddAfterEvict(t *testing.T) {
+	store := NewNodeBindingStore()
+
+	store.Add("uid-1/prefill-0", "node-A")
+	store.EvictByUID("uid-1")
+	assert.Nil(t, store.Load("uid-1/prefill-0"))
+
+	// Re-adding after eviction should work.
+	store.Add("uid-1/prefill-0", "node-B")
+	got := store.Load("uid-1/prefill-0")
+	assert.Equal(t, []string{"node-B"}, got.UnsortedList())
+}
+
+func TestNodeBindingStore_Len(t *testing.T) {
+	store := NewNodeBindingStore()
+	assert.Equal(t, 0, store.Len())
+
+	store.Add("uid-1/prefill-0", "node-A")
+	store.Add("uid-1/prefill-1", "node-B")
+	assert.Equal(t, 1, store.Len(), "two sub-keys under same UID = 1 RBG entry")
+
+	store.Add("uid-2/decode-0", "node-C")
+	assert.Equal(t, 2, store.Len(), "two distinct UIDs = 2 RBG entries")
+
+	store.EvictByUID("uid-1")
+	assert.Equal(t, 1, store.Len(), "uid-1 evicted, only uid-2 remains")
+
+	store.EvictByUID("uid-2")
+	assert.Equal(t, 0, store.Len(), "all UIDs evicted")
+}
+
+// ---------------------------------------------------------------------------
+// splitKey
+// ---------------------------------------------------------------------------
+
+func TestSplitKey_Valid(t *testing.T) {
+	uid, subKey, ok := splitKey("uid-123/prefill-0")
+	assert.True(t, ok)
+	assert.Equal(t, "uid-123", uid)
+	assert.Equal(t, "prefill-0", subKey)
+}
+
+func TestSplitKey_NoSlash(t *testing.T) {
+	_, _, ok := splitKey("noslash")
+	assert.False(t, ok)
+}
+
+func TestSplitKey_EmptyParts(t *testing.T) {
+	_, _, ok := splitKey("/subkey")
+	assert.False(t, ok)
+
+	_, _, ok = splitKey("uid/")
+	assert.False(t, ok)
+}
+
 // ---------------------------------------------------------------------------
 // buildKey
 // ---------------------------------------------------------------------------

--- a/pkg/reconciler/roleinstance/sync/node_binding_test.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding_test.go
@@ -1346,3 +1346,33 @@ func TestInjectInPlaceScheduling_RequiredAvoidFoldWithPreExistingTerms(t *testin
 	assert.Equal(t, "avoid-key", exprs[2].Key)
 	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, exprs[2].Operator)
 }
+
+func TestInjectInPlaceScheduling_InvalidAvoidKeySkipped(t *testing.T) {
+	store := NewNodeBindingStore()
+	store.Add("uid-1/prefill-0", "node-A")
+
+	instance := statefulInstance("uid-1", "prefill")
+	instance.Annotations = map[string]string{
+		constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+		constants.RoleInplaceSchedulingAvoidAnnotationKey: "valid-key, invalid key with spaces, also/bad!",
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prefill-0",
+			Labels: map[string]string{
+				constants.ComponentNameLabelKey: "Prefill",
+			},
+		},
+	}
+
+	InjectInPlaceScheduling(pod, instance, store)
+
+	na := pod.Spec.Affinity.NodeAffinity
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	assert.NotNil(t, req)
+	// Only "valid-key" passes validation; the other two are skipped.
+	assert.Len(t, req.NodeSelectorTerms, 1)
+	assert.Len(t, req.NodeSelectorTerms[0].MatchExpressions, 1)
+	assert.Equal(t, "valid-key", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+}

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
@@ -215,6 +215,20 @@ func newVersionedInstance(
 		instance.Annotations[constants.RoleInstanceGangSchedulingAnnotationKey] = v
 	}
 
+	// Propagate in-place scheduling annotation from RoleInstanceSet to RoleInstance so that
+	// the instance controller can inject nodeAffinity when recreating pods.
+	if v, ok := currentSet.Annotations[constants.RoleInplaceSchedulingAnnotationKey]; ok {
+		instance.Annotations[constants.RoleInplaceSchedulingAnnotationKey] = v
+	}
+	// Propagate in-place scheduling granularity annotation (Pod vs Component).
+	if v, ok := currentSet.Annotations[constants.RoleInplaceSchedulingGranularityAnnotationKey]; ok {
+		instance.Annotations[constants.RoleInplaceSchedulingGranularityAnnotationKey] = v
+	}
+	// Propagate in-place scheduling avoid annotation (hard-exclude nodes carrying a specific label).
+	if v, ok := currentSet.Annotations[constants.RoleInplaceSchedulingAvoidAnnotationKey]; ok {
+		instance.Annotations[constants.RoleInplaceSchedulingAvoidAnnotationKey] = v
+	}
+
 	portallocator.AllocatePortsForInstance(instance, currentSet)
 
 	return instance

--- a/pkg/reconciler/roleinstanceset/statelessmode/core/implement.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/core/implement.go
@@ -214,6 +214,12 @@ func GenInstanceFromTemplate(template *workloadsv1alpha2.RoleInstanceTemplate, s
 	annotationsToCopy := []string{
 		// Gang-scheduling: enables orphan-pod checks and atomic pod recreation.
 		constants.RoleInstanceGangSchedulingAnnotationKey,
+		// In-place scheduling: injects nodeAffinity for cache reuse on recreation.
+		constants.RoleInplaceSchedulingAnnotationKey,
+		// In-place scheduling granularity: controls Pod vs Component binding.
+		constants.RoleInplaceSchedulingGranularityAnnotationKey,
+		// In-place scheduling avoid: hard-excludes nodes carrying a specific label.
+		constants.RoleInplaceSchedulingAvoidAnnotationKey,
 	}
 	for _, key := range annotationsToCopy {
 		if v, ok := set.Annotations[key]; ok {

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -144,6 +144,14 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceSetApplyConfiguration(
 	roleInstanceSetLabel := maps.Clone(matchLabels)
 	roleInstanceSetLabel[fmt.Sprintf(constants.RoleRevisionLabelKeyFmt, role.Name)] = revisionKey
 
+	// When in-place scheduling is enabled for this role, propagate the real
+	// RBG UID (Kubernetes object UID) as a label. This enables the node
+	// binding store to use a globally unique key that changes on RBG
+	// delete/recreate, preventing stale binding inheritance.
+	if role.Annotations[constants.RoleInplaceSchedulingAnnotationKey] != "" {
+		roleInstanceSetLabel[constants.RBGOwnerUIDLabelKey] = string(rbg.UID)
+	}
+
 	// set default instance pattern annotation to Stateful only if not explicitly set in role.Annotations
 	roleInstanceSetAnnotation := maps.Clone(rbg.GetCommonAnnotationsFromRole(role))
 	if role.Annotations[constants.RoleInstancePatternKey] == "" {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -85,6 +85,7 @@ func TestE2E(t *testing.T) {
 			testcasev1alpha2.RunUpdateStrategyTestCases(f)
 			testcasev1alpha2.RunCoordinatedPolicyTestCases(f)
 			testcasev1alpha2.RunConvergenceTestCases(f)
+			testcasev1alpha2.RunInplaceSchedulingTestCases(f)
 		},
 	)
 

--- a/test/e2e/testcase/v1alpha2/inplace_scheduling.go
+++ b/test/e2e/testcase/v1alpha2/inplace_scheduling.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/test/e2e/framework"
+	"sigs.k8s.io/rbgs/test/utils"
+	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
+)
+
+// RunInplaceSchedulingTestCases verifies that the in-place scheduling feature
+// correctly injects nodeAffinity into Pods after a rolling upgrade.
+//
+// This test uses two roles in a single RBG:
+//   - role-pod:      Stateful (Standalone) → Pod-level granularity (default)
+//   - role-component: Stateless (Standalone with pattern=Stateless) → Component-level granularity (default)
+//
+// Both roles use Preferred mode with maxSurge=0, maxUnavailable=1 (delete-first).
+// After the rolling upgrade completes, the test asserts that:
+//  1. Pods of both roles carry preferredDuringScheduling nodeAffinity
+//  2. The affinity references kubernetes.io/hostname with the correct node name
+//  3. Both roles reference the same node (single-node cluster)
+func RunInplaceSchedulingTestCases(f *framework.Framework) {
+	ginkgo.Describe("inplace-scheduling", func() {
+
+		ginkgo.It("injects nodeAffinity after rolling upgrade for both Pod and Component granularity", func() {
+			rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-inplace-scheduling", f.Namespace).WithRoles(
+				[]workloadsv1alpha2.RoleSpec{
+					// Role 1: Stateful → Pod-level granularity (smart default)
+					wrappersv2.BuildStandaloneRole("role-pod").
+						WithReplicas(2).
+						WithAnnotations(map[string]string{
+							constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+						}).
+						WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+							MaxSurge:       ptr.To(intstr.FromInt32(0)),
+							MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						}).Obj(),
+
+					// Role 2: Stateless → Component-level granularity (smart default)
+					wrappersv2.BuildStandaloneRole("role-component").
+						WithReplicas(2).
+						WithAnnotations(map[string]string{
+							constants.RoleInstancePatternKey:             string(constants.StatelessPattern),
+							constants.RoleInplaceSchedulingAnnotationKey: constants.InplaceSchedulingPreferred,
+						}).
+						WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+							MaxSurge:       ptr.To(intstr.FromInt32(0)),
+							MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+						}).Obj(),
+				}).Obj()
+
+			f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+			gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+			f.ExpectRbgV2Equal(rbg)
+
+			// Both roles should have 2 Ready pods initially.
+			gomega.Expect(getPodUIDsForRole(f, rbg, "role-pod")).Should(gomega.HaveLen(2))
+			gomega.Expect(getPodUIDsForRole(f, rbg, "role-component")).Should(gomega.HaveLen(2))
+
+			// Record initial pod UIDs for both roles.
+			initialPodUIDs := getPodUIDsForRole(f, rbg, "role-pod")
+			initialComponentPodUIDs := getPodUIDsForRole(f, rbg, "role-component")
+
+			// Trigger rolling upgrade by adding an env var to both roles.
+			// Env var changes cannot be applied in-place, forcing pod recreation.
+			updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+				for i := range rbg.Spec.Roles {
+					rbg.Spec.Roles[i].StandalonePattern.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+						{Name: "INPLACE_E2E", Value: "v2"},
+					}
+				}
+			})
+
+			// Wait for rolling upgrade to complete.
+			f.ExpectRbgV2Equal(rbg)
+
+			// Verify pods were recreated (UIDs changed).
+			var updatedPodUIDs map[string]types.UID
+			gomega.Eventually(func() bool {
+				updatedPodUIDs = getPodUIDsForRole(f, rbg, "role-pod")
+				if len(updatedPodUIDs) != 2 {
+					return false
+				}
+				for name := range updatedPodUIDs {
+					if initialPodUIDs[name] == updatedPodUIDs[name] {
+						return false
+					}
+				}
+				return true
+			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+				"role-pod pods should be recreated with new UIDs")
+
+			gomega.Eventually(func() bool {
+				componentUIDs := getPodUIDsForRole(f, rbg, "role-component")
+				if len(componentUIDs) != 2 {
+					return false
+				}
+				for name := range componentUIDs {
+					if initialComponentPodUIDs[name] == componentUIDs[name] {
+						return false
+					}
+				}
+				return true
+			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+				"role-component pods should be recreated with new UIDs")
+
+			// ---------------------------------------------------------------
+			// Assert nodeAffinity injection
+			// ---------------------------------------------------------------
+
+			// Get pods for both roles.
+			rolePods := listPodsForRole(f, rbg, "role-pod")
+			componentPods := listPodsForRole(f, rbg, "role-component")
+
+			gomega.Expect(rolePods).Should(gomega.HaveLen(2))
+			gomega.Expect(componentPods).Should(gomega.HaveLen(2))
+
+			// Verify role-pod (Pod-level granularity): each Pod has preferred affinity
+			// and the affinity includes the node it's actually running on.
+			for _, pod := range rolePods {
+				gomega.Expect(pod.Spec.NodeName).ShouldNot(gomega.BeEmpty(),
+					"pod %s should be assigned to a node", pod.Name)
+				assertAffinityContainsNode(pod, pod.Spec.NodeName, "role-pod")
+			}
+
+			// Verify role-component (Component-level granularity): each Pod has preferred affinity
+			// and the affinity includes the node it's actually running on.
+			for _, pod := range componentPods {
+				gomega.Expect(pod.Spec.NodeName).ShouldNot(gomega.BeEmpty(),
+					"pod %s should be assigned to a node", pod.Name)
+				assertAffinityContainsNode(pod, pod.Spec.NodeName, "role-component")
+			}
+		})
+
+		ginkgo.It("injects avoid anti-affinity and preferred affinity after pod deletion", func() {
+			const avoidLabelKey = "workloads.x-k8s.io/heavy-tenant"
+
+			rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-inplace-avoid", f.Namespace).WithRoles(
+				[]workloadsv1alpha2.RoleSpec{
+					wrappersv2.BuildStandaloneRole("role-avoid").
+						WithReplicas(1).
+						WithAnnotations(map[string]string{
+							constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingPreferred,
+							constants.RoleInplaceSchedulingAvoidAnnotationKey: avoidLabelKey,
+						}).Obj(),
+				}).Obj()
+
+			f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+			gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+			f.ExpectRbgV2Equal(rbg)
+
+			// Should have 1 Ready pod.
+			initialUIDs := getPodUIDsForRole(f, rbg, "role-avoid")
+			gomega.Expect(initialUIDs).Should(gomega.HaveLen(1))
+
+			// Delete the pod to trigger recreation.
+			pods := listPodsForRole(f, rbg, "role-avoid")
+			gomega.Expect(pods).Should(gomega.HaveLen(1))
+			gomega.Expect(f.Client.Delete(f.Ctx, &pods[0])).Should(gomega.Succeed())
+
+			// Wait for the new pod to be created with a different UID.
+			gomega.Eventually(func() bool {
+				newUIDs := getPodUIDsForRole(f, rbg, "role-avoid")
+				if len(newUIDs) != 1 {
+					return false
+				}
+				for name, uid := range newUIDs {
+					if initialUIDs[name] == uid {
+						return false
+					}
+				}
+				return true
+			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+				"pod should be recreated with a new UID after deletion")
+
+			// Wait for the new pod to be Running+Ready.
+			f.ExpectRbgV2Equal(rbg)
+
+			// ---------------------------------------------------------------
+			// Assert affinity injection on the new pod
+			// ---------------------------------------------------------------
+			newPods := listPodsForRole(f, rbg, "role-avoid")
+			gomega.Expect(newPods).Should(gomega.HaveLen(1))
+			newPod := newPods[0]
+
+			gomega.Expect(newPod.Spec.NodeName).ShouldNot(gomega.BeEmpty())
+
+			na := newPod.Spec.Affinity.NodeAffinity
+			gomega.Expect(na).ShouldNot(gomega.BeNil(),
+				"pod %s should have nodeAffinity injected", newPod.Name)
+
+			// 1. Verify preferred affinity (from node binding)
+			assertAffinityContainsNode(newPod, newPod.Spec.NodeName, "role-avoid")
+
+			// 2. Verify avoid anti-affinity (required + DoesNotExist)
+			req := na.RequiredDuringSchedulingIgnoredDuringExecution
+			gomega.Expect(req).ShouldNot(gomega.BeNil(),
+				"pod %s should have required anti-affinity injected", newPod.Name)
+
+			var avoidFound bool
+			for _, term := range req.NodeSelectorTerms {
+				for _, expr := range term.MatchExpressions {
+					if expr.Key == avoidLabelKey &&
+						expr.Operator == corev1.NodeSelectorOpDoesNotExist {
+						avoidFound = true
+						break
+					}
+				}
+				if avoidFound {
+					break
+				}
+			}
+			gomega.Expect(avoidFound).Should(gomega.BeTrue(),
+				"pod %s should have required anti-affinity with key=%s and operator=DoesNotExist, got: %+v",
+				newPod.Name, avoidLabelKey, req.NodeSelectorTerms)
+		})
+
+		ginkgo.It("Required mode with avoid: pod stays Pending when historical node carries avoid label", func() {
+			const avoidLabelKey = "workloads.x-k8s.io/heavy-tenant"
+
+			rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-inplace-required-avoid", f.Namespace).WithRoles(
+				[]workloadsv1alpha2.RoleSpec{
+					wrappersv2.BuildStandaloneRole("role-req-avoid").
+						WithReplicas(1).
+						WithAnnotations(map[string]string{
+							constants.RoleInplaceSchedulingAnnotationKey:      constants.InplaceSchedulingRequired,
+							constants.RoleInplaceSchedulingAvoidAnnotationKey: avoidLabelKey,
+						}).Obj(),
+				}).Obj()
+
+			f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+			gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+			f.ExpectRbgV2Equal(rbg)
+
+			// Should have 1 Ready pod.
+			initialUIDs := getPodUIDsForRole(f, rbg, "role-req-avoid")
+			gomega.Expect(initialUIDs).Should(gomega.HaveLen(1))
+
+			// Record the node name where the pod is running.
+			pods := listPodsForRole(f, rbg, "role-req-avoid")
+			gomega.Expect(pods).Should(gomega.HaveLen(1))
+			originalNode := pods[0].Spec.NodeName
+			gomega.Expect(originalNode).ShouldNot(gomega.BeEmpty())
+
+			// Label the original node with the avoid key so the DoesNotExist
+			// constraint will reject it.
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: originalNode}}
+			gomega.Expect(f.Client.Get(f.Ctx, client.ObjectKeyFromObject(node), node)).Should(gomega.Succeed())
+			mergeFrom := client.MergeFrom(node.DeepCopy())
+			if node.Labels == nil {
+				node.Labels = make(map[string]string)
+			}
+			node.Labels[avoidLabelKey] = "true"
+			gomega.Expect(f.Client.Patch(f.Ctx, node, mergeFrom)).Should(gomega.Succeed())
+
+			// Ensure the label is removed after the test regardless of outcome.
+			// Use DeferCleanup instead of defer so it runs in Ginkgo's cleanup
+			// phase, which is more robust against panics and context cancellation.
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				freshNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: originalNode}}
+				if err := f.Client.Get(ctx, client.ObjectKeyFromObject(freshNode), freshNode); err == nil {
+					cleanMerge := client.MergeFrom(freshNode.DeepCopy())
+					delete(freshNode.Labels, avoidLabelKey)
+					_ = f.Client.Patch(ctx, freshNode, cleanMerge)
+				}
+			})
+
+			// Delete the pod to trigger recreation.
+			gomega.Expect(f.Client.Delete(f.Ctx, &pods[0])).Should(gomega.Succeed())
+
+			// Wait for the new pod to be created with a different UID.
+			gomega.Eventually(func() bool {
+				newUIDs := getPodUIDsForRole(f, rbg, "role-req-avoid")
+				for name, uid := range newUIDs {
+					if initialUIDs[name] != uid {
+						return true
+					}
+				}
+				return false
+			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+				"a new pod with a different UID should be created")
+
+			// ---------------------------------------------------------------
+			// Assert: the new pod has merged Required affinity AND stays Pending
+			// ---------------------------------------------------------------
+			gomega.Eventually(func() bool {
+				newPods := listPodsForRole(f, rbg, "role-req-avoid")
+				for _, p := range newPods {
+					if initialUIDs[p.Name] == p.UID {
+						continue // skip the old pod being terminated
+					}
+					if p.Spec.Affinity == nil || p.Spec.Affinity.NodeAffinity == nil {
+						return false
+					}
+					return true
+				}
+				return false
+			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
+				"new pod should have affinity injected")
+
+			newPods := listPodsForRole(f, rbg, "role-req-avoid")
+			var newPod corev1.Pod
+			for _, p := range newPods {
+				if initialUIDs[p.Name] != p.UID {
+					newPod = p
+					break
+				}
+			}
+
+			na := newPod.Spec.Affinity.NodeAffinity
+			gomega.Expect(na).ShouldNot(gomega.BeNil())
+
+			// Verify the merged Required term (hostname + avoid in one term).
+			assertMergedRequiredAvoidTerm(na, originalNode, avoidLabelKey)
+
+			// No preferred terms in Required mode.
+			gomega.Expect(na.PreferredDuringSchedulingIgnoredDuringExecution).Should(gomega.BeEmpty())
+
+			// Scheduling outcome: the pod must either be Pending (single-node
+			// cluster) OR scheduled to a node DIFFERENT from the original.
+			assertPodNotScheduledOnOriginalNode(f, newPod, originalNode)
+		})
+	})
+}
+
+// assertMergedRequiredAvoidTerm verifies that the NodeAffinity has exactly ONE
+// NodeSelectorTerm containing TWO MatchExpressions (hostname In + avoid
+// DoesNotExist) — AND semantics within a single term.
+func assertMergedRequiredAvoidTerm(na *corev1.NodeAffinity, originalNode, avoidLabelKey string) {
+	ginkgo.GinkgoHelper()
+
+	req := na.RequiredDuringSchedulingIgnoredDuringExecution
+	gomega.Expect(req).ShouldNot(gomega.BeNil())
+	gomega.Expect(req.NodeSelectorTerms).Should(gomega.HaveLen(1),
+		"Required mode + avoid must produce a single merged term (AND semantics)")
+
+	exprs := req.NodeSelectorTerms[0].MatchExpressions
+	gomega.Expect(exprs).Should(gomega.HaveLen(2))
+
+	// hostname In [originalNode]
+	gomega.Expect(exprs[0].Key).Should(gomega.Equal("kubernetes.io/hostname"))
+	gomega.Expect(exprs[0].Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
+	gomega.Expect(exprs[0].Values).Should(gomega.ContainElement(originalNode))
+
+	// avoid key DoesNotExist
+	gomega.Expect(exprs[1].Key).Should(gomega.Equal(avoidLabelKey))
+	gomega.Expect(exprs[1].Operator).Should(gomega.Equal(corev1.NodeSelectorOpDoesNotExist))
+}
+
+// assertPodNotScheduledOnOriginalNode waits for a stable period then verifies
+// that the pod is either Pending or Running on a node different from
+// originalNode.
+func assertPodNotScheduledOnOriginalNode(f *framework.Framework, pod corev1.Pod, originalNode string) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Consistently(func() bool {
+		live := &corev1.Pod{}
+		if err := f.Client.Get(f.Ctx, client.ObjectKeyFromObject(&pod), live); err != nil {
+			return false
+		}
+		switch live.Status.Phase {
+		case corev1.PodRunning:
+			return live.Spec.NodeName != originalNode
+		case corev1.PodPending:
+			return true
+		default:
+			return true
+		}
+	}, "12s", "2s").Should(gomega.BeTrue(),
+		"pod must either stay Pending or run on a node != %s", originalNode)
+
+	live := &corev1.Pod{}
+	gomega.Expect(f.Client.Get(f.Ctx, client.ObjectKeyFromObject(&pod), live)).Should(gomega.Succeed())
+	if live.Status.Phase == corev1.PodRunning {
+		gomega.Expect(live.Spec.NodeName).ShouldNot(gomega.Equal(originalNode),
+			"pod must NOT be scheduled back to the original node which carries the avoid label")
+	} else {
+		gomega.Expect(live.Status.Phase).Should(gomega.Equal(corev1.PodPending),
+			"pod should be either Pending or Running on a different node")
+	}
+}
+
+// listPodsForRole returns the list of non-deleted Pods belonging to a role.
+func listPodsForRole(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) []corev1.Pod {
+	podList := &corev1.PodList{}
+	err := f.Client.List(f.Ctx, podList,
+		client.InNamespace(rbg.Namespace),
+		client.MatchingLabels{
+			constants.GroupNameLabelKey: rbg.Name,
+			constants.RoleNameLabelKey:  roleName,
+		},
+	)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	var result []corev1.Pod
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp == nil {
+			result = append(result, pod)
+		}
+	}
+	return result
+}
+
+// assertAffinityContainsNode verifies that the Pod has a preferredDuringScheduling
+// nodeAffinity term with weight=100, key=kubernetes.io/hostname, and that
+// the specified node is present in the values list.
+func assertAffinityContainsNode(pod corev1.Pod, expectedNode, roleName string) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Expect(pod.Spec.Affinity).ShouldNot(gomega.BeNil(),
+		"[%s] pod %s should have affinity injected", roleName, pod.Name)
+	gomega.Expect(pod.Spec.Affinity.NodeAffinity).ShouldNot(gomega.BeNil(),
+		"[%s] pod %s should have nodeAffinity injected", roleName, pod.Name)
+
+	terms := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	gomega.Expect(terms).ShouldNot(gomega.BeEmpty(),
+		"[%s] pod %s should have preferred scheduling terms", roleName, pod.Name)
+
+	// Find the in-place scheduling term (weight=100, key=kubernetes.io/hostname).
+	var found bool
+	for _, term := range terms {
+		if term.Weight != 100 {
+			continue
+		}
+		for _, expr := range term.Preference.MatchExpressions {
+			if expr.Key == "kubernetes.io/hostname" &&
+				expr.Operator == corev1.NodeSelectorOpIn {
+				for _, v := range expr.Values {
+					if v == expectedNode {
+						found = true
+						break
+					}
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+	gomega.Expect(found).Should(gomega.BeTrue(),
+		"[%s] pod %s should have preferred affinity including node %s, got: %+v",
+		roleName, pod.Name, expectedNode, terms)
+}

--- a/test/envtest/testutil/setup.go
+++ b/test/envtest/testutil/setup.go
@@ -42,6 +42,7 @@ import (
 	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	workloadscontroller "sigs.k8s.io/rbgs/internal/controller/workloads"
+	instancesync "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	"sigs.k8s.io/rbgs/pkg/scheduler"
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
 )
@@ -103,13 +104,17 @@ func SetupTestEnv() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Setup all controllers
-	err = SetupRBGController(TestMgr)
+	// Share one NodeBindingStore between RBG (eviction on delete) and
+	// RoleInstance (record + inject) controllers.
+	nodeBindings := instancesync.NewNodeBindingStore()
+
+	err = SetupRBGController(TestMgr, nodeBindings)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = SetupInstanceSetController(TestMgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupInstanceController(TestMgr)
+	err = SetupInstanceController(TestMgr, nodeBindings)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = SetupRBGScalingAdapterController(TestMgr)
@@ -196,8 +201,8 @@ func SetupManager(ctx context.Context) (manager.Manager, error) {
 }
 
 // SetupRBGController sets up the RoleBasedGroup controller
-func SetupRBGController(mgr manager.Manager) error {
-	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.KubeSchedulerPlugin)
+func SetupRBGController(mgr manager.Manager, bindings *instancesync.NodeBindingStore) error {
+	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.KubeSchedulerPlugin, bindings)
 	if err != nil {
 		return err
 	}
@@ -217,8 +222,8 @@ func SetupRBGSController(mgr manager.Manager) error {
 }
 
 // SetupInstanceController sets up the Instance controller
-func SetupInstanceController(mgr manager.Manager) error {
-	instanceReconciler := workloadscontroller.NewRoleInstanceReconciler(mgr)
+func SetupInstanceController(mgr manager.Manager, bindings *instancesync.NodeBindingStore) error {
+	instanceReconciler := workloadscontroller.NewRoleInstanceReconciler(mgr, bindings)
 	return instanceReconciler.SetupWithManager(mgr, controller.Options{})
 }
 

--- a/test/wrappers/v1alpha2/role_wrapper.go
+++ b/test/wrappers/v1alpha2/role_wrapper.go
@@ -48,6 +48,16 @@ func (rw *StandaloneRoleWrapper) WithDependencies(deps []string) *StandaloneRole
 	return rw
 }
 
+func (rw *StandaloneRoleWrapper) WithAnnotations(annotations map[string]string) *StandaloneRoleWrapper {
+	if rw.Annotations == nil {
+		rw.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		rw.Annotations[k] = v
+	}
+	return rw
+}
+
 func (rw *StandaloneRoleWrapper) WithEngineRuntime(er []workloadsv1alpha2.EngineRuntime) *StandaloneRoleWrapper {
 	rw.EngineRuntimes = er
 	return rw


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

This PR implements **Inplace Scheduling** — a feature that injects nodeAffinity into recreated Pods so they are steered toward nodes where the same workload has previously run, enabling reuse of node-local cached resources.

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

#### Core Implementation

- **`node_binding.go`** — New file implementing the in-place scheduling engine:
  - `NodeBindingStore` — two-level `map[uid]*rbgBindings{map[subKey]→nodes}`, enabling O(1) eviction by RBG UID when an RBG is deleted (via `EvictByUID` called from an RBG delete event handler):
    - Pod-level inner key: `{podName}` → single-node set
    - Component-level inner key: `{roleName}-{componentName}` → multi-node set
    - `Load()` returns a **cloned snapshot** (`sets.Clone()`) to avoid data races when callers iterate the set concurrently with `Add()` (safe under `MaxConcurrentReconciles > 1`)
    - `EvictByUID()` and the RBG delete handler emit `klog.InfoS()` logs for observability
    - `Len()` exposed for testing and debugging
  - `RecordNodeBindings()` — observes Running+Ready Pods and records their node bindings (emits `klog.V(4)` when a new key is first recorded)
  - `InjectInPlaceScheduling()` — injects nodeAffinity on Pod creation:
    - Mode check (Preferred / Required)
    - Exclusive topology bypass
    - **Avoid anti-affinity**: `role-inplace-scheduling-avoid` annotation injects `requiredDuringSchedulingIgnoredDuringExecution` with `DoesNotExist` operator to hard-exclude nodes carrying a user-specified label
    - Granularity-aware affinity injection: `preferredDuringSchedulingIgnoredDuringExecution` (weight 100) or `requiredDuringSchedulingIgnoredDuringExecution`
  - `resolveGranularity()` — smart defaults: Stateful → Pod, Stateless → Component (detected via `RoleInstanceIndexLabelKey` label)

- **`instance_scale.go`** — Integration points:
  - `RecordNodeBindings()` called at the beginning of `Scale()` (piggybacks on already-fetched Pods)
  - `InjectInPlaceScheduling()` called in `createPods()` before Pod creation

#### Annotation Propagation

- **Stateful mode** (`stateful_instance_set_utils.go`): propagates `role-inplace-scheduling`, `role-inplace-scheduling-granularity`, and `role-inplace-scheduling-avoid` from RoleInstanceSet to RoleInstance
- **Stateless mode** (`implement.go`): adds the same three annotations to `annotationsToCopy`
- **RBG → RoleInstanceSet** (`roleinstanceset_reconciler.go`): propagates the real RBG UID (`RBGOwnerUIDLabelKey`) as a label when in-place scheduling is enabled, ensuring globally unique binding keys across RBG lifecycles

#### GC — Binding Cleanup on RBG Deletion

- **`api.go`** (`sync` package): exports `EvictNodeBindings(uid)` as the cross-package entry point for cleaning up bindings
- **`rolebasedgroup_controller.go`**: registers a `handler.Funcs` delete handler via `.Watches()` on RBG. When an RBG is deleted, the handler calls `EvictNodeBindings(string(obj.GetUID()))` for O(1) cleanup. No reconcile is enqueued (`.For()` already handles that) — the handler exists purely for the side-effect of freeing in-memory bindings using the UID (which is only available from the delete event, not from a subsequent `Get`)

#### Constants

- **`annotation.go`**: new constants for mode (`Preferred`/`Required`), granularity (`Pod`/`Component`), and avoid annotation
- **`label.go`**: `RBGOwnerUIDLabelKey` for RBG lifecycle isolation

#### Tests

- **`node_binding_test.go`** — 63 unit tests covering:
  - `NodeBindingStore`: Add/Load, idempotency, multi-node accumulation, empty key, **EvictByUID (basic + non-existent + add-after-evict)**, **Len**
  - `splitKey`: valid key, no slash, empty parts
  - `buildKey`: Pod/Component keys, missing fields, unknown granularity
  - `resolveGranularity`: explicit override, Stateful→Pod, Stateless→Component
  - `isPodRunningAndReady`: 5 Pod phase scenarios
  - `RecordNodeBindings`: Stateful/Pod, Stateless/Component, skip non-Ready, skip missing UID
  - `InjectInPlaceScheduling`: Preferred/Required affinity, Component multi-node, no annotation, invalid mode, exclusive topology bypass, no binding, missing label, preserve existing affinity, **Required+avoid merged AND semantics**
  - Avoid anti-affinity: injection, no-binding fallback, no-avoid skip, exclusive skip, no-mode skip
  - Record→Inject integration: Stateful same-name hit, Stateless surge component hit

- **`inplace_scheduling.go`** — 3 E2E tests:
  1. **Dual-role affinity injection after rolling upgrade**:
     - `role-pod` (Stateful, Pod-level granularity, smart default)
     - `role-component` (Stateless, Component-level granularity, smart default)
     - Both use Preferred mode, `maxSurge=0`, `maxUnavailable=1`
     - Rolling upgrade triggered via env var change (forces Pod recreation)
     - Asserts new Pods carry `preferredDuringSchedulingIgnoredDuringExecution` with `weight=100`, `key=kubernetes.io/hostname`, values containing the Pod's actual node
  2. **Avoid anti-affinity + preferred affinity after Pod deletion**:
     - Single role with 1 replica, Preferred mode, `role-inplace-scheduling-avoid` set to `workloads.x-k8s.io/heavy-tenant`
     - Pod deleted manually → controller recreates it
     - Asserts new Pod has both:
       - `preferredDuringSchedulingIgnoredDuringExecution` (weight 100, node binding)
       - `requiredDuringSchedulingIgnoredDuringExecution` with `DoesNotExist` operator (avoid anti-affinity)
  3. **Required mode + avoid: merged AND semantics**:
     - Single role with 1 replica, Required mode + avoid annotation
     - Historical node labelled with avoid key → Pod deleted
     - Asserts merged `NodeSelectorTerm` (hostname In + avoid DoesNotExist in same term = AND)
     - Asserts Pod is either Pending (single-node) or scheduled to a different node (multi-node)
     - Node label cleaned up via `ginkgo.DeferCleanup`

- **`role_wrapper.go`** — added `WithAnnotations()` builder method for test convenience

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

No. See KEP #351

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

| Type      | File                                                    | Count | Coverage                                                                                                                                                                                                      |
|-----------|---------------------------------------------------------|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Unit Test | `pkg/reconciler/roleinstance/sync/node_binding_test.go` | 63    | NodeBindingStore (incl. EvictByUID, Len), splitKey, buildKey, resolveGranularity, isPodRunningAndReady, RecordNodeBindings, InjectInPlaceScheduling (incl. avoid + Required merge), Record→Inject integration |
| E2E Test  | `test/e2e/testcase/v1alpha2/inplace_scheduling.go`      | 3     | 1) Dual-role affinity after rolling upgrade; 2) Avoid anti-affinity after Pod deletion; 3) Required+avoid merged AND semantics with node label cleanup                                                        |

### Ⅴ. Describe how to verify it

1. **Unit tests**: `go test ./pkg/reconciler/roleinstance/sync/... -v`
2. **E2E test**: Run the controller locally, then `go test ./test/e2e/ -v -ginkgo.v --ginkgo.focus="inplace-scheduling" -timeout 10m`
3. **Manual verification**:
   - Create an RBG with annotation `rbg.workloads.x-k8s.io/role-inplace-scheduling: "Preferred"` on a role
   - Wait for Pods to become Ready (bindings are recorded)
   - Trigger a rolling upgrade (e.g., change env var)
   - Observe that new Pods carry `preferredDuringSchedulingIgnoredDuringExecution` nodeAffinity with `weight=100` pointing to historical nodes
   - For avoid: set `rbg.workloads.x-k8s.io/role-inplace-scheduling-avoid: "some-label-key"` and verify `requiredDuringSchedulingIgnoredDuringExecution` with `DoesNotExist` is injected

### VI. Special notes for reviews

- The `NodeBindingStore` uses a **two-level map** keyed by RBG UID (`map[uid]→rbgBindings{map[subKey]→nodes}`). When an RBG is deleted, a `handler.Funcs` delete handler registered in the RBG reconciler's `SetupWithManager` calls `EvictNodeBindings(uid)` for O(1) cleanup — no TTL, webhooks, finalizers, or background GC goroutines needed. A single `sync.RWMutex` protects both levels; all operations hold the lock for very short durations.
- `Load()` returns a **cloned snapshot** (`sets.Clone()`) rather than a direct reference to the inner set. This prevents data races when callers iterate the returned set (e.g., `sets.List(nodes)`) concurrently with `Add()` modifying the same key — critical under `MaxConcurrentReconciles > 1` with Component-level granularity where multiple RoleInstances share the same store key.
- The avoid anti-affinity uses `requiredDuringSchedulingIgnoredDuringExecution` + `DoesNotExist` (hard constraint), **not** negative weight on preferred terms — Kubernetes scheduler does not support negative weights.
- In **Required** mode, the avoid `DoesNotExist` expression is **merged into the same `NodeSelectorTerm`** as the hostname `In` constraint. Separate terms are ORed by K8s, but we need AND semantics (historical node AND no avoid label).
- Granularity auto-detection relies on the `rbg.workloads.x-k8s.io/role-instance-index` label (present on Stateful RoleInstances, absent on Stateless ones). No annotation propagation needed for detection.
- The `RBGOwnerUIDLabelKey` ensures node bindings are scoped to the current RBG lifecycle. Deleting and recreating the RBG produces a new UID, so stale bindings from a previous RBG are never reused.

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
