### PR TITLE
test(e2e): verify controller RBAC and webhook-cert bootstrap in a live cluster

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -178,6 +178,42 @@ jobs:
           done
           echo "All CRDs verified successfully"
 
+      - name: Verify controller RBAC and webhook-cert bootstrap
+        run: |
+          set -euo pipefail
+          NS=rbgs-system
+          echo "== RBAC objects installed by the chart =="
+          kubectl get clusterrole rbgs-controller-role
+          kubectl get clusterrolebinding rbgs-controller-rolebinding
+          kubectl -n "$NS" get role rbgs-controller-secret-role
+          kubectl -n "$NS" get rolebinding rbgs-controller-secret-rolebinding
+          kubectl -n "$NS" get serviceaccount rbgs-controller-sa
+
+          echo "== webhook-cert secret bootstrapped by the controller (exercises the cert Role) =="
+          for i in $(seq 1 24); do
+            CRT=$(kubectl -n "$NS" get secret rbgs-webhook-cert -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
+            if [ -n "$CRT" ]; then
+              echo "webhook-cert secret present with non-empty tls.crt"
+              break
+            fi
+            if [ "$i" -eq 24 ]; then
+              echo "::error::webhook-cert secret rbgs-webhook-cert was not bootstrapped (cert Role/RBAC broken?)"
+              kubectl -n "$NS" describe secret rbgs-webhook-cert || true
+              kubectl -n "$NS" logs -l control-plane=rbgs-controller --tail=100 || true
+              exit 1
+            fi
+            echo "waiting for webhook-cert secret... ($i/24)"
+            sleep 5
+          done
+
+          echo "== caBundle injected into the validating webhook =="
+          CA=$(kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
+          if [ -z "$CA" ]; then
+            echo "::error::caBundle not injected into rbgs-validating-webhook-configuration"
+            exit 1
+          fi
+          echo "RBAC and webhook-cert bootstrap verified"
+
       - name: Pre-load e2e test images
         run: |
           # Pull and load e2e test images to avoid image pull timeout during tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -192,12 +192,13 @@ jobs:
           echo "== webhook-cert secret bootstrapped by the controller (exercises the cert Role) =="
           for i in $(seq 1 24); do
             CRT=$(kubectl -n "$NS" get secret rbgs-webhook-cert -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
-            if [ -n "$CRT" ]; then
-              echo "webhook-cert secret present with non-empty tls.crt"
+            KEY=$(kubectl -n "$NS" get secret rbgs-webhook-cert -o jsonpath='{.data.tls\.key}' 2>/dev/null || true)
+            if [ -n "$CRT" ] && [ -n "$KEY" ]; then
+              echo "webhook-cert secret present with non-empty tls.crt and tls.key"
               break
             fi
             if [ "$i" -eq 24 ]; then
-              echo "::error::webhook-cert secret rbgs-webhook-cert was not bootstrapped (cert Role/RBAC broken?)"
+              echo "::error::webhook-cert secret rbgs-webhook-cert was not fully bootstrapped (missing tls.crt/tls.key; cert Role/RBAC broken?)"
               kubectl -n "$NS" describe secret rbgs-webhook-cert || true
               kubectl -n "$NS" logs -l control-plane=rbgs-controller --tail=100 || true
               exit 1
@@ -206,10 +207,11 @@ jobs:
             sleep 5
           done
 
-          echo "== caBundle injected into the validating webhook =="
-          CA=$(kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
-          if [ -z "$CA" ]; then
-            echo "::error::caBundle not injected into rbgs-validating-webhook-configuration"
+          echo "== caBundle injected into every webhook of the validating webhook config =="
+          if ! kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o json \
+              | jq -e '(.webhooks | length > 0) and all(.webhooks[]; (.clientConfig.caBundle // "") != "")' >/dev/null; then
+            echo "::error::caBundle not injected into every webhook of rbgs-validating-webhook-configuration"
+            kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o yaml || true
             exit 1
           fi
           echo "RBAC and webhook-cert bootstrap verified"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -88,6 +88,7 @@ func TestE2E(t *testing.T) {
 			testcasev1alpha2.RunInplaceSchedulingTestCases(f)
 			testcasev1alpha2.RunWarmupTestCases(f)
 			testcasev1alpha2.RunWebhookValidationTestCases(f)
+			testcasev1alpha2.RunRBACAndWebhookBootstrapTestCases(f)
 		},
 	)
 

--- a/test/e2e/testcase/v1alpha2/rbac_webhook_bootstrap.go
+++ b/test/e2e/testcase/v1alpha2/rbac_webhook_bootstrap.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	rbgwebhook "sigs.k8s.io/rbgs/pkg/webhook"
+	"sigs.k8s.io/rbgs/test/e2e/framework"
+)
+
+// RBAC object names produced by the rbgs Helm chart (deploy/helm/rbgs/templates/rbac)
+// and the kustomize config (config/rbac). Kept in one place so a chart reorganization
+// that drops or renames one of them fails these cases with a clear signal rather than
+// an opaque downstream webhook-TLS error.
+const (
+	controllerClusterRoleName        = "rbgs-controller-role"
+	controllerClusterRoleBindingName = "rbgs-controller-rolebinding"
+	certRoleName                     = "rbgs-controller-secret-role"
+	certRoleBindingName              = "rbgs-controller-secret-rolebinding"
+	controllerServiceAccountName     = "rbgs-controller-sa"
+)
+
+const (
+	bootstrapTimeout  = 2 * time.Minute
+	bootstrapInterval = 5 * time.Second
+)
+
+// controllerNamespace is where the controller (and its RBAC + webhook cert secret) is
+// deployed. Defaults to the chart's rbgs-system; override with RBGS_NAMESPACE.
+func controllerNamespace() string {
+	if ns := os.Getenv("RBGS_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return "rbgs-system"
+}
+
+// RunRBACAndWebhookBootstrapTestCases verifies, against the real cluster the chart was
+// installed into, that the controller's RBAC wiring is present and that the webhook-cert
+// bootstrap actually works end to end. The webhook-cert Role is hand-maintained
+// (namespace- and resourceName-scoped, not marker-generated), so it is the piece most
+// likely to break silently when the chart/kustomize layout is reorganized.
+func RunRBACAndWebhookBootstrapTestCases(f *framework.Framework) {
+	ginkgo.Describe(
+		"controller RBAC and webhook-cert bootstrap", func() {
+			ns := controllerNamespace()
+
+			ginkgo.BeforeEach(func() {
+				f.RegisterDebugFn(func() { dumpBootstrapDebugInfo(f, ns) })
+			})
+
+			ginkgo.It(
+				"should install the controller RBAC objects with resolvable bindings", func() {
+					_, err := f.Clientset.RbacV1().ClusterRoles().Get(f.Ctx, controllerClusterRoleName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "ClusterRole %q should exist", controllerClusterRoleName)
+
+					_, err = f.Clientset.CoreV1().ServiceAccounts(ns).Get(f.Ctx, controllerServiceAccountName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "ServiceAccount %s/%s should exist", ns, controllerServiceAccountName)
+
+					crb, err := f.Clientset.RbacV1().ClusterRoleBindings().Get(f.Ctx, controllerClusterRoleBindingName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "ClusterRoleBinding %q should exist", controllerClusterRoleBindingName)
+					gomega.Expect(crb.RoleRef.Kind).Should(gomega.Equal("ClusterRole"))
+					gomega.Expect(crb.RoleRef.Name).Should(gomega.Equal(controllerClusterRoleName),
+						"ClusterRoleBinding roleRef must resolve to the controller ClusterRole")
+					gomega.Expect(subjectsHaveServiceAccount(crb.Subjects, controllerServiceAccountName, ns)).Should(gomega.BeTrue(),
+						"ClusterRoleBinding must bind ServiceAccount %s/%s", ns, controllerServiceAccountName)
+
+					rb, err := f.Clientset.RbacV1().RoleBindings(ns).Get(f.Ctx, certRoleBindingName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "RoleBinding %s/%s should exist", ns, certRoleBindingName)
+					gomega.Expect(rb.RoleRef.Kind).Should(gomega.Equal("Role"))
+					gomega.Expect(rb.RoleRef.Name).Should(gomega.Equal(certRoleName),
+						"cert RoleBinding roleRef must resolve to the webhook-cert Role")
+					gomega.Expect(subjectsHaveServiceAccount(rb.Subjects, controllerServiceAccountName, ns)).Should(gomega.BeTrue(),
+						"cert RoleBinding must bind ServiceAccount %s/%s", ns, controllerServiceAccountName)
+				},
+			)
+
+			ginkgo.It(
+				"should scope the webhook-cert Role to secret create + rbgs-webhook-cert get/update", func() {
+					role, err := f.Clientset.RbacV1().Roles(ns).Get(f.Ctx, certRoleName, metav1.GetOptions{})
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Role %s/%s should exist", ns, certRoleName)
+
+					secret := rbgwebhook.WebhookCertSecretName
+					gomega.Expect(secretVerbAllowed(role, "create", "")).Should(gomega.BeTrue(),
+						"cert Role must allow creating secrets (to bootstrap %s)", secret)
+					gomega.Expect(secretVerbAllowed(role, "get", secret)).Should(gomega.BeTrue(),
+						"cert Role must allow get on secret %s", secret)
+					gomega.Expect(secretVerbAllowed(role, "update", secret)).Should(gomega.BeTrue(),
+						"cert Role must allow update on secret %s", secret)
+				},
+			)
+
+			ginkgo.It(
+				"should bootstrap the webhook-cert secret in the live cluster", func() {
+					// This only succeeds if the controller could create+get+update the secret
+					// through the cert Role above (no RBAC Forbidden), so it exercises the Role
+					// for real rather than just reading its rules.
+					secret := rbgwebhook.WebhookCertSecretName
+					gomega.Eventually(func() error {
+						s, err := f.Clientset.CoreV1().Secrets(ns).Get(f.Ctx, secret, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						if len(s.Data["tls.crt"]) == 0 {
+							return fmt.Errorf("secret %s/%s has empty tls.crt", ns, secret)
+						}
+						if len(s.Data["tls.key"]) == 0 {
+							return fmt.Errorf("secret %s/%s has empty tls.key", ns, secret)
+						}
+						return nil
+					}, bootstrapTimeout, bootstrapInterval).Should(gomega.Succeed(),
+						"controller must bootstrap the webhook-cert secret via the cert Role")
+				},
+			)
+
+			ginkgo.It(
+				"should inject the CA bundle into the validating webhook and conversion CRDs", func() {
+					for _, name := range rbgwebhook.ValidatingWebhookConfigurations() {
+						gomega.Eventually(func() error {
+							vwc, err := f.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(f.Ctx, name, metav1.GetOptions{})
+							if err != nil {
+								return err
+							}
+							if len(vwc.Webhooks) == 0 {
+								return fmt.Errorf("ValidatingWebhookConfiguration %s has no webhooks", name)
+							}
+							for _, wh := range vwc.Webhooks {
+								if len(wh.ClientConfig.CABundle) == 0 {
+									return fmt.Errorf("webhook %q in %s has empty caBundle", wh.Name, name)
+								}
+							}
+							return nil
+						}, bootstrapTimeout, bootstrapInterval).Should(gomega.Succeed(),
+							"caBundle must be injected into ValidatingWebhookConfiguration %s", name)
+					}
+
+					crdClient := newCRDClient()
+					for _, name := range rbgwebhook.ConversionWebhookCRDs() {
+						gomega.Eventually(func() error {
+							crd := &apiextv1.CustomResourceDefinition{}
+							if err := crdClient.Get(f.Ctx, client.ObjectKey{Name: name}, crd); err != nil {
+								return err
+							}
+							if crd.Spec.Conversion == nil || crd.Spec.Conversion.Webhook == nil ||
+								crd.Spec.Conversion.Webhook.ClientConfig == nil {
+								return fmt.Errorf("CRD %s has no conversion webhook clientConfig", name)
+							}
+							if len(crd.Spec.Conversion.Webhook.ClientConfig.CABundle) == 0 {
+								return fmt.Errorf("CRD %s conversion webhook has empty caBundle", name)
+							}
+							return nil
+						}, bootstrapTimeout, bootstrapInterval).Should(gomega.Succeed(),
+							"caBundle must be injected into conversion CRD %s", name)
+					}
+				},
+			)
+		},
+	)
+}
+
+// subjectsHaveServiceAccount reports whether subjects include the given ServiceAccount.
+func subjectsHaveServiceAccount(subjects []rbacv1.Subject, name, namespace string) bool {
+	for _, s := range subjects {
+		if s.Kind == rbacv1.ServiceAccountKind && s.Name == name && s.Namespace == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// secretVerbAllowed reports whether the Role grants verb on core "secrets". When name is
+// non-empty, the matching rule must either be unrestricted or list that resourceName.
+func secretVerbAllowed(role *rbacv1.Role, verb, name string) bool {
+	for _, r := range role.Rules {
+		if !slices.Contains(r.APIGroups, "") && !slices.Contains(r.APIGroups, "*") {
+			continue
+		}
+		if !slices.Contains(r.Resources, "secrets") && !slices.Contains(r.Resources, "*") {
+			continue
+		}
+		if !slices.Contains(r.Verbs, verb) && !slices.Contains(r.Verbs, "*") {
+			continue
+		}
+		if name == "" || len(r.ResourceNames) == 0 || slices.Contains(r.ResourceNames, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// newCRDClient builds a read client that understands CustomResourceDefinition, which the
+// shared framework scheme does not register.
+func newCRDClient() client.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(apiextv1.AddToScheme(scheme))
+	c, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "build CRD client")
+	return c
+}
+
+// dumpBootstrapDebugInfo prints the state of the RBAC + webhook-cert objects when the
+// current spec failed, to make RBAC/cert regressions diagnosable from CI logs.
+func dumpBootstrapDebugInfo(f *framework.Framework, ns string) {
+	if !ginkgo.CurrentSpecReport().Failed() {
+		return
+	}
+	fmt.Printf("\n========== webhook-cert bootstrap debug (namespace %s) ==========\n", ns)
+
+	if role, err := f.Clientset.RbacV1().Roles(ns).Get(f.Ctx, certRoleName, metav1.GetOptions{}); err != nil {
+		fmt.Printf("Role %s: %v\n", certRoleName, err)
+	} else {
+		fmt.Printf("Role %s rules: %+v\n", certRoleName, role.Rules)
+	}
+
+	if s, err := f.Clientset.CoreV1().Secrets(ns).Get(f.Ctx, rbgwebhook.WebhookCertSecretName, metav1.GetOptions{}); err != nil {
+		fmt.Printf("Secret %s: %v\n", rbgwebhook.WebhookCertSecretName, err)
+	} else {
+		keys := make([]string, 0, len(s.Data))
+		for k := range s.Data {
+			keys = append(keys, k)
+		}
+		fmt.Printf("Secret %s data keys: %v\n", rbgwebhook.WebhookCertSecretName, keys)
+	}
+
+	pods, err := f.Clientset.CoreV1().Pods(ns).List(f.Ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("list pods: %v\n", err)
+		return
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		fmt.Printf("pod %s phase=%s\n", p.Name, p.Status.Phase)
+	}
+}

--- a/test/e2e/testcase/v1alpha2/rbac_webhook_bootstrap.go
+++ b/test/e2e/testcase/v1alpha2/rbac_webhook_bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -103,17 +104,16 @@ func RunRBACAndWebhookBootstrapTestCases(f *framework.Framework) {
 			)
 
 			ginkgo.It(
-				"should scope the webhook-cert Role to secret create + rbgs-webhook-cert get/update", func() {
+				"should scope the webhook-cert Role to exactly secret create + rbgs-webhook-cert get/update", func() {
 					role, err := f.Clientset.RbacV1().Roles(ns).Get(f.Ctx, certRoleName, metav1.GetOptions{})
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "Role %s/%s should exist", ns, certRoleName)
 
+					// Assert the exact least-privilege grant set, so this case also fails if the
+					// Role is broadened (extra verbs, unrestricted get/update, wildcards, or any
+					// resource other than core secrets) — not just if a needed verb is missing.
 					secret := rbgwebhook.WebhookCertSecretName
-					gomega.Expect(secretVerbAllowed(role, "create", "")).Should(gomega.BeTrue(),
-						"cert Role must allow creating secrets (to bootstrap %s)", secret)
-					gomega.Expect(secretVerbAllowed(role, "get", secret)).Should(gomega.BeTrue(),
-						"cert Role must allow get on secret %s", secret)
-					gomega.Expect(secretVerbAllowed(role, "update", secret)).Should(gomega.BeTrue(),
-						"cert Role must allow update on secret %s", secret)
+					gomega.Expect(secretRuleViolations(role, secret)).Should(gomega.BeEmpty(),
+						"cert Role must grant exactly: create secrets; get/update on %s only", secret)
 				},
 			)
 
@@ -195,24 +195,44 @@ func subjectsHaveServiceAccount(subjects []rbacv1.Subject, name, namespace strin
 	return false
 }
 
-// secretVerbAllowed reports whether the Role grants verb on core "secrets". When name is
-// non-empty, the matching rule must either be unrestricted or list that resourceName.
-func secretVerbAllowed(role *rbacv1.Role, verb, name string) bool {
+// secretRuleViolations returns human-readable reasons the cert Role deviates from the
+// intended least-privilege grant set — create on secrets (any name), plus get/update on
+// only the named webhook-cert secret. An empty result means the Role is exactly scoped.
+// It reports both missing grants and over-permissive ones (extra verbs, unrestricted
+// get/update, wildcards, or any resource beyond core secrets).
+func secretRuleViolations(role *rbacv1.Role, secretName string) []string {
+	// Expected effective grants keyed as "verb|comma-joined-sorted-resourceNames".
+	expected := map[string]bool{
+		"create|":              true, // create cannot be resourceName-scoped
+		"get|" + secretName:    true,
+		"update|" + secretName: true,
+	}
+
+	var violations []string
+	got := map[string]bool{}
 	for _, r := range role.Rules {
-		if !slices.Contains(r.APIGroups, "") && !slices.Contains(r.APIGroups, "*") {
+		if len(r.APIGroups) != 1 || r.APIGroups[0] != "" || len(r.Resources) != 1 || r.Resources[0] != "secrets" {
+			violations = append(violations, fmt.Sprintf("rule grants beyond core secrets: groups=%v resources=%v", r.APIGroups, r.Resources))
 			continue
 		}
-		if !slices.Contains(r.Resources, "secrets") && !slices.Contains(r.Resources, "*") {
-			continue
-		}
-		if !slices.Contains(r.Verbs, verb) && !slices.Contains(r.Verbs, "*") {
-			continue
-		}
-		if name == "" || len(r.ResourceNames) == 0 || slices.Contains(r.ResourceNames, name) {
-			return true
+		names := append([]string(nil), r.ResourceNames...)
+		slices.Sort(names)
+		scope := strings.Join(names, ",")
+		for _, v := range r.Verbs {
+			got[v+"|"+scope] = true
 		}
 	}
-	return false
+	for g := range got {
+		if !expected[g] {
+			violations = append(violations, "unexpected grant: "+g)
+		}
+	}
+	for e := range expected {
+		if !got[e] {
+			violations = append(violations, "missing grant: "+e)
+		}
+	}
+	return violations
 }
 
 // newCRDClient builds a read client that understands CustomResourceDefinition, which the


### PR DESCRIPTION
### What
Adds explicit real-environment coverage that the controller's RBAC wiring and webhook-cert bootstrap actually work in the kind cluster the chart is installed into.

- **Go e2e case** (`RunRBACAndWebhookBootstrapTestCases`, wired into the existing suite):
  - ClusterRole / ClusterRoleBinding / Role / RoleBinding / ServiceAccount exist, and the bindings' `roleRef` + subjects resolve to the right names.
  - The webhook-cert `Role` is scoped to `secrets: create` + `get`/`update` on `rbgs-webhook-cert`.
  - The `rbgs-webhook-cert` secret is actually bootstrapped (proves the Role permits create/get/update at runtime — no RBAC `Forbidden`).
  - The CA bundle is injected into the validating webhook and the conversion CRDs.
- **Fast `kubectl` smoke-check step** in the helm `e2e-test` job for an early, clear signal.

### Why
Today this surface is only exercised *implicitly*. The webhook-cert `Role` is hand-maintained (namespace- and `resourceNames`-scoped, not marker-generated). If a chart/kustomize reorganization drops or misnames it, the controller can't create its cert secret and the failure shows up as an **opaque webhook-TLS error** downstream, not "Role missing". Motivated by reviewing the chart reorg in #403 — the render was behavior-preserving, but the repo had no explicit assertion guarding this going forward.

### Notes
- Test-only; **no production code changes.**
- Namespace defaults to `rbgs-system`, overridable via `RBGS_NAMESPACE`.
- Smoke-check is scoped to the helm `e2e-test` job (chart object names); the manifest job is left unchanged to keep the diff focused.
