### PR TITLE
refactor(helm): group values under global/controller/crdUpgrade and u…

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -158,9 +158,9 @@ jobs:
           helm upgrade --install rbgs deploy/helm/rbgs \
             --create-namespace \
             --namespace rbgs-system \
-            --set image.tag=e2e-test \
-            --set crdUpgrade.tag=e2e-test \
-            --set portAllocator.enabled=true \
+            --set controller.image.tag=e2e-test \
+            --set crdUpgrade.image.tag=e2e-test \
+            --set controller.features.portAllocator.enabled=true \
             --wait
           kubectl get deploy -n rbgs-system
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -117,7 +117,7 @@ jobs:
           helm upgrade --install rbgs deploy/helm/rbgs \
             --create-namespace \
             --namespace rbgs-system \
-            --set portAllocator.enabled=true \
+            --set controller.features.portAllocator.enabled=true \
             --wait
           kubectl get deploy -n rbgs-system
 

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ helm-deploy: manifests ## Deploy controller via Helm to the K8s cluster specifie
 	$(HELM) upgrade --install rbgs deploy/helm/rbgs \
 		--create-namespace \
 		--namespace rbgs-system \
-		--set image.tag=$(TAG) \
+		--set controller.image.tag=$(TAG) \
 		--wait
 
 .PHONY: install-crds

--- a/deploy/helm/rbgs/README.md
+++ b/deploy/helm/rbgs/README.md
@@ -8,10 +8,10 @@ CRD upgrade Job into your Kubernetes cluster.
 
 - **Controller manager** (`rbgs-controller-manager` Deployment) reconciling RBG workloads.
 - **RBAC**: ServiceAccounts, ClusterRole/ClusterRoleBinding, and cert Role/RoleBinding.
-- **Webhooks**: validating/mutating webhook configurations and the webhook Service
+- **Webhooks**: a validating webhook configuration and the webhook Service
   (certificates are bootstrapped by the controller itself, no cert-manager required).
 - **CRD Upgrader Job** (optional, enabled by default): a `pre-install,pre-upgrade` Helm hook Job
-  that applies/upgrades the RBG CRDs before the controller starts.
+  (with its own ServiceAccount and RBAC) that applies/upgrades the RBG CRDs before the controller starts.
 
 ## Prerequisites
 
@@ -58,7 +58,7 @@ kubectl -n rbgs-system get pods -l control-plane=rbgs-controller
 | --- | ----------- | ------- |
 | `controller.replicaCount` | Number of controller replicas (leader election is enabled) | `2` |
 | `controller.image.repository` | Controller image repository | `rolebasedgroup/rbgs-controller` |
-| `controller.image.tag` | Controller image tag | `.Chart.appVersion` |
+| `controller.image.tag` | Controller image tag | pinned per release in `values.yaml` (falls back to `.Chart.AppVersion` if unset) |
 | `controller.image.pullPolicy` | Controller image pull policy | `IfNotPresent` |
 | `controller.imagePullSecrets` | Overrides `global.imagePullSecrets` for the controller when set | `[]` |
 | `controller.resources` | Controller container resources | see `values.yaml` |
@@ -85,7 +85,7 @@ kubectl -n rbgs-system get pods -l control-plane=rbgs-controller
 | --- | ----------- | ------- |
 | `crdUpgrade.enabled` | Enable the CRD Upgrader Job (`pre-install,pre-upgrade` hook) | `true` |
 | `crdUpgrade.image.repository` | CRD Upgrader image repository | `rolebasedgroup/rbgs-upgrade-crd` |
-| `crdUpgrade.image.tag` | CRD Upgrader image tag | `.Chart.appVersion` |
+| `crdUpgrade.image.tag` | CRD Upgrader image tag | pinned per release in `values.yaml` (falls back to `.Chart.AppVersion` if unset) |
 | `crdUpgrade.image.pullPolicy` | CRD Upgrader image pull policy | `IfNotPresent` |
 | `crdUpgrade.imagePullSecrets` | Overrides `global.imagePullSecrets` for the Job when set | `[]` |
 | `crdUpgrade.ttlSecondsAfterFinished` | Job TTL after completion | `259200` (3 days) |

