### PR TITLE
Enable HPA scaling for RoleBasedGroupSet

### DIFF
--- a/api/workloads/v1alpha1/rolebasedgroupset_conversion.go
+++ b/api/workloads/v1alpha1/rolebasedgroupset_conversion.go
@@ -64,6 +64,7 @@ func (src *RoleBasedGroupSet) ConvertTo(dstRaw conversion.Hub) error {
 		ObservedGeneration: src.Status.ObservedGeneration,
 		Replicas:           src.Status.Replicas,
 		ReadyReplicas:      src.Status.ReadyReplicas,
+		Selector:           src.Status.Selector,
 		Conditions:         src.Status.Conditions,
 	}
 
@@ -101,6 +102,7 @@ func (dst *RoleBasedGroupSet) ConvertFrom(srcRaw conversion.Hub) error {
 		ObservedGeneration: src.Status.ObservedGeneration,
 		Replicas:           src.Status.Replicas,
 		ReadyReplicas:      src.Status.ReadyReplicas,
+		Selector:           src.Status.Selector,
 		Conditions:         src.Status.Conditions,
 	}
 

--- a/api/workloads/v1alpha1/rolebasedgroupset_types.go
+++ b/api/workloads/v1alpha1/rolebasedgroupset_types.go
@@ -48,6 +48,11 @@ type RoleBasedGroupSetStatus struct {
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas" protobuf:"varint,3,opt,name=readyReplicas"`
 
+	// Selector is a label query over child RoleBasedGroups managed by this RoleBasedGroupSet.
+	// It is exposed via the scale subresource so HPA/KEDA can target RoleBasedGroupSet.
+	// +optional
+	Selector string `json:"selector,omitempty"`
+
 	// Conditions track the condition of the rbgs
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -59,7 +64,7 @@ type RoleBasedGroupSetStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="DESIRED",type="string",JSONPath=".status.replicas",description="desired replicas"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.readyReplicas",description="ready replicas"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -41,6 +41,28 @@ func (rbg *RoleBasedGroup) GetCommonLabelsFromRole(role *RoleSpec) map[string]st
 	}
 }
 
