### PR TITLE
chore: update controller stress test

### DIFF
--- a/test/stress/scripts/setup-kwok.sh
+++ b/test/stress/scripts/setup-kwok.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Deploy kwok into an existing Kubernetes cluster for stress testing.
-# This installs kwok controller + stage-fast via Helm, then creates
-# fake nodes that simulate Pod Ready without real containers.
+# This installs kwok controller + stage-fast via Helm, applies custom Pod
+# lifecycle stages for precise delay control, then creates fake nodes
+# that simulate Pod Ready without real containers.
 set -euo pipefail
 
 KWOK_NAMESPACE="${KWOK_NAMESPACE:-kube-system}"
@@ -16,12 +17,12 @@ echo "Fake nodes: ${FAKE_NODE_COUNT} (each ${FAKE_NODE_CPU} CPU, ${FAKE_NODE_MEM
 echo ""
 
 # 1. Add kwok Helm repo
-echo "[1/4] Adding kwok Helm repo..."
+echo "[1/5] Adding kwok Helm repo..."
 helm repo add kwok https://kwok.sigs.k8s.io/charts 2>/dev/null || true
 helm repo update kwok
 
 # 2. Install kwok controller (skip if already installed)
-echo "[2/4] Installing kwok controller..."
+echo "[2/5] Installing kwok controller..."
 if helm status kwok -n "${KWOK_NAMESPACE}" >/dev/null 2>&1; then
     echo "  kwok already installed, skipping"
 else
@@ -29,7 +30,7 @@ else
 fi
 
 # 3. Install stage-fast (Pod simulation stages)
-echo "[3/4] Installing kwok stage-fast..."
+echo "[3/5] Installing kwok stage-fast..."
 if helm status kwok-stage-fast -n "${KWOK_NAMESPACE}" >/dev/null 2>&1; then
     echo "  stage-fast already installed, skipping"
 else
@@ -41,8 +42,21 @@ echo "  Waiting for kwok controller..."
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=kwok -n "${KWOK_NAMESPACE}" --timeout=60s 2>/dev/null || \
 kubectl wait --for=condition=Ready pod -l app=kwok-controller -n "${KWOK_NAMESPACE}" --timeout=60s 2>/dev/null || true
 
-# 4. Create fake nodes
-echo "[4/4] Creating ${FAKE_NODE_COUNT} fake nodes..."
+# 4. Apply custom Pod lifecycle stages (overrides pod-ready/pod-delete from stage-fast,
+#    adds pod-initialize/pod-running with specific delays for stress testing)
+echo "[4/5] Applying custom Pod lifecycle stages..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGE_FILE="${SCRIPT_DIR}/../templates/kwok-stage.yaml"
+if [ -f "${STAGE_FILE}" ]; then
+    kubectl apply -f "${STAGE_FILE}"
+    # Remove pod-complete from stage-fast to avoid conflict with custom pod-running stage
+    kubectl delete stage pod-complete --ignore-not-found=true
+else
+    echo "  WARNING: Custom stage file not found at ${STAGE_FILE}, using stage-fast defaults"
+fi
+
+# 5. Create fake nodes
+echo "[5/5] Creating ${FAKE_NODE_COUNT} fake nodes..."
 for i in $(seq 0 $((FAKE_NODE_COUNT - 1))); do
     NODE_NAME="kwok-node-${i}"
     if kubectl get node "${NODE_NAME}" >/dev/null 2>&1; then

--- a/test/stress/scripts/teardown-kwok.sh
+++ b/test/stress/scripts/teardown-kwok.sh
@@ -25,6 +25,11 @@ if [ "${UNINSTALL_KWOK}" = "true" ]; then
     echo "[3/3] Uninstalling kwok..."
     helm uninstall kwok-stage-fast -n "${KWOK_NAMESPACE}" 2>/dev/null || true
     helm uninstall kwok -n "${KWOK_NAMESPACE}" 2>/dev/null || true
+    # Also delete custom stages applied via kubectl apply (not managed by Helm)
+    kubectl delete stage pod-initialize --ignore-not-found=true 2>/dev/null || true
+    kubectl delete stage pod-running --ignore-not-found=true 2>/dev/null || true
+    kubectl delete stage pod-ready --ignore-not-found=true 2>/dev/null || true
+    kubectl delete stage pod-delete --ignore-not-found=true 2>/dev/null || true
 else
     echo "[3/3] Keeping kwok installed (set UNINSTALL_KWOK=true to remove)"
 fi

--- a/test/stress/templates.go
+++ b/test/stress/templates.go
@@ -66,14 +66,19 @@ func GenerateRBG(index int, scenario *Scenario) *unstructured.Unstructured {
 		},
 	}
 