--- a/deploy/helm/rbgs/README.md
+++ b/deploy/helm/rbgs/README.md
@@ -1,0 +1,141 @@
+# RBGS Helm Chart
+
+Helm chart for the [RoleBasedGroup](https://github.com/sgl-project/rbg) (RBG) controller. It deploys the
+`rbgs-controller-manager` Deployment together with its RBAC, webhook configuration, and an optional
+CRD upgrade Job into your Kubernetes cluster.
+
+## What Gets Installed
+
+- **Controller manager** (`rbgs-controller-manager` Deployment) reconciling RBG workloads.
+- **RBAC**: ServiceAccounts, ClusterRole/ClusterRoleBinding, and cert Role/RoleBinding.
+- **Webhooks**: validating/mutating webhook configurations and the webhook Service
+  (certificates are bootstrapped by the controller itself, no cert-manager required).
+- **CRD Upgrader Job** (optional, enabled by default): a `pre-install,pre-upgrade` Helm hook Job
+  that applies/upgrades the RBG CRDs before the controller starts.
+
+## Prerequisites
+
+- Kubernetes >= 1.28
+- Helm 3
+
+## Installing
+
+```bash
+helm upgrade --install rbgs deploy/helm/rbgs \
+    --create-namespace \
+    --namespace rbgs-system \
+    --wait
+```
+
+Or use the Makefile shortcut:
+
+```bash
+make helm-deploy
+```
+
+If you prefer to manage CRDs manually, apply `config/crd/bases/` with kubectl and disable the
+CRD Upgrader Job with `--set crdUpgrade.enabled=false`. See [doc/install.md](../../../doc/install.md)
+for the full installation guide.
+
+Verify the deployment:
+
+```bash
+kubectl -n rbgs-system get deploy rbgs-controller-manager
+kubectl -n rbgs-system get pods -l control-plane=rbgs-controller
+```
+
+## Values
+
+### Global
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `global.imagePullSecrets` | Image pull secrets shared by the controller Deployment and the crd-upgrade Job | `[]` |
+
+### Controller
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `controller.replicaCount` | Number of controller replicas (leader election is enabled) | `2` |
+| `controller.image.repository` | Controller image repository | `rolebasedgroup/rbgs-controller` |
+| `controller.image.tag` | Controller image tag | `.Chart.appVersion` |
+| `controller.image.pullPolicy` | Controller image pull policy | `IfNotPresent` |
+| `controller.imagePullSecrets` | Overrides `global.imagePullSecrets` for the controller when set | `[]` |
+| `controller.resources` | Controller container resources | see `values.yaml` |
+| `controller.nodeSelector` | Controller pod node selector | `{}` |
+| `controller.tolerations` | Controller pod tolerations | `[]` |
+| `controller.podAnnotations` | Controller pod annotations | `{}` |
+| `controller.podSecurityContext` | Controller pod security context | `{}` |
+| `controller.securityContext` | Controller container security context | `{}` |
+| `controller.tuning.maxConcurrentReconciles` | Concurrent reconcile workers per controller | `10` |
+| `controller.tuning.kubeApiQPS` | Max QPS from the controller to the API server | `20` |
+| `controller.tuning.kubeApiBurst` | Max burst for throttle to the API server (should be > QPS) | `30` |
+| `controller.pprof.enabled` | Enable the pprof profiling server | `false` |
+| `controller.pprof.bindAddress` | Address the pprof endpoint binds to | `":6060"` |
+| `controller.pprof.containerPort` | Container port exposed for pprof | `6060` |
+| `controller.features.gangScheduling.schedulerName` | Gang scheduling scheduler: `scheduler-plugins` \| `volcano` | `scheduler-plugins` |
+| `controller.features.portAllocator.enabled` | Enable dynamic port allocation to pods | `false` |
+| `controller.features.portAllocator.strategy` | Port allocation strategy (`random`) | `random` |
+| `controller.features.portAllocator.startPort` | Starting port of the allocatable range | `30000` |
+| `controller.features.portAllocator.portRange` | Size of the allocatable port range | `5000` |
+
+### CRD Upgrader
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `crdUpgrade.enabled` | Enable the CRD Upgrader Job (`pre-install,pre-upgrade` hook) | `true` |
+| `crdUpgrade.image.repository` | CRD Upgrader image repository | `rolebasedgroup/rbgs-upgrade-crd` |
+| `crdUpgrade.image.tag` | CRD Upgrader image tag | `.Chart.appVersion` |
+| `crdUpgrade.image.pullPolicy` | CRD Upgrader image pull policy | `IfNotPresent` |
+| `crdUpgrade.imagePullSecrets` | Overrides `global.imagePullSecrets` for the Job when set | `[]` |
+| `crdUpgrade.ttlSecondsAfterFinished` | Job TTL after completion | `259200` (3 days) |
+| `crdUpgrade.tolerations` | Job pod tolerations | `[{operator: Exists}]` |
+| `crdUpgrade.nodeSelector` | Job pod node selector | `{}` |
+
+## Uninstalling
+
+```bash
+# Uninstall the controller (CRDs are preserved)
+helm uninstall rbgs --namespace rbgs-system
+
+# Optional: delete CRDs (WARNING: this deletes all RoleBasedGroup resources)
+kubectl delete -f config/crd/bases/
+```
+
+## Upgrading
+
+### Breaking change: values regrouped in chart v0.8.0
+
+**Upgrade path**: from chart **v0.8.0-alpha.2 or earlier** (all previous releases, e.g. `v0.7.0`
+and the `v0.8.0-alpha.x` pre-releases, used the flat values layout) to chart **v0.8.0 or later**.
+
+Chart values were restructured from a flat layout into three top-level groups: `global`,
+`controller`, and `crdUpgrade`.
+
+> **Warning**: Helm does **not** fail on unknown values. If your values file or `--set` flags
+> still use the old top-level keys, they are **silently ignored** and the controller runs with
+> chart defaults. Migrate your overrides before upgrading.
+
+| Old key (<= v0.8.0-alpha.2) | New key (>= v0.8.0) |
+| --------------------------- | ------------------- |
+| `replicaCount` | `controller.replicaCount` |
+| `image.*` | `controller.image.*` |
+| `resources.*` | `controller.resources.*` |
+| `nodeSelector` / `tolerations` | `controller.nodeSelector` / `controller.tolerations` |
+| `podAnnotations` | `controller.podAnnotations` |
+| `podSecurityContext` / `securityContext` | `controller.podSecurityContext` / `controller.securityContext` |
+| `imagePullSecrets` | `global.imagePullSecrets` (or per-component `controller.imagePullSecrets` / `crdUpgrade.imagePullSecrets`) |
+| `controllerTuning.*` | `controller.tuning.*` |
+| `pprof.*` | `controller.pprof.*` |
+| `schedulerName` | `controller.features.gangScheduling.schedulerName` |
+| `portAllocator.*` | `controller.features.portAllocator.*` |
+| `crdUpgrade.repository` | `crdUpgrade.image.repository` |
+| `crdUpgrade.tag` | `crdUpgrade.image.tag` |
+| `crdUpgrade.imagePullPolicy` | `crdUpgrade.image.pullPolicy` |
+
+After upgrading, verify that your overrides took effect:
+
+```bash
+helm -n rbgs-system get values rbgs
+kubectl -n rbgs-system get deploy rbgs-controller-manager -o yaml | grep -A20 'args:'
+```

--- a/deploy/helm/rbgs/templates/NOTES.txt
+++ b/deploy/helm/rbgs/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{- if .Release.IsInstall }}
+{{ .Chart.Name }} ({{ .Chart.AppVersion }}) installed in namespace "{{ .Release.Namespace }}".
+{{- end }}
+{{- if .Release.IsUpgrade }}
+{{ .Chart.Name }} upgraded to {{ .Chart.AppVersion }} in namespace "{{ .Release.Namespace }}".
+
+Verify your effective values after upgrading:
+  helm -n {{ .Release.Namespace }} get values {{ .Release.Name }}
+{{- end }}
+
+Check the controller:
+  kubectl -n {{ .Release.Namespace }} get deploy rbgs-controller-manager
+  kubectl -n {{ .Release.Namespace }} get pods -l control-plane=rbgs-controller
+
+NOTE: chart v0.8.0 introduced a BREAKING CHANGE: values were regrouped under
+`global`, `controller`, and `crdUpgrade`. Old top-level keys (e.g. `image.*`,
+`replicaCount`, `schedulerName`, `portAllocator.*`) are SILENTLY IGNORED by Helm.
+See the migration table in the chart README.md.