+// GetGroupSetLabels returns RoleBasedGroupSet ownership labels propagated from
+// a child RoleBasedGroup to its Pods. These labels intentionally stay out of
+// workload selectors because Deployment/StatefulSet selectors are immutable,
+// but they are added to Pod templates so RoleBasedGroupSet's scale subresource
+// selector can directly select all Pods belonging to the set for HPA metrics.
+func (rbg *RoleBasedGroup) GetGroupSetLabels() map[string]string {
+	if rbg == nil || len(rbg.Labels) == 0 {
+		return nil
+	}
+	labels := make(map[string]string, 2)
+	if value := rbg.Labels[constants.GroupSetNameLabelKey]; value != "" {
+		labels[constants.GroupSetNameLabelKey] = value
+	}
+	if value := rbg.Labels[constants.GroupSetIndexLabelKey]; value != "" {
+		labels[constants.GroupSetIndexLabelKey] = value
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	return labels
+}
+
 // GetCommonAnnotationsFromRole returns common annotations for a role.
 // System-managed role annotations (e.g. RoleWorkloadTypeAnnotationKey,
 // RoleSizeAnnotationKey) are filtered out to prevent them from leaking

--- a/api/workloads/v1alpha2/rolebasedgroupset_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroupset_types.go
@@ -63,6 +63,11 @@ type RoleBasedGroupSetStatus struct {
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas" protobuf:"varint,3,opt,name=readyReplicas"`
 
+	// Selector is a label query over child RoleBasedGroups managed by this RoleBasedGroupSet.
+	// It is exposed via the scale subresource so HPA/KEDA can target RoleBasedGroupSet.
+	// +optional
+	Selector string `json:"selector,omitempty"`
+
 	// Conditions track the condition of the rbgs
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -74,7 +79,7 @@ type RoleBasedGroupSetStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="DESIRED",type="string",JSONPath=".status.replicas",description="desired replicas"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.readyReplicas",description="ready replicas"

--- a/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupsetstatus.go
+++ b/client-go/applyconfiguration/workloads/v1alpha1/rolebasedgroupsetstatus.go
@@ -27,6 +27,7 @@ type RoleBasedGroupSetStatusApplyConfiguration struct {
 	ObservedGeneration *int64                           `json:"observedGeneration,omitempty"`
 	Replicas           *int32                           `json:"replicas,omitempty"`
 	ReadyReplicas      *int32                           `json:"readyReplicas,omitempty"`
+	Selector           *string                          `json:"selector,omitempty"`
 	Conditions         []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
@@ -57,6 +58,14 @@ func (b *RoleBasedGroupSetStatusApplyConfiguration) WithReplicas(value int32) *R
 // If called multiple times, the ReadyReplicas field is set to the value of the last call.
 func (b *RoleBasedGroupSetStatusApplyConfiguration) WithReadyReplicas(value int32) *RoleBasedGroupSetStatusApplyConfiguration {
 	b.ReadyReplicas = &value
+	return b
+}
+
+// WithSelector sets the Selector field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Selector field is set to the value of the last call.
+func (b *RoleBasedGroupSetStatusApplyConfiguration) WithSelector(value string) *RoleBasedGroupSetStatusApplyConfiguration {
+	b.Selector = &value
 	return b
 }
 

--- a/client-go/applyconfiguration/workloads/v1alpha2/rolebasedgroupsetstatus.go
+++ b/client-go/applyconfiguration/workloads/v1alpha2/rolebasedgroupsetstatus.go
@@ -27,6 +27,7 @@ type RoleBasedGroupSetStatusApplyConfiguration struct {
 	ObservedGeneration *int64                           `json:"observedGeneration,omitempty"`
 	Replicas           *int32                           `json:"replicas,omitempty"`
 	ReadyReplicas      *int32                           `json:"readyReplicas,omitempty"`
+	Selector           *string                          `json:"selector,omitempty"`
 	Conditions         []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
@@ -57,6 +58,14 @@ func (b *RoleBasedGroupSetStatusApplyConfiguration) WithReplicas(value int32) *R
 // If called multiple times, the ReadyReplicas field is set to the value of the last call.
 func (b *RoleBasedGroupSetStatusApplyConfiguration) WithReadyReplicas(value int32) *RoleBasedGroupSetStatusApplyConfiguration {
 	b.ReadyReplicas = &value
+	return b
+}
+
+// WithSelector sets the Selector field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Selector field is set to the value of the last call.
+func (b *RoleBasedGroupSetStatusApplyConfiguration) WithSelector(value string) *RoleBasedGroupSetStatusApplyConfiguration {
+	b.Selector = &value
 	return b
 }
 

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -16781,12 +16781,18 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  Selector is a label query over child RoleBasedGroups managed by this RoleBasedGroupSet.
+                  It is exposed via the scale subresource so HPA/KEDA can target RoleBasedGroupSet.
+                type: string
             type: object
         type: object
     served: true
     storage: false
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
@@ -41625,12 +41631,18 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  Selector is a label query over child RoleBasedGroups managed by this RoleBasedGroupSet.
+                  It is exposed via the scale subresource so HPA/KEDA can target RoleBasedGroupSet.
+                type: string
             type: object
         type: object
     served: true
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/internal/controller/workloads/rolebasedgroupset_controller.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller.go
@@ -275,6 +275,7 @@ func (r *RoleBasedGroupSetReconciler) updateStatus(
 	// Create a deep copy of the status to modify.
 	newStatus := *rbgset.Status.DeepCopy()
 	newStatus.Replicas = int32(len(rbglist.Items))
+	newStatus.Selector = labels.Set{constants.GroupSetNameLabelKey: rbgset.Name}.String()
 
 	// Calculate the number of ready replicas.
 	readyReplicas := 0

--- a/internal/controller/workloads/rolebasedgroupset_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroupset_controller_test.go
@@ -1130,6 +1130,11 @@ func TestRoleBasedGroupSetReconciler_Reconcile_StatusUpdate(t *testing.T) {
 				// Verify status fields
 				assert.Equal(t, tt.expectReplicas, updatedRBGSet.Status.Replicas)
 				assert.Equal(t, tt.expectReadyReplicas, updatedRBGSet.Status.ReadyReplicas)
+				assert.Equal(
+					t,
+					fmt.Sprintf("%s=%s", constants.GroupSetNameLabelKey, tt.initialRBGSet.Name),
+					updatedRBGSet.Status.Selector,
+				)
 
 				// Verify condition
 				assert.NotEmpty(t, updatedRBGSet.Status.Conditions, "Status conditions should not be empty")

--- a/pkg/reconciler/pod_reconciler.go
+++ b/pkg/reconciler/pod_reconciler.go
@@ -124,6 +124,14 @@ func (r *PodReconciler) ConstructPodTemplateSpecApplyConfiguration(
 		}
 	}
 
+	groupSetLabels := rbg.GetGroupSetLabels()
+	if len(groupSetLabels) > 0 && podLabels == nil {
+		podLabels = make(map[string]string, len(groupSetLabels))
+	}
+	for k, v := range groupSetLabels {
+		podLabels[k] = v
+	}
+
 	// construct pod template spec configuration
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podTemplateSpec)
 	if err != nil {

--- a/pkg/reconciler/pod_reconciler_test.go
+++ b/pkg/reconciler/pod_reconciler_test.go
@@ -496,6 +496,10 @@ func TestPodReconciler_ConstructPodTemplateSpecApplyConfiguration(t *testing.T) 
 
 	// Test data
 	rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "test-ns").Obj()
+	rbg.Labels = map[string]string{
+		constants.GroupSetNameLabelKey:  "test-rbgs",
+		constants.GroupSetIndexLabelKey: "0",
+	}
 	role := &rbg.Spec.Roles[0]
 
 	tests := []struct {
@@ -572,6 +576,8 @@ func TestPodReconciler_ConstructPodTemplateSpecApplyConfiguration(t *testing.T) 
 							assert.Equal(t, v, result.Labels[k])
 						}
 					}
+					assert.Equal(t, "test-rbgs", result.Labels[constants.GroupSetNameLabelKey])
+					assert.Equal(t, "0", result.Labels[constants.GroupSetIndexLabelKey])
 				}
 			},
 		)

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -300,6 +300,9 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByCustomCompone
 		if err != nil {
 			return err
 		}
