### PR TITLE
ci: build controller image from source in manifest e2e test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -318,10 +318,15 @@ jobs:
 
           kubectl get deploy -n rbgs-system
 
-      - name: Enable portAllocator on controller deployment
+      - name: Build and load controller image
         run: |
-          # Patch controller deployment to enable portAllocator, equivalent to helm --set portAllocator.enabled=true
+          make docker-build-controller TAG=e2e-test
+          kind load docker-image docker.io/rolebasedgroup/rbgs-controller:e2e-test --name rbgs-manifest-e2e
+
+      - name: Patch controller deployment with built image and enable portAllocator
+        run: |
           kubectl patch deployment rbgs-controller-manager -n rbgs-system --type=json -p='[
+            {"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "rolebasedgroup/rbgs-controller:e2e-test"},
             {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-port-allocator=true"},
             {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--port-allocate-strategy=random"},
             {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--start-port=30000"},


### PR DESCRIPTION
The e2e-test-manifest job was using a stale pre-built image from manifests.yaml that did not include inplace scheduling support, causing the inplace scheduling e2e test to fail. Build the image from source and patch the deployment to use it.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