--- a/deploy/helm/rbgs/templates/crd-upgrade/crd-upgrade.yaml
+++ b/deploy/helm/rbgs/templates/crd-upgrade/crd-upgrade.yaml
@@ -15,7 +15,7 @@ spec:
 {{- end }}
   template:
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.crdUpgrade.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -30,8 +30,8 @@ spec:
       serviceAccountName: rbgs-crds-upgrade
       containers:
         - name: rbgs-crds-upgrade
-          image: "{{ .Values.crdUpgrade.repository }}:{{ .Values.crdUpgrade.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.crdUpgrade.imagePullPolicy | default "IfNotPresent" }}
+          image: "{{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: WEBHOOK_NAMESPACE
               value: {{ .Release.Namespace | quote }}

--- a/deploy/helm/rbgs/templates/crd-upgrade/crd-upgrade.yaml
+++ b/deploy/helm/rbgs/templates/crd-upgrade/crd-upgrade.yaml
@@ -15,7 +15,7 @@ spec:
 {{- end }}
   template:
     spec:
-      {{- with .Values.crdUpgrade.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with .Values.crdUpgrade.imagePullSecrets | default (.Values.global).imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/rbgs/templates/manager/manager.yaml
+++ b/deploy/helm/rbgs/templates/manager/manager.yaml
@@ -6,47 +6,47 @@ metadata:
   labels:
     control-plane: rbgs-controller
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:
       control-plane: rbgs-controller
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.controller.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         control-plane: rbgs-controller
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.controller.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: rbgs-controller-sa
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           args:
             - --metrics-bind-address=:8443
             - --leader-elect
             - --health-probe-bind-address=:8081
-            {{- if .Values.controllerTuning }}
-            - --max-concurrent-reconciles={{ .Values.controllerTuning.maxConcurrentReconciles | default 10 }}
-            - --kube-api-qps={{ .Values.controllerTuning.kubeApiQPS | default 20 }}
-            - --kube-api-burst={{ .Values.controllerTuning.kubeApiBurst | default 30 }}
+            {{- if .Values.controller.tuning }}
+            - --max-concurrent-reconciles={{ .Values.controller.tuning.maxConcurrentReconciles | default 10 }}
+            - --kube-api-qps={{ .Values.controller.tuning.kubeApiQPS | default 20 }}
+            - --kube-api-burst={{ .Values.controller.tuning.kubeApiBurst | default 30 }}
             {{- end }}
-            {{- if .Values.portAllocator.enabled }}
+            {{- if .Values.controller.features.portAllocator.enabled }}
             - --enable-port-allocator=true
-            - --port-allocate-strategy={{ .Values.portAllocator.strategy | default "random" }}
-            - --start-port={{ .Values.portAllocator.startPort | default 30000 }}
-            - --port-range={{ .Values.portAllocator.portRange | default 5000 }}
+            - --port-allocate-strategy={{ .Values.controller.features.portAllocator.strategy | default "random" }}
+            - --start-port={{ .Values.controller.features.portAllocator.startPort | default 30000 }}
+            - --port-range={{ .Values.controller.features.portAllocator.portRange | default 5000 }}
             {{- end }}
-            - --scheduler-name={{ .Values.schedulerName | default "scheduler-plugins" }}
-            {{- if .Values.pprof.enabled }}
+            - --scheduler-name={{ .Values.controller.features.gangScheduling.schedulerName | default "scheduler-plugins" }}
+            {{- if .Values.controller.pprof.enabled }}
             - --enable-pprof=true
-            - --pprof-bind-address={{ .Values.pprof.bindAddress | default ":6060" }}
+            - --pprof-bind-address={{ .Values.controller.pprof.bindAddress | default ":6060" }}
             {{- end }}
           env:
             - name: POD_NAMESPACE
@@ -56,22 +56,22 @@ spec:
           command:
             - /manager
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.pprof.enabled }}
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          {{- if .Values.controller.pprof.enabled }}
           ports:
             - name: pprof
