### PR TITLE
test(e2e): stabilize flaky v1alpha2 specs on slow CI clusters

### DIFF
--- a/test/e2e/testcase/v1alpha2/coordinated_policy.go
+++ b/test/e2e/testcase/v1alpha2/coordinated_policy.go
@@ -291,7 +291,11 @@ func RunCoordinatedPolicyTestCases(f *framework.Framework) {
 							Roles: []string{"role-a", "role-b"},
 							Strategy: workloadsv1alpha2.CoordinatedPolicyStrategy{
 								Scaling: &workloadsv1alpha2.ScalingCoordinationStrategy{
-									MaxSkew:     ptr.To(intstr.FromString("50%")),
+									// With desiredReplicas=3, maxSkew=33% makes the scaler advance one
+									// replica per batch (1->2->3) instead of jumping 1->3 in a single
+									// batch (which 50% would allow). Combined with OrderReady gating,
+									// this bounds the ready-replicas skew to 1 by design.
+									MaxSkew:     ptr.To(intstr.FromString("33%")),
 									Progression: workloadsv1alpha2.OrderReadyProgression,
 								},
 							},
@@ -312,8 +316,12 @@ func RunCoordinatedPolicyTestCases(f *framework.Framework) {
 				rbg.Spec.Roles[1].Replicas = ptr.To(int32(3))
 			})
 
-			// During scaling, verify skew constraint is respected
-			// Use RoleInstanceSet.Status.ReadyReplicas (the signal the controller uses)
+			// During scaling, verify the coordination constrains the ready-replicas skew.
+			// The scaler bounds currentReplicas progress by maxSkew and OrderReady gates each
+			// batch until every role's current replicas are ready; with maxSkew=33% and
+			// desiredReplicas=3 it advances 1->2->3, so the ready-replicas skew stays <=1 by
+			// design rather than by timing luck.
+			// Read RoleInstanceSet.Status.ReadyReplicas (the signal the controller uses)
 			// instead of counting RoleInstance conditions to avoid reconcile latency flakiness.
 			gomega.Consistently(func() bool {
 				roleAReady := getRoleInstanceSetReadyReplicas(f, rbg, "role-a")

--- a/test/e2e/testcase/v1alpha2/ris.go
+++ b/test/e2e/testcase/v1alpha2/ris.go
@@ -86,7 +86,9 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 
 		// Wait for all initial pods to become Ready
 		f.ExpectRbgV2Equal(rbg)
-		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(4))
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(4))
 
 		time.Sleep(2 * time.Second)
 
@@ -144,7 +146,9 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 
 		// Wait for all initial pods to become Ready
 		f.ExpectRbgV2Equal(rbg)
-		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(4))
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(4))
 
 		time.Sleep(2 * time.Second)
 
@@ -229,7 +233,9 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 			return countRoleInstances(f, rbg, "role-1")
 		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2),
 			"surge instances should be cleaned up after rolling update completes")
-		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2))
 	})
 
 	// Test 4: Decreasing partition step-by-step must continue to roll the