-	// Add rollout strategy if in-place update is enabled
+	// Add rollout strategy to each role if in-place update is enabled
 	if scenario.InPlaceUpdate {
 		spec := rbg.Object["spec"].(map[string]interface{})
-		spec["rolloutStrategy"] = map[string]interface{}{
-			"type": "RollingUpdate",
-			"rollingUpdate": map[string]interface{}{
-				"type": "InPlaceIfPossible",
-			},
+		roles := spec["roles"].([]interface{})
+		for i, r := range roles {
+			role := r.(map[string]interface{})
+			role["rolloutStrategy"] = map[string]interface{}{
+				"type": "RollingUpdate",
+				"rollingUpdate": map[string]interface{}{
+					"type": "InPlaceIfPossible",
+				},
+			}
+			roles[i] = role
 		}
 	}
 
@@ -84,9 +89,6 @@ func buildStandaloneRole(name string, scenario *Scenario) map[string]interface{}
 	return map[string]interface{}{
 		"name":     name,
 		"replicas": int64(1),
-		"annotations": map[string]interface{}{
-			"rbg.workloads.x-k8s.io/role-workload-type": "apps/v1/Deployment",
-		},
 		"standalonePattern": map[string]interface{}{
 			"template": map[string]interface{}{
 				"metadata": map[string]interface{}{
@@ -105,9 +107,6 @@ func buildLWSRole(name string, scenario *Scenario) map[string]interface{} {
 	return map[string]interface{}{
 		"name":     name,
 		"replicas": int64(1),
-		"annotations": map[string]interface{}{
-			"rbg.workloads.x-k8s.io/role-workload-type": "leaderworkerset.x-k8s.io/v1/LeaderWorkerSet",
-		},
 		"leaderWorkerPattern": map[string]interface{}{
 			"size": int64(scenario.LWSSize),
 			"template": map[string]interface{}{

--- a/test/stress/templates_test.go
+++ b/test/stress/templates_test.go
@@ -33,10 +33,10 @@ func TestGenerateRBG(t *testing.T) {
 		{
 			name: "basic standalone",
 			scenario: &Scenario{
-				Namespace:   "test-ns",
-				RolesPerRBG: 2,
-				LWSRoles:    0,
-				LWSSize:     4,
+				Namespace:    "test-ns",
+				RolesPerRBG:  2,
+				LWSRoles:     0,
+				LWSSize:      4,
 				UseKwokNodes: true,
 			},
 			index:    0,
@@ -59,10 +59,10 @@ func TestGenerateRBG(t *testing.T) {
 		{
 			name: "mixed lws and standalone",
 			scenario: &Scenario{
-				Namespace:   "test-ns",
-				RolesPerRBG: 3,
-				LWSRoles:    1,
-				LWSSize:     4,
+				Namespace:    "test-ns",
+				RolesPerRBG:  3,
+				LWSRoles:     1,
+				LWSSize:      4,
 				UseKwokNodes: false,
 			},
 			index:    42,
@@ -97,9 +97,11 @@ func TestGenerateRBG(t *testing.T) {
 			index:    0,
 			wantName: "stress-rbg-0000",
 			checkFn: func(t *testing.T, rbg *unstructured.Unstructured) {
-				strategy, found, _ := unstructured.NestedMap(rbg.Object, "spec", "rolloutStrategy")
+				roles, _, _ := unstructured.NestedSlice(rbg.Object, "spec", "roles")
+				role := roles[0].(map[string]interface{})
+				strategy, found, _ := unstructured.NestedMap(role, "rolloutStrategy")
 				if !found {
-					t.Fatal("expected rolloutStrategy when InPlaceUpdate is true")
+					t.Fatal("expected rolloutStrategy on role when InPlaceUpdate is true")
 				}
 				if strategy["type"] != "RollingUpdate" {
 					t.Errorf("expected RollingUpdate type, got %v", strategy["type"])


### PR DESCRIPTION
The RBG template generation logic in the stress test framework was inconsistent with the current API specification: `rolloutStrategy` was incorrectly set at the `spec` level, whereas the actual API requires it to be configured per-role. Additionally, the `role-workload-type` annotation is no longer needed, and the KWOK environment lacked fine-grained control over Pod lifecycle delays. This commit fixes these issues to keep the stress test framework aligned with real API behavior.

**`test/stress/templates.go`**
- Moved `rolloutStrategy` from the `spec` level to each individual role, matching the actual RBG API field path.
- Removed the deprecated `rbg.workloads.x-k8s.io/role-workload-type` annotation from both `buildStandaloneRole` and `buildLWSRole`.

**`test/stress/templates_test.go`**
- Updated the `InPlaceUpdate` test case to assert `rolloutStrategy` on the role instead of the spec.
- Fixed gofmt alignment in struct field formatting.

**`test/stress/scripts/setup-kwok.sh`**
- Added step 4: Apply custom KWOK Pod lifecycle stages (`kwok-stage.yaml`) that override the default `pod-ready`/`pod-delete` from stage-fast and introduce `pod-initialize`/`pod-running` stages for precise delay control during stress testing.
- Delete the `pod-complete` stage from stage-fast to avoid conflict with the custom `pod-running` stage.
- Renumbered setup steps from 4 to 5.

**`test/stress/scripts/teardown-kwok.sh`**
- Added cleanup for custom stages (`pod-initialize`, `pod-running`, `pod-ready`, `pod-delete`) that were applied via `kubectl apply` (not managed by Helm) during teardown.