### PR TITLE
feat: compute maxUnavailable correctly when validating rollout strategy

### DIFF
--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
@@ -949,3 +949,16 @@ func TestIsStablyUnhealthyEdgeCases(t *testing.T) {
 		t.Errorf("instance not yet in the map must return false")
 	}
 }
+
+func TestComputeMaxUnavailable_RoundsUpWhenMaxSurgeIsZero(t *testing.T) {
+	set := buildSet("s", 3, ptr.To(intstrutil.FromInt32(0)), ptr.To(intstrutil.FromString("30%")))
+
+	got, err := computeMaxUnavailable(set, 0)
+
+	if err != nil {
+		t.Fatalf("computeMaxUnavailable() error = %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("computeMaxUnavailable() = %d, want 1", got)
+	}
+}

--- a/pkg/reconciler/roleinstanceset_reconciler_test.go
+++ b/pkg/reconciler/roleinstanceset_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -285,6 +286,59 @@ func TestRoleInstanceSetReconciler_LeaderWorkerPattern_TemplateIsolation(t *test
 	// This is the key test for the DeepCopy fix
 	assert.Len(t, roleTemplate.Template.Spec.Containers[0].Env, 1)
 	assert.Equal(t, "COMMON", roleTemplate.Template.Spec.Containers[0].Env[0].Name)
+}
+
+func TestRoleInstanceSetReconciler_RoundsUpMaxUnavailableWhenMaxSurgeIsZero(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = workloadsv1alpha2.AddToScheme(scheme)
+
+	role := wrappersv2.BuildStandaloneRole("test-role").
+		WithReplicas(3).
+		WithWorkload("workloads.x-k8s.io/v1alpha2", "RoleInstanceSet").
+		WithRollingUpdate(workloadsv1alpha2.RollingUpdate{
+			MaxUnavailable: ptr.To(intstr.FromString("30%")),
+			MaxSurge:       ptr.To(intstr.FromInt32(0)),
+			Partition:      ptr.To(intstr.FromInt32(0)),
+		}).
+		Obj()
+	rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").
+		WithRoles([]workloadsv1alpha2.RoleSpec{role}).
+		Obj()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := NewRoleInstanceSetReconciler(scheme, fakeClient)
+
+	ctx := context.Background()
+	err := reconciler.Reconciler(ctx, rbg, &role, nil, expectedRevisionHash)
+
+	assert.NoError(t, err)
+	ris := &workloadsv1alpha2.RoleInstanceSet{}
+	err = fakeClient.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      rbg.GetWorkloadName(&role),
+			Namespace: rbg.Namespace,
+		},
+		ris,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "30%", ris.Spec.UpdateStrategy.MaxUnavailable.String())
+	assert.Equal(t, "0", ris.Spec.UpdateStrategy.MaxSurge.String())
+}
+
+func TestRoleInstanceSetReconciler_ValidateRolloutStrategyRoundsUpMaxUnavailableWhenMaxSurgeIsZero(t *testing.T) {
+	strategy := &workloadsv1alpha2.RolloutStrategy{
+		Type: workloadsv1alpha2.RollingUpdateStrategyType,
+		RollingUpdate: &workloadsv1alpha2.RollingUpdate{
+			MaxUnavailable: ptr.To(intstr.FromString("30%")),
+			MaxSurge:       ptr.To(intstr.FromInt32(0)),
+			Partition:      ptr.To(intstr.FromInt32(0)),
+		},
+	}
+
+	_, err := validateRolloutStrategy(strategy, 3)
+
+	assert.NoError(t, err)
 }
 
 // TestRoleInstanceSetReconciler_ValidateRoleTemplateReferences tests that

--- a/pkg/reconciler/sts_reconciler.go
+++ b/pkg/reconciler/sts_reconciler.go
@@ -634,13 +634,13 @@ func validateRolloutStrategy(
 	if err != nil {
 		return nil, err
 	}
-	maxAvailable, err := intstr.GetScaledValueFromIntOrPercent(
-		rollingStrategy.RollingUpdate.MaxUnavailable, replicas, false,
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(
+		rollingStrategy.RollingUpdate.MaxUnavailable, replicas, maxSurge == 0,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if maxAvailable == 0 && maxSurge == 0 {
+	if maxUnavailable == 0 && maxSurge == 0 {
 		return nil, fmt.Errorf(
 			"RollingUpdate is invalid: " +
 				"rolloutStrategy.rollingUpdate.maxUnavailable may not be 0 when maxSurge is 0",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

Currently, `validateRolloutStrategy` calculates `maxUnavailable` without taking `maxSurge` into account, and this should be fixed.

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

Use `maxSurge==0` as roundUp parameter of function `GetScaledValueFromIntOrPercent`.

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

When the mode is stateful, replicas is less than 4, and maxUnavailable is set to 30%, the final maxUnavailable value will be 0, which is unexpected.

### VI. Special notes for reviews

## Checklist

- [-] Format your code `make fmt`.
- [-] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