+		componentLabels := maps.Clone(podTemplateApplyConfiguration.Labels)
+		componentLabels[constants.ComponentSizeLabelKey] = fmt.Sprintf("%d", *component.Size)
+
 		// construct service name
 		svcName := component.ServiceName
 		if svcName == "" {
@@ -315,9 +318,7 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByCustomCompone
 				WithSize(*component.Size).
 				WithAnnotations(component.Annotations).
 				WithLabels(component.Labels).
-				WithTemplate(podTemplateApplyConfiguration.WithLabels(map[string]string{
-					constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *component.Size),
-				})))
+				WithTemplate(podTemplateApplyConfiguration.WithLabels(componentLabels)))
 	}
 	return nil
 }
@@ -361,7 +362,7 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 	leaderPodReconciler.SetPodGroupManager(r.podGroupManager)
 	leaderPodReconciler.SetInjectors([]string{"config", "sidecar", "common_env", "lwp_env"})
 	leaderTemplateApplyCfg, err := leaderPodReconciler.ConstructPodTemplateSpecApplyConfiguration(
-		ctx, rbg, role, matchLabels, leaderTemp,
+		ctx, rbg, role, maps.Clone(matchLabels), leaderTemp,
 	)
 	if err != nil {
 		logger.Error(err, "patch Construct PodTemplateSpecApplyConfiguration failed", "rbg", keyOfRbg(rbg))
@@ -380,7 +381,7 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 	// workerTemplate do not need to inject sidecar
 	workerPodReconciler.SetInjectors([]string{"config", "common_env", "lwp_env"})
 	workerTemplateApplyCfg, err := workerPodReconciler.ConstructPodTemplateSpecApplyConfiguration(
-		ctx, rbg, role, matchLabels, workerTemp,
+		ctx, rbg, role, maps.Clone(matchLabels), workerTemp,
 	)
 	if err != nil {
 		logger.Error(err, "patch Construct PodTemplateSpecApplyConfiguration failed", "rbg", keyOfRbg(rbg))
@@ -392,6 +393,14 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 		return err
 	}
 
+	leaderLabels := maps.Clone(leaderTemplateApplyCfg.Labels)
+	leaderLabels[constants.ComponentNameLabelKey] = string(constants.LeaderComponentType)
+	leaderLabels[constants.ComponentSizeLabelKey] = fmt.Sprintf("%d", *lwp.Size)
+
+	workerLabels := maps.Clone(workerTemplateApplyCfg.Labels)
+	workerLabels[constants.ComponentNameLabelKey] = string(constants.WorkerComponentType)
+	workerLabels[constants.ComponentSizeLabelKey] = fmt.Sprintf("%d", *lwp.Size)
+
 	workerSize := utils.NonZeroValue(*lwp.Size - 1)
 	roleInstanceTemplateConfig.
 		WithComponents(
@@ -399,17 +408,11 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 				WithName(string(constants.LeaderComponentType)).
 				WithServiceName(svcName).
 				WithSize(1).
-				WithTemplate(leaderTemplateApplyCfg.WithLabels(map[string]string{
-					constants.ComponentNameLabelKey: string(constants.LeaderComponentType),
-					constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *lwp.Size),
-				})),
+				WithTemplate(leaderTemplateApplyCfg.WithLabels(leaderLabels)),
 			workloadsv1alpha2client.RoleInstanceComponent().
 				WithName(string(constants.WorkerComponentType)).
 				WithSize(workerSize).
-				WithTemplate(workerTemplateApplyCfg.WithLabels(map[string]string{
-					constants.ComponentNameLabelKey: string(constants.WorkerComponentType),
-					constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *lwp.Size),
-				})))
+				WithTemplate(workerTemplateApplyCfg.WithLabels(workerLabels)))
 	return nil
 }
 
@@ -434,13 +437,14 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateFromStandaloneP
 		return err
 	}
 
+	podLabels := maps.Clone(podTemplateApplyConfiguration.Labels)
+	podLabels[constants.ComponentSizeLabelKey] = "1"
+
 	roleInstanceTemplateConfig.
 		WithComponents(workloadsv1alpha2client.RoleInstanceComponent().
 			WithName(role.Name).
 			WithServiceName(svcName).
-			WithTemplate(podTemplateApplyConfiguration.WithLabels(map[string]string{
-				constants.ComponentSizeLabelKey: "1",
-			})).
+			WithTemplate(podTemplateApplyConfiguration.WithLabels(podLabels)).
 			WithSize(1))
 	return nil
 }


### PR DESCRIPTION
我的场景中，是1P1D，或者2P3D这种成对扩容的，当前RoleBasedGroupSet因为没有Selector，无法被HPA/KEDA接管。

这个PR实现了RBGs的Selector，兼容了HPA/KEDA，实现按组的自动扩缩容
