### PR TITLE
chore: outdated field name in validation

### DIFF
--- a/api/workloads/v1alpha2/roletemplate_validation.go
+++ b/api/workloads/v1alpha2/roletemplate_validation.go
@@ -138,17 +138,17 @@ func validateRoleTemplateFields(
 		// RawExtension cannot be inspected by CEL, so validate in controller.
 		if !hasTemplatePatch {
 			return fmt.Errorf(
-				"spec.roles[%d].templatePatch: required when templateRef is set (if no overrides needed, use empty object: templatePatch: {})",
+				"spec.roles[%d]: templateRef.patch is required when templateRef is set (if no overrides needed, set patch to empty object: {})",
 				index,
 			)
 		}
 		return nil
 	}
 
-	// templateRef is not set: templatePatch must not be set.
+	// templateRef is not set: templateRef.patch must not be set.
 	if hasTemplatePatch {
 		return fmt.Errorf(
-			"spec.roles[%d].templatePatch: only valid when templateRef is set",
+			"spec.roles[%d]: templateRef.patch is only valid when templateRef is set",
 			index,
 		)
 	}

--- a/pkg/reconciler/roleinstanceset_reconciler_test.go
+++ b/pkg/reconciler/roleinstanceset_reconciler_test.go
@@ -321,7 +321,7 @@ func TestRoleInstanceSetReconciler_ValidateRoleTemplateReferences(t *testing.T) 
 			useTemplateRef:   true,
 			useTemplatePatch: false,
 			expectError:      true,
-			errorMsg:         "templatePatch: required when templateRef is set",
+			errorMsg:         "templateRef.patch is required when templateRef is set",
 		},
 		{
 			name:           "LeaderWorkerSet with templateRef should fail",


### PR DESCRIPTION
The validation error messages in `roletemplate_validation.go` referenced the field as `templatePatch`, which does not match the actual API field path `templateRef.patch`. This inconsistency could confuse users when debugging validation failures. This PR corrects the field name in all error messages and updates the corresponding unit test assertion.

**`api/workloads/v1alpha2/roletemplate_validation.go`**
- Updated the error message for missing `patch` when `templateRef` is set: `templatePatch: required when templateRef is set` → `templateRef.patch is required when templateRef is set`.
- Updated the error message for `patch` set without `templateRef`: `templatePatch: only valid when templateRef is set` → `templateRef.patch is only valid when templateRef is set`.
- Updated the corresponding code comments to use `templateRef.patch` consistently.

**`pkg/reconciler/roleinstanceset_reconciler_test.go`**
- Updated the test assertion in `TestRoleInstanceSetReconciler_ValidateRoleTemplateReferences` to match the corrected error message string.