-              containerPort: {{ .Values.pprof.containerPort | default 6060 }}
+              containerPort: {{ .Values.controller.pprof.containerPort | default 6060 }}
               protocol: TCP
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+      {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.controller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/rbgs/templates/manager/manager.yaml
+++ b/deploy/helm/rbgs/templates/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         control-plane: rbgs-controller
     spec:
-      {{- with .Values.controller.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with .Values.controller.imagePullSecrets | default (.Values.global).imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -28,6 +28,7 @@ spec:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- $pprof := .Values.controller.pprof | default dict }}
           args:
             - --metrics-bind-address=:8443
             - --leader-elect
@@ -37,16 +38,19 @@ spec:
             - --kube-api-qps={{ .Values.controller.tuning.kubeApiQPS | default 20 }}
             - --kube-api-burst={{ .Values.controller.tuning.kubeApiBurst | default 30 }}
             {{- end }}
-            {{- if .Values.controller.features.portAllocator.enabled }}
+            {{- $features := .Values.controller.features | default dict }}
+            {{- $portAllocator := $features.portAllocator | default dict }}
+            {{- if $portAllocator.enabled }}
             - --enable-port-allocator=true
-            - --port-allocate-strategy={{ .Values.controller.features.portAllocator.strategy | default "random" }}
-            - --start-port={{ .Values.controller.features.portAllocator.startPort | default 30000 }}
-            - --port-range={{ .Values.controller.features.portAllocator.portRange | default 5000 }}
+            - --port-allocate-strategy={{ $portAllocator.strategy | default "random" }}
+            - --start-port={{ $portAllocator.startPort | default 30000 }}
+            - --port-range={{ $portAllocator.portRange | default 5000 }}
             {{- end }}
-            - --scheduler-name={{ .Values.controller.features.gangScheduling.schedulerName | default "scheduler-plugins" }}
-            {{- if .Values.controller.pprof.enabled }}
+            {{- $gangScheduling := $features.gangScheduling | default dict }}
+            - --scheduler-name={{ $gangScheduling.schedulerName | default "scheduler-plugins" }}
+            {{- if $pprof.enabled }}
             - --enable-pprof=true
-            - --pprof-bind-address={{ .Values.controller.pprof.bindAddress | default ":6060" }}
+            - --pprof-bind-address={{ $pprof.bindAddress | default ":6060" }}
             {{- end }}
           env:
             - name: POD_NAMESPACE
@@ -58,11 +62,11 @@ spec:
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-          {{- if .Values.controller.pprof.enabled }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy | default "IfNotPresent" }}
+          {{- if $pprof.enabled }}
           ports:
             - name: pprof
