### PR TITLE
test: fix coordinated policy scaling test flake

### DIFF
--- a/test/e2e/testcase/v1alpha2/coordinated_policy.go
+++ b/test/e2e/testcase/v1alpha2/coordinated_policy.go
@@ -313,9 +313,11 @@ func RunCoordinatedPolicyTestCases(f *framework.Framework) {
 			})
 
 			// During scaling, verify skew constraint is respected
+			// Use RoleInstanceSet.Status.ReadyReplicas (the signal the controller uses)
+			// instead of counting RoleInstance conditions to avoid reconcile latency flakiness.
 			gomega.Consistently(func() bool {
-				roleAReady := countReadyRoleInstances(f, rbg, "role-a")
-				roleBReady := countReadyRoleInstances(f, rbg, "role-b")
+				roleAReady := getRoleInstanceSetReadyReplicas(f, rbg, "role-a")
+				roleBReady := getRoleInstanceSetReadyReplicas(f, rbg, "role-b")
 				skew := int(math.Abs(float64(roleAReady - roleBReady)))
 				return skew <= 1
 			}, 30, 2).Should(gomega.BeTrue(),
@@ -325,8 +327,8 @@ func RunCoordinatedPolicyTestCases(f *framework.Framework) {
 			f.ExpectRbgV2Equal(rbg)
 
 			// Verify both roles have 3 ready instances
-			gomega.Expect(countReadyRoleInstances(f, rbg, "role-a")).Should(gomega.Equal(3))
-			gomega.Expect(countReadyRoleInstances(f, rbg, "role-b")).Should(gomega.Equal(3))
+			gomega.Expect(getRoleInstanceSetReadyReplicas(f, rbg, "role-a")).Should(gomega.Equal(int32(3)))
+			gomega.Expect(getRoleInstanceSetReadyReplicas(f, rbg, "role-b")).Should(gomega.Equal(int32(3)))
 
 			// Verify stability after coordinated scaling
 			finalPodUIDs := getPodUIDsForRole(f, rbg, "role-a")

--- a/test/e2e/testcase/v1alpha2/ris.go
+++ b/test/e2e/testcase/v1alpha2/ris.go
@@ -361,9 +361,8 @@ func getRoleInstanceSetReadyReplicas(f *framework.Framework, rbg *workloadsv1alp
 		Name:      fmt.Sprintf("%s-%s", rbg.Name, roleName),
 		Namespace: rbg.Namespace,
 	}, ris)
-	if err != nil {
-		return 0
-	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(),
+		"failed to get RoleInstanceSet for role %s", roleName)
 	return ris.Status.ReadyReplicas
 }
 

--- a/test/e2e/testcase/v1alpha2/ris.go
+++ b/test/e2e/testcase/v1alpha2/ris.go
@@ -353,6 +353,20 @@ func countReadyRoleInstances(f *framework.Framework, rbg *workloadsv1alpha2.Role
 	return ready
 }
 
+// getRoleInstanceSetReadyReplicas returns the RoleInstanceSet.Status.ReadyReplicas for the given role.
+// This is the authoritative signal used by the controller's coordination algorithm.
+func getRoleInstanceSetReadyReplicas(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) int32 {
+	ris := &workloadsv1alpha2.RoleInstanceSet{}
+	err := f.Client.Get(f.Ctx, client.ObjectKey{
+		Name:      fmt.Sprintf("%s-%s", rbg.Name, roleName),
+		Namespace: rbg.Namespace,
+	}, ris)
+	if err != nil {
+		return 0
+	}
+	return ris.Status.ReadyReplicas
+}
+
 // getReadyOrdinals returns the set of ordinal indices for Ready RoleInstances.
 func getReadyOrdinals(f *framework.Framework, rbg *workloadsv1alpha2.RoleBasedGroup, roleName string) sets.Set[int] {
 	instances := listRoleInstances(f, rbg, roleName)


### PR DESCRIPTION
## Summary
- Fix flaky `scaling coordination with OrderReady progression constrains scaling skew` test
- Switch from `RoleInstanceAllPodsReady` conditions to `RoleInstanceSet.Status.ReadyReplicas` for skew validation
- Eliminate timing gap between controller coordination signal and test assertion

## Root Cause
The test was checking `RoleInstanceAllPodsReady` conditions on RoleInstance CRs, which is subject to controller reconcile latency (2-5s in slow CI). The controller's coordination algorithm uses `RoleInstanceSet.Status.ReadyReplicas`, creating a signal mismatch that caused intermittent failures when conditions lagged behind actual pod readiness.

## Changes
- Added `getRoleInstanceSetReadyReplicas()` helper to read authoritative signal
- Updated skew assertion and final verification to use `RoleInstanceSet.Status.ReadyReplicas`

## Test plan
- [ ] Run e2e tests locally to verify fix
- [ ] Re-run CI multiple times to confirm flake is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)