### PR TITLE
docs: add inference-engine-runtime to ecosystem projects in README

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -280,6 +280,7 @@ RBG 集成生态组件用于生产级 LLM 推理：
 | 项目 | 说明 |
 |:-----|:-----|
 | [**rbg-planner**](https://github.com/rolebasedgroup/rbg-planner) | 引擎无关的 SLA 驱动 LLM 推理自动伸缩器。通过可插拔指标适配器支持 SGLang、vLLM、NVIDIA Dynamo，基于 ARIMA 负载预测和自动 SLA 画像，扩缩 prefill/decode 角色以满足 TTFT/ITL 延迟目标。 |
+| [**inference-engine-runtime**](https://github.com/rolebasedgroup/inference-engine-runtime) | Python 推理引擎 Sidecar 运行时。为 SGLang 和 vLLM 引擎提供 LoRA 适配器管理、统一 Prometheus 指标及分布式拓扑管理。 |
 | [**inference-ext-cli**](https://github.com/rolebasedgroup/inference-ext-cli) | RBG CLI 扩展（`llmctl`），用于 LLM 推理工作负载管理。提供服务/模型管理、基准测试编排、自动参数搜索（Optuna）、收敛分析及实验可视化 Web 面板。 |
 | [**rbg-agent-guide**](https://github.com/rolebasedgroup/rbg-agent-guide) | RBG 运维 AI Agent 技能指南。为 AI 编程助手（如 Claude Code）提供部署技能，帮助用户通过 RBG CRD 和 CLI 将 LLM 模型部署到 Kubernetes。 |
 | [**rolebasedgroup.github.io**](https://github.com/rolebasedgroup/rolebasedgroup.github.io) | RBG 官方文档网站，基于 Docusaurus 构建，部署于 [rolebasedgroup.github.io](https://rolebasedgroup.github.io)。 |

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ The [rolebasedgroup](https://github.com/rolebasedgroup) GitHub organization host
 | Project | Description |
 |:--------|:------------|
 | [**rbg-planner**](https://github.com/rolebasedgroup/rbg-planner) | Engine-agnostic, SLA-driven autoscaler for LLM inference on Kubernetes. Supports SGLang, vLLM, NVIDIA Dynamo via pluggable metrics adapters. Uses ARIMA-based load prediction and automatic SLA profiling to scale prefill/decode roles to meet TTFT/ITL latency targets. |
+| [**inference-engine-runtime**](https://github.com/rolebasedgroup/inference-engine-runtime) | Python-based sidecar runtime for AI inference engines. Provides LoRA adapter management, unified Prometheus metrics, and distributed topology management for SGLang and vLLM engines. |
 | [**inference-ext-cli**](https://github.com/rolebasedgroup/inference-ext-cli) | RBG CLI extension (`llmctl`) for LLM inference workload management. Provides service/model management, benchmark orchestration, automated parameter search (Optuna), convergence analysis, and web dashboards for experiment visualization. |
 | [**rbg-agent-guide**](https://github.com/rolebasedgroup/rbg-agent-guide) | AI agent skill guides for RBG operations. Provides deployment skills for AI coding assistants (e.g., Claude Code) to help users deploy LLM models to Kubernetes using RBG CRD and CLI. |
 | [**rolebasedgroup.github.io**](https://github.com/rolebasedgroup/rolebasedgroup.github.io) | Official RBG documentation website built with Docusaurus, deployed at [rolebasedgroup.github.io](https://rolebasedgroup.github.io). |


### PR DESCRIPTION
## Summary
- Add `inference-engine-runtime` (Patio sidecar runtime) to the ecosystem projects table in README.md
- Add the same entry to README-zh_CN.md (Chinese version)

## Companion repos
- https://github.com/rolebasedgroup/inference-engine-runtime

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Check inference-engine-runtime link is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)