-              containerPort: {{ .Values.controller.pprof.containerPort | default 6060 }}
+              containerPort: {{ $pprof.containerPort | default 6060 }}
               protocol: TCP
           {{- end }}
           resources:

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -1,86 +1,85 @@
 # Default values for rbgs-controller.
 
-replicaCount: 2
+global:
+  # imagePullSecrets is shared by the controller Deployment and the crd-upgrade Job.
+  imagePullSecrets: []
 
-image:
-  repository: rolebasedgroup/rbgs-controller
-  pullPolicy: IfNotPresent
-  tag: "v0.8.0-69fe55d"
-
-imagePullSecrets: []
-
-podAnnotations: {}
-
-podSecurityContext: {}
-# fsGroup: 2000
-
-securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
-
-resources:
-  limits:
-    cpu: 1000m
-    memory: 1536Mi
-  requests:
-    cpu: 100m
-    memory: 256Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-# Gang scheduling scheduler name configuration.
-# Supported values: scheduler-plugins, volcano
-# Defaults to scheduler-plugins.
-schedulerName: scheduler-plugins
-
-# Controller runtime tuning parameters.
-controllerTuning:
-  # The number of concurrent reconcile workers per controller.
-  maxConcurrentReconciles: 10
-  # Maximum QPS from the controller to the Kubernetes API server.
-  # Increase for large-scale deployments to avoid client-side throttling.
-  kubeApiQPS: 20
-  # Maximum burst for throttle from the controller to the Kubernetes API server.
-  # Should be set higher than kubeApiQPS.
-  kubeApiBurst: 30
-
-# Pprof profiling server configuration.
-# When enabled, exposes pprof endpoints for performance debugging.
-pprof:
-  enabled: false
-  # The address the pprof endpoint binds to.
-  bindAddress: ":6060"
-  # The container port exposed for pprof (used in pod spec).
-  containerPort: 6060
+controller:
+  replicaCount: 2
+  # imagePullSecrets overrides global.imagePullSecrets for the controller when set.
+  imagePullSecrets: []
+  image:
+    repository: rolebasedgroup/rbgs-controller
+    tag: "v0.8.0-69fe55d"
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1536Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  podAnnotations: {}
+  podSecurityContext: {}
+  # fsGroup: 2000
+  securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # tuning holds controller runtime tuning parameters.
+  tuning:
+    # The number of concurrent reconcile workers per controller.
+    maxConcurrentReconciles: 10
+    # Maximum QPS from the controller to the Kubernetes API server.
+    # Increase for large-scale deployments to avoid client-side throttling.
+    kubeApiQPS: 20
+    # Maximum burst for throttle from the controller to the Kubernetes API server.
+    # Should be set higher than kubeApiQPS.
+    kubeApiBurst: 30
+  # pprof holds the pprof profiling server configuration.
+  # When enabled, exposes pprof endpoints for performance debugging.
+  pprof:
+    enabled: false
+    # The address the pprof endpoint binds to.
+    bindAddress: ":6060"
+    # The container port exposed for pprof (used in pod spec).
+    containerPort: 6060
+  # features holds controller feature flags passed to /manager.
+  features:
+    # gangScheduling configures the gang scheduling scheduler.
+    gangScheduling:
+      # schedulerName selects the gang scheduling scheduler: scheduler-plugins | volcano.
+      schedulerName: scheduler-plugins
+    # portAllocator configures dynamic port allocation to pods.
+    portAllocator:
+      # Whether to enable the port allocator feature.
+      enabled: false
+      # Port allocation strategy. Supported values: random.
+      strategy: random
+      # The starting port number of the allocatable port range.
+      startPort: 30000
+      # The size of the allocatable port range.
+      portRange: 5000
 
 crdUpgrade:
   # Whether to enable CRD Upgrader Job (runs before install/upgrade)
   enabled: true
   # Time-to-live (TTL) for crd-upgrade jobs after completion. Default is 259200 seconds (3 days).
   ttlSecondsAfterFinished: 259200