@@ -259,7 +265,9 @@ func RunRoleInstanceSetWorkloadTestCases(f *framework.Framework) {
 
 		// Wait for both initial pods to become Ready.
 		f.ExpectRbgV2Equal(rbg)
-		gomega.Expect(countReadyRoleInstances(f, rbg, "role-1")).Should(gomega.Equal(2))
+		gomega.Eventually(func() int {
+			return countReadyRoleInstances(f, rbg, "role-1")
+		}, utils.Timeout, utils.Interval).Should(gomega.Equal(2))
 
 		time.Sleep(2 * time.Second)
 

--- a/test/e2e/testcase/v1alpha2/scaling_adapter.go
+++ b/test/e2e/testcase/v1alpha2/scaling_adapter.go
@@ -24,6 +24,7 @@ import (
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/scale"
 	"sigs.k8s.io/rbgs/test/e2e/framework"
+	"sigs.k8s.io/rbgs/test/utils"
 	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
 )
 
@@ -76,18 +77,9 @@ func RunRbgScalingAdapterControllerTestCases(f *framework.Framework) {
 					f.ExpectRbgV2Equal(rbg)
 					f.ExpectRbgV2ScalingAdapterEqual(rbg)
 
-					newRbg := &workloadsv1alpha2.RoleBasedGroup{}
-					gomega.Expect(
-						f.Client.Get(
-							f.Ctx, client.ObjectKey{
-								Name:      rbg.Name,
-								Namespace: rbg.Namespace,
-							}, newRbg,
-						),
-					).Should(gomega.Succeed())
-
-					newRbg.Spec.Roles = rbg.Spec.Roles[1:]
-					gomega.Expect(f.Client.Update(f.Ctx, newRbg)).Should(gomega.Succeed())
+					updateRbgSpecV2Retry(f, rbg, func(newRbg *workloadsv1alpha2.RoleBasedGroup) {
+						newRbg.Spec.Roles = rbg.Spec.Roles[1:]
+					})
 					f.ExpectScalingAdapterV2NotExist(rbg, rbg.Spec.Roles[0])
 					f.ExpectRoleScalingAdapterV2Equal(rbg, rbg.Spec.Roles[1], nil)
 
@@ -113,21 +105,12 @@ func RunRbgScalingAdapterControllerTestCases(f *framework.Framework) {
 					f.ExpectRbgV2Equal(rbg)
 					f.ExpectRbgV2ScalingAdapterEqual(rbg)
 
-					newRbg := &workloadsv1alpha2.RoleBasedGroup{}
-					gomega.Expect(
-						f.Client.Get(
-							f.Ctx, client.ObjectKey{
-								Name:      rbg.Name,
-								Namespace: rbg.Namespace,
-							}, newRbg,
-						),
-					).Should(gomega.Succeed())
-
-					newRbg.Spec.Roles = append(
-						newRbg.Spec.Roles, wrappersv2.BuildStandaloneRole("role-2").
-							WithScalingAdapter(true).Obj(),
-					)
-					gomega.Expect(f.Client.Update(f.Ctx, newRbg)).Should(gomega.Succeed())
+					newRbg := updateRbgSpecV2Retry(f, rbg, func(newRbg *workloadsv1alpha2.RoleBasedGroup) {
+						newRbg.Spec.Roles = append(
+							newRbg.Spec.Roles, wrappersv2.BuildStandaloneRole("role-2").
+								WithScalingAdapter(true).Obj(),
+						)
+					})
 					f.ExpectScalingAdapterV2NotExist(rbg, newRbg.Spec.Roles[0])
 					f.ExpectRoleScalingAdapterV2Equal(rbg, newRbg.Spec.Roles[1], nil)
 
@@ -157,19 +140,10 @@ func RunRbgScalingAdapterControllerTestCases(f *framework.Framework) {
 					f.ExpectRbgV2Equal(rbg)
 					f.ExpectRbgV2ScalingAdapterEqual(rbg)
 
-					newRbg := &workloadsv1alpha2.RoleBasedGroup{}
-					gomega.Expect(
-						f.Client.Get(
-							f.Ctx, client.ObjectKey{
-								Name:      rbg.Name,
-								Namespace: rbg.Namespace,
-							}, newRbg,
-						),
-					).Should(gomega.Succeed())
-
-					newRbg.Spec.Roles[0].ScalingAdapter.Enable = false
-					newRbg.Spec.Roles[1].ScalingAdapter = nil
-					gomega.Expect(f.Client.Update(f.Ctx, newRbg)).Should(gomega.Succeed())
+					updateRbgSpecV2Retry(f, rbg, func(newRbg *workloadsv1alpha2.RoleBasedGroup) {
+						newRbg.Spec.Roles[0].ScalingAdapter.Enable = false
+						newRbg.Spec.Roles[1].ScalingAdapter = nil
+					})
 					f.ExpectScalingAdapterV2NotExist(rbg, rbg.Spec.Roles[0])
 					f.ExpectScalingAdapterV2NotExist(rbg, rbg.Spec.Roles[1])
 
@@ -237,4 +211,26 @@ func RunRbgScalingAdapterControllerTestCases(f *framework.Framework) {
 			)
 		},
 	)
+}
+
+// updateRbgSpecV2Retry re-fetches the RBG and applies mutate before Update,
+// retrying on a 409 Conflict which can happen when the controller writes to the
+// RBG between our Get and Update (more likely on slower clusters). The caller's
+// original rbg is left untouched so post-update assertions can still reference it.
+func updateRbgSpecV2Retry(
+	f *framework.Framework,
+	rbg *workloadsv1alpha2.RoleBasedGroup,
+	mutate func(newRbg *workloadsv1alpha2.RoleBasedGroup),
+) *workloadsv1alpha2.RoleBasedGroup {
+	newRbg := &workloadsv1alpha2.RoleBasedGroup{}
+	gomega.Eventually(func() error {
+		if err := f.Client.Get(
+			f.Ctx, client.ObjectKey{Name: rbg.Name, Namespace: rbg.Namespace}, newRbg,
+		); err != nil {
+			return err
+		}
+		mutate(newRbg)
+		return f.Client.Update(f.Ctx, newRbg)
+	}, utils.Timeout, utils.Interval).Should(gomega.Succeed())
+	return newRbg
 }


### PR DESCRIPTION
### Ⅰ. Motivation

The v1alpha2 e2e test cases contained several sources of flakiness that could cause spurious failures, especially on slower clusters:

1. **Race on RBG updates** — Several scaling-adapter tests did a `Get` immediately followed by an `Update`. When the controller wrote to the RBG in between, the `Update` failed with a `409 Conflict`, causing the test to fail non-deterministically.
2. **Reliance on reconcile timing** — The coordinated-policy scaling test used `MaxSkew=50%`, which allows the scaler to jump `1->3` in a single batch.
3. **Immediate readiness assertions** — `RoleInstanceSet` tests asserted ready-replica counts with a single synchronous `Expect`, which does not tolerate reconcile latency.

### Ⅱ. Modifications

- **`scaling_adapter.go`**: Introduced a `updateRbgSpecV2Retry` helper that re-fetches the RBG and re-applies the mutation inside a `gomega.Eventually`, retrying on `409 Conflict`. Refactored the three role-mutation test steps (delete role, add role, toggle scaling adapter) to use it. The caller's original `rbg` is left untouched so subsequent assertions still reference it.
- **`coordinated_policy.go`**: Changed `MaxSkew` from `50%` to `33%` so that, with `desiredReplicas=3`, the scaler advances one replica per batch (`1->2->3`). Combined with `OrderReady` gating, this bounds the ready-replicas skew to `1` by design rather than by timing. Updated the comments to explain the reasoning.
- **`ris.go`**: Replaced synchronous `gomega.Expect(countReadyRoleInstances(...))` readiness checks with `gomega.Eventually(...)` polling (using `utils.Timeout`/`utils.Interval`) to tolerate reconcile latency.