+  # imagePullSecrets overrides global.imagePullSecrets for the crd-upgrade Job when set.
+  imagePullSecrets: []
   # CRD Upgrader image configuration
-  repository: rolebasedgroup/rbgs-upgrade-crd
-  tag: "v0.8.0-69fe55d"
-  imagePullPolicy: IfNotPresent
+  image:
+    repository: rolebasedgroup/rbgs-upgrade-crd
+    tag: "v0.8.0-69fe55d"
+    pullPolicy: IfNotPresent
   # Tolerations for CRD Upgrader Job pod
   tolerations:
     - operator: Exists
   # Node selector for CRD Upgrader Job pod
   nodeSelector: {}
-
-# Port allocator configuration for dynamic port allocation to pods.
-portAllocator:
-  # Whether to enable the port allocator feature.
-  enabled: false
-  # Port allocation strategy. Supported values: random.
-  strategy: random
-  # The starting port number of the allocatable port range.
-  startPort: 30000
-  # The size of the allocatable port range.
-  portRange: 5000

--- a/doc/dev/how_to_develop.md
+++ b/doc/dev/how_to_develop.md
@@ -288,21 +288,22 @@ make build
 
 #### Deploying with pprof via Helm
 
-Set `pprof.enabled=true` in your Helm values:
+Set `controller.pprof.enabled=true` in your Helm values:
 
 ```shell
 helm upgrade --install rbgs deploy/helm/rbgs \
     --namespace rbgs-system \
-    --set pprof.enabled=true \
-    --set pprof.port=6060
+    --set controller.pprof.enabled=true \
+    --set controller.pprof.containerPort=6060
 ```
 
 Or in `values.yaml`:
 
 ```yaml
-pprof:
-  enabled: true
-  port: 6060
+controller:
+  pprof:
+    enabled: true
+    containerPort: 6060
 ```
 
 #### Collecting Profiles

--- a/doc/dev/how_to_release.md
+++ b/doc/dev/how_to_release.md
@@ -37,11 +37,11 @@
 
 ### 🔄 What It Updates  
 
-| File               | Field Updated       | Example Value        | Source                     |
-|--------------------|---------------------|----------------------|----------------------------|
-| `Chart.yaml`       | `version`          | `0.5.0-alpha.2`      | Branch name (without `v`)  |
-| `Chart.yaml`       | `appVersion`       | `0.5.0-abc123`       | Image tag without `v`      |
-| `values.yaml`      | `image.tag`        | `v0.5.0-abc123`      | Makefile `VERSION` + Git SHA |
+| File               | Field Updated           | Example Value        | Source                     |
+|--------------------|-------------------------|----------------------|----------------------------|
+| `Chart.yaml`       | `version`              | `0.5.0-alpha.2`      | Branch name (without `v`)  |
+| `Chart.yaml`       | `appVersion`           | `0.5.0-abc123`       | Image tag without `v`      |
+| `values.yaml`      | `controller.image.tag` | `v0.5.0-abc123`      | Makefile `VERSION` + Git SHA |
 
 ---
 
@@ -145,7 +145,7 @@ When releasing a new version, use `update-release.sh` script:
 
    This script updates:
    - `deploy/helm/rbgs/Chart.yaml` (version, appVersion)
-   - `deploy/helm/rbgs/values.yaml` (image.tag)
+   - `deploy/helm/rbgs/values.yaml` (controller.image.tag, crdUpgrade.image.tag)
    - `config/manager/kustomization.yaml` (newTag)
    - `deploy/kubectl/manifests.yaml` (regenerated with conversion webhook)
 

--- a/doc/features/gang-scheduling.md
+++ b/doc/features/gang-scheduling.md
@@ -72,7 +72,7 @@ spec:
 
 ## Volcano Gang Scheduling
 
-Volcano is a batch scheduling system with advanced gang scheduling features. To use Volcano, configure the controller with `--scheduler-name=volcano` or set `schedulerName: volcano` in Helm values.
+Volcano is a batch scheduling system with advanced gang scheduling features. To use Volcano, configure the controller with `--scheduler-name=volcano` or set `controller.features.gangScheduling.schedulerName: volcano` in Helm values.
 
 ### Enable via Annotations
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -44,8 +44,8 @@ make helm-deploy
 | Parameter | Description | Default |
 |-----------|-------------|------|
 | `crdUpgrade.enabled` | Enable CRD Upgrader Job | `true` |
-| `crdUpgrade.repository` | CRD Upgrader image repository | `rolebasedgroup/rbgs-upgrade-crd` |
-| `crdUpgrade.tag` | CRD Upgrader image tag | Same as `image.tag` |
+| `crdUpgrade.image.repository` | CRD Upgrader image repository | `rolebasedgroup/rbgs-upgrade-crd` |
+| `crdUpgrade.image.tag` | CRD Upgrader image tag | Same as `controller.image.tag` |
 | `crdUpgrade.ttlSecondsAfterFinished` | Job TTL after completion | `259200` (3 days) |
 | `crdUpgrade.tolerations` | Pod tolerations | `[{operator: Exists}]` |
 | `crdUpgrade.nodeSelector` | Pod node selector | `{}` |

--- a/test/stress/scripts/deploy-controller.sh
+++ b/test/stress/scripts/deploy-controller.sh
@@ -52,17 +52,18 @@ echo "[2/4] Deploying controller via Helm..."
 helm upgrade --install "${RELEASE_NAME}" "${PROJECT_ROOT}/deploy/helm/rbgs" \
     --create-namespace \
     --namespace "${NAMESPACE}" \
-    --set image.tag="${IMAGE_TAG}" \
-    --set replicaCount="${REPLICAS}" \
-    --set resources.limits.cpu="${CONTROLLER_CPU}" \
-    --set resources.limits.memory="${CONTROLLER_MEMORY}" \
-    --set resources.requests.cpu="${CONTROLLER_CPU_REQUEST}" \
-    --set resources.requests.memory="${CONTROLLER_MEMORY_REQUEST}" \
-    --set controllerTuning.maxConcurrentReconciles="${MAX_RECONCILES}" \
-    --set controllerTuning.kubeApiQPS="${KUBE_API_QPS}" \
-    --set controllerTuning.kubeApiBurst="${KUBE_API_BURST}" \
-    --set pprof.enabled="${PPROF_ENABLED}" \
-    --set pprof.port="${PPROF_PORT}" \
+    --set controller.image.tag="${IMAGE_TAG}" \
+    --set controller.replicaCount="${REPLICAS}" \
+    --set controller.resources.limits.cpu="${CONTROLLER_CPU}" \
+    --set controller.resources.limits.memory="${CONTROLLER_MEMORY}" \
+    --set controller.resources.requests.cpu="${CONTROLLER_CPU_REQUEST}" \
+    --set controller.resources.requests.memory="${CONTROLLER_MEMORY_REQUEST}" \
+    --set controller.tuning.maxConcurrentReconciles="${MAX_RECONCILES}" \
+    --set controller.tuning.kubeApiQPS="${KUBE_API_QPS}" \
+    --set controller.tuning.kubeApiBurst="${KUBE_API_BURST}" \
+    --set controller.pprof.enabled="${PPROF_ENABLED}" \
+    --set controller.pprof.bindAddress=":${PPROF_PORT}" \
+    --set controller.pprof.containerPort="${PPROF_PORT}" \
     --wait --timeout=120s
 
 # Wait for rollout

--- a/tools/release/update-release.sh
+++ b/tools/release/update-release.sh
@@ -76,8 +76,9 @@ fi
 
 VALUES_FILE="${CHARTS_DIR}/rbgs/values.yaml"
 if [[ -f "$VALUES_FILE" ]]; then
-    # Update tag field (quoted, to avoid YAML numeric/scientific-notation coercion)
-    sed -i.bak -E "s/^(  tag:[[:space:]]+).*/\1\"$TAG\"/" "$VALUES_FILE"
+    # Update tag fields (controller.image.tag and crdUpgrade.image.tag, both at
+    # 4-space indent). Quoted to avoid YAML numeric/scientific-notation coercion.
+    sed -i.bak -E "s/^(    tag:[[:space:]]+).*/\1\"$TAG\"/" "$VALUES_FILE"
     rm -f "${VALUES_FILE}.bak"
     echo "Updated $VALUES_FILE tag to \"$TAG\""
 else
@@ -110,7 +111,7 @@ echo "Update completed successfully!"
 echo ""
 echo "Summary of changes:"
 echo "  - Helm Chart.yaml: version=$CLEAN_VERSION, appVersion=$APP_VERSION"
-echo "  - Helm values.yaml: image.tag=$TAG"
+echo "  - Helm values.yaml: controller.image.tag=$TAG (and crdUpgrade.image.tag)"
 echo "  - kustomization.yaml: newTag=$TAG"
 echo "  - deploy/kubectl/manifests.yaml: regenerated with conversion webhook"
 echo ""

--- a/tools/release/update-release.sh
+++ b/tools/release/update-release.sh
@@ -76,11 +76,22 @@ fi
 
 VALUES_FILE="${CHARTS_DIR}/rbgs/values.yaml"
 if [[ -f "$VALUES_FILE" ]]; then
-    # Update tag fields (controller.image.tag and crdUpgrade.image.tag, both at
-    # 4-space indent). Quoted to avoid YAML numeric/scientific-notation coercion.
-    sed -i.bak -E "s/^(    tag:[[:space:]]+).*/\1\"$TAG\"/" "$VALUES_FILE"
-    rm -f "${VALUES_FILE}.bak"
-    echo "Updated $VALUES_FILE tag to \"$TAG\""
+    # Update image tags for the controller and crdUpgrade sections only.
+    # We scope the edit by tracking the top-level section and the "image:"
+    # sub-block, so a future unrelated "tag:" at the same indentation level is
+    # never silently overwritten. Quoted to avoid YAML numeric/scientific-notation coercion.
+    awk -v tag="$TAG" '
+        /^[A-Za-z0-9_-]+:/ { section = $1; sub(/:.*/, "", section); subsection = "" }
+        /^  [A-Za-z0-9_-]+:/ { subsection = $1; sub(/:.*/, "", subsection) }
+        {
+            if ((section == "controller" || section == "crdUpgrade") && subsection == "image" && $0 ~ /^    tag:[[:space:]]/) {
+                print "    tag: \"" tag "\""
+                next
+            }
+            print
+        }
+    ' "$VALUES_FILE" > "${VALUES_FILE}.tmp" && mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
+    echo "Updated $VALUES_FILE controller.image.tag and crdUpgrade.image.tag to \"$TAG\""
 else
     echo "Error: $VALUES_FILE not found at ${VALUES_FILE}!"
     exit 1


### PR DESCRIPTION
### Ⅰ. Motivation

The rbgs Helm chart `values.yaml` used a flat structure that mixed controller settings, image config, feature flags, and CRD-upgrade settings at the top level. This made the values hard to read and left no clear place for shared config. This PR reorganizes the values into logical groups and introduces a shared `global` section that individual components can override.

### Ⅱ. Modifications

**Chart values (`deploy/helm/rbgs/values.yaml`)**
- Add top-level `global.imagePullSecrets`, shared by the controller Deployment and the crd-upgrade Job, overridable per component via  `controller.imagePullSecrets` / `crdUpgrade.imagePullSecrets`.
- Nest controller settings under `controller.*`: `replicaCount`, `image`  (with `pullPolicy` moved inside), `resources`, `nodeSelector`, `tolerations`,  `podAnnotations`, `podSecurityContext`, `securityContext`, `tuning`  (renamed from`controllerTuning`), `pprof`, and a new `features` group holding  `gangScheduling.schedulerName` (was top-level `schedulerName`) and  `portAllocator`.
- Nest CRD upgrader image fields under `crdUpgrade.image.*`  (`repository` / `tag` / `pullPolicy`, previously flat  `repository` / `tag` / `imagePullPolicy`).

**Templates**
- Update `templates/manager/manager.yaml` and  `templates/crd-upgrade/crd-upgrade.yaml` to the new value paths.
- `imagePullSecrets` uses component-level value with fallback to  `global.imagePullSecrets`.

**Tooling & docs**
- `Makefile` (`helm-deploy`): `--set image.tag` → `--set controller.image.tag`.
- `tools/release/update-release.sh`: update the `sed` to match the 4-space  indented `tag:` fields (`controller.image.tag` and `crdUpgrade.image.tag`).
- Docs: `doc/install.md`, `doc/dev/how_to_develop.md` (pprof),  `doc/dev/how_to_release.md`, `doc/features/gang-scheduling.md`.

### Ⅲ. Does this pull request fix one issue?

NONE

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new tests. This is a Helm chart value/field reorganization; correctness isverified by rendering the chart (`helm template`).

### Ⅴ. Describe how to verify it

```bash
# Chart renders with defaults
helm template deploy/helm/rbgs

# Per-component override falls back to global correctly
helm template deploy/helm/rbgs \
  --set 'controller.imagePullSecrets[0].name=ctrl-secret' \
  --set 'global.imagePullSecrets[0].name=global-secret' | grep -A1 imagePullSecrets
# controller uses ctrl-secret; crd-upgrade Job falls back to global-secret

# Release script sed still targets both image tags
sed -E 's/^(    tag:[[:space:]]+).*/\1"vTEST"/' deploy/helm/rbgs/values.yaml | grep 'tag:'
```

### VI. Special notes for reviews

This is a **breaking change** for anyone overriding chart values: existing`--set`/custom values files using the old flat keys (e.g. `image.tag`,`schedulerName`, `controllerTuning`, `portAllocator`, `crdUpgrade.tag`) must be migrated to the new nested paths.

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [x] Update the documentation related to the change.