### PR TITLE
feat: add exponential backoff for restart policy with API and docs improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,26 @@ build: ## Build manager binary.
 	GOPROXY=${GOPROXY} \
 	go build -v -o bin/manager -ldflags $(ldflags) cmd/rbgs/main.go
 
+.PHONY: build-cli
+build-cli:  ## Build cli binary.
+	GOARCH=${TARGETARCH} \
+	GOOS=${TARGETOS} \
+	CGO_ENABLED=0 \
+	GO111MODULE=on \
+	GOPROXY=${GOPROXY} \
+	go build -mod vendor -v -o bin/kubectl-rbg -ldflags $(ldflags) cmd/cli/main.go
+
+CLI_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+
+.PHONY: build-cli-all
+build-cli-all: ## Build cli binaries for all platforms.
+	@for platform in $(CLI_PLATFORMS); do \
+		GOOS=$${platform%%/*} GOARCH=$${platform##*/} \
+		CGO_ENABLED=0 GO111MODULE=on GOPROXY=${GOPROXY} \
+		go build -mod vendor -v -o bin/kubectl-rbg-$${platform%%/*}-$${platform##*/} -ldflags $(ldflags) cmd/cli/main.go; \
+		echo "Built bin/kubectl-rbg-$${platform%%/*}-$${platform##*/}"; \
+	done
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/rbgs/main.go

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -160,6 +160,7 @@ const (
 )
 
 // RestartPolicyConfig groups restart policy type and backoff configuration.
+// +kubebuilder:validation:XValidation:rule="!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds) || self.maxDelaySeconds >= self.baseDelaySeconds",message="maxDelaySeconds must be greater than or equal to baseDelaySeconds"
 type RestartPolicyConfig struct {
 	// Type defines the restart policy when pod failures happen.
 	// Default is RecreateRoleInstanceOnPodRestart.
@@ -174,12 +175,14 @@ type RestartPolicyConfig struct {
 	// Default is 30.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=30
 	BaseDelaySeconds *int32 `json:"baseDelaySeconds,omitempty"`
 
 	// MaxDelaySeconds caps the exponential backoff delay (seconds).
 	// Default is 600.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=600
 	MaxDelaySeconds *int32 `json:"maxDelaySeconds,omitempty"`
 }
 

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -23956,6 +23956,7 @@ spec:
                             backoff configuration.
                           properties:
                             baseDelaySeconds:
+                              default: 30
                               description: |-
                                 BaseDelaySeconds is the base delay between restart attempts (seconds).
                                 Subsequent attempts use exponential backoff: delay = min(base * 2^(restartCount-1), maxDelaySeconds).
@@ -23963,6 +23964,7 @@ spec:
                               minimum: 0
                               type: integer
                             maxDelaySeconds:
+                              default: 600
                               description: |-
                                 MaxDelaySeconds caps the exponential backoff delay (seconds).
                                 Default is 600.
@@ -23978,6 +23980,11 @@ spec:
                               - RecreateRoleInstanceOnPodRestart
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: maxDelaySeconds must be greater than or equal
+                              to baseDelaySeconds
+                            rule: '!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds)
+                              || self.maxDelaySeconds >= self.baseDelaySeconds'
                       type: object
                     dependencies:
                       description: Dependencies of the role
@@ -25385,6 +25392,7 @@ spec:
                             backoff configuration.
                           properties:
                             baseDelaySeconds:
+                              default: 30
                               description: |-
                                 BaseDelaySeconds is the base delay between restart attempts (seconds).
                                 Subsequent attempts use exponential backoff: delay = min(base * 2^(restartCount-1), maxDelaySeconds).
@@ -25392,6 +25400,7 @@ spec:
                               minimum: 0
                               type: integer
                             maxDelaySeconds:
+                              default: 600
                               description: |-
                                 MaxDelaySeconds caps the exponential backoff delay (seconds).
                                 Default is 600.
@@ -25407,6 +25416,11 @@ spec:
                               - RecreateRoleInstanceOnPodRestart
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: maxDelaySeconds must be greater than or equal
+                              to baseDelaySeconds
+                            rule: '!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds)
+                              || self.maxDelaySeconds >= self.baseDelaySeconds'
                         sharedServiceSelection:
                           description: SharedServiceSelection indicates the service
                             policy of the role

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -24450,6 +24450,7 @@ spec:
                                     and backoff configuration.
                                   properties:
                                     baseDelaySeconds:
+                                      default: 30
                                       description: |-
                                         BaseDelaySeconds is the base delay between restart attempts (seconds).
                                         Subsequent attempts use exponential backoff: delay = min(base * 2^(restartCount-1), maxDelaySeconds).
@@ -24457,6 +24458,7 @@ spec:
                                       minimum: 0
                                       type: integer
                                     maxDelaySeconds:
+                                      default: 600
                                       description: |-
                                         MaxDelaySeconds caps the exponential backoff delay (seconds).
                                         Default is 600.
@@ -24472,6 +24474,11 @@ spec:
                                       - RecreateRoleInstanceOnPodRestart
                                       type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: maxDelaySeconds must be greater than
+                                      or equal to baseDelaySeconds
+                                    rule: '!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds)
+                                      || self.maxDelaySeconds >= self.baseDelaySeconds'
                               type: object
                             dependencies:
                               description: Dependencies of the role
@@ -25914,6 +25921,7 @@ spec:
                                     and backoff configuration.
                                   properties:
                                     baseDelaySeconds:
+                                      default: 30
                                       description: |-
                                         BaseDelaySeconds is the base delay between restart attempts (seconds).
                                         Subsequent attempts use exponential backoff: delay = min(base * 2^(restartCount-1), maxDelaySeconds).
@@ -25921,6 +25929,7 @@ spec:
                                       minimum: 0
                                       type: integer
                                     maxDelaySeconds:
+                                      default: 600
                                       description: |-
                                         MaxDelaySeconds caps the exponential backoff delay (seconds).
                                         Default is 600.
@@ -25936,6 +25945,11 @@ spec:
                                       - RecreateRoleInstanceOnPodRestart
                                       type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: maxDelaySeconds must be greater than
+                                      or equal to baseDelaySeconds
+                                    rule: '!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds)
+                                      || self.maxDelaySeconds >= self.baseDelaySeconds'
                                 sharedServiceSelection:
                                   description: SharedServiceSelection indicates the
                                     service policy of the role

--- a/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
@@ -119,6 +119,7 @@ spec:
                   configuration for all pods within the RoleInstance.
                 properties:
                   baseDelaySeconds:
+                    default: 30
                     description: |-
                       BaseDelaySeconds is the base delay between restart attempts (seconds).
                       Subsequent attempts use exponential backoff: delay = min(base * 2^(restartCount-1), maxDelaySeconds).
@@ -126,6 +127,7 @@ spec:
                     minimum: 0
                     type: integer
                   maxDelaySeconds:
+                    default: 600
                     description: |-
                       MaxDelaySeconds caps the exponential backoff delay (seconds).
                       Default is 600.
@@ -141,6 +143,10 @@ spec:
                     - RecreateRoleInstanceOnPodRestart
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: maxDelaySeconds must be greater than or equal to baseDelaySeconds
+                  rule: '!has(self.baseDelaySeconds) || !has(self.maxDelaySeconds)
+                    || self.maxDelaySeconds >= self.baseDelaySeconds'
             required:
             - components
             type: object

--- a/doc/best-practice/en/01-deploy-inference-service.md
+++ b/doc/best-practice/en/01-deploy-inference-service.md
@@ -399,7 +399,7 @@ spec:
 | `leaderWorkerPattern.template` | object | Yes | - | Base Pod template shared by all Pods (Leader and Workers) |
 | `leaderWorkerPattern.leaderTemplatePatch` | object | No | - | Strategic Merge Patch applied only to Leader Pod |
 | `leaderWorkerPattern.workerTemplatePatch` | object | No | - | Strategic Merge Patch applied only to Worker Pod |
-| `leaderWorkerPattern.restartPolicy` | string | No | `RecreateRoleInstanceOnPodRestart` | Policy on Pod failure: `None` or `RecreateRoleInstanceOnPodRestart` (recreate entire instance) |
+| `leaderWorkerPattern.restartPolicy` | object | No | `type: RecreateRoleInstanceOnPodRestart` | Restart policy config: `type` (`None` or `RecreateRoleInstanceOnPodRestart`), `baseDelaySeconds` (default: 30), `maxDelaySeconds` (default: 600) |
 
 #### RBG Auto-Injected Environment Variables
 

--- a/doc/best-practice/zh/01-deploy-inference-service.md
+++ b/doc/best-practice/zh/01-deploy-inference-service.md
@@ -399,7 +399,7 @@ spec:
 | `leaderWorkerPattern.template` | object | 是 | - | 所有 Pod（Leader 和 Worker）共享的基础 Pod 模板 |
 | `leaderWorkerPattern.leaderTemplatePatch` | object | 否 | - | 仅应用到 Leader Pod 的 Strategic Merge Patch |
 | `leaderWorkerPattern.workerTemplatePatch` | object | 否 | - | 仅应用到 Worker Pod 的 Strategic Merge Patch |
-| `leaderWorkerPattern.restartPolicy` | string | 否 | `RecreateRoleInstanceOnPodRestart` | Pod 故障时的策略：`None` 或 `RecreateRoleInstanceOnPodRestart`（重建整个实例） |
+| `leaderWorkerPattern.restartPolicy` | object | 否 | `type: RecreateRoleInstanceOnPodRestart` | 重启策略配置：`type`（`None` 或 `RecreateRoleInstanceOnPodRestart`）、`baseDelaySeconds`（默认: 30）、`maxDelaySeconds`（默认: 600） |
 
 #### RBG 自动注入的环境变量
 

--- a/doc/features/failure-handling.md
+++ b/doc/features/failure-handling.md
@@ -107,6 +107,8 @@ restartPolicy:
 
 With the above configuration: first crash is immediate, second crash delayed 10s, third 20s, fourth 40s, fifth 80s, sixth and beyond capped at 120s.
 
+> **Note**: `maxDelaySeconds` must be greater than or equal to `baseDelaySeconds` (enforced by CEL validation at admission). Because `maxDelaySeconds` defaults to 600, setting `baseDelaySeconds` above 600 without explicitly setting `maxDelaySeconds` will be rejected. If you need a base delay above 600s, set `maxDelaySeconds` to the same or higher value.
+
 ## Excluding Components from Restart Policy Trigger
 
 You can prevent specific pods from triggering the role's restart policy by setting an annotation on the pod template. This is useful for auxiliary components (e.g., monitoring, logging sidecars) whose failures should not affect the main workload. The annotation works with any deployment pattern (standalonePattern, leaderWorkerPattern, or customComponentsPattern).

--- a/doc/features/failure-handling.md
+++ b/doc/features/failure-handling.md
@@ -16,6 +16,14 @@ RBG supports multiple failure handling policies: `None` and `RecreateRoleInstanc
 Set the `restartPolicy` field on the pattern (`leaderWorkerPattern` or `customComponentsPattern`).
 `standalonePattern` has no `restartPolicy` field — it is always `None` (single pod, recreating the instance is equivalent to normal pod replacement).
 
+`restartPolicy` is an object with the following fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `RecreateRoleInstanceOnPodRestart` | Restart policy type: `None` or `RecreateRoleInstanceOnPodRestart`. |
+| `baseDelaySeconds` | int | `30` | Base delay (seconds) for exponential backoff between restart attempts. Set to `0` with `maxDelaySeconds: 0` to disable backoff entirely. |
+| `maxDelaySeconds` | int | `600` | Cap (seconds) for the exponential backoff delay. |
+
 ```yaml
 apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
@@ -28,7 +36,8 @@ spec:
       replicas: 3
       leaderWorkerPattern:
         size: 2
-        restartPolicy: RecreateRoleInstanceOnPodRestart
+        restartPolicy:
+          type: RecreateRoleInstanceOnPodRestart
         template:
           spec:
             containers:
@@ -40,7 +49,8 @@ spec:
       replicas: 1
       leaderWorkerPattern:
         size: 2
-        restartPolicy: None
+        restartPolicy:
+          type: None
         template:
           spec:
             containers:
@@ -58,6 +68,45 @@ spec:
                 image: nginx:latest
 ```
 
+## Exponential Backoff
+
+When `restartPolicy.type` is `RecreateRoleInstanceOnPodRestart`, subsequent crash-triggered recreations within a stability window are delayed by exponential backoff:
+
+- **First crash**: immediate recreation (no delay).
+- **Second crash** (within the stability window): delayed by `baseDelaySeconds`.
+- **Each subsequent crash**: delay doubles, capped at `maxDelaySeconds`.
+- Formula: `delay = min(baseDelaySeconds * 2^(restartCount-1), maxDelaySeconds)`.
+
+The stability window is `max(maxDelaySeconds * 2, 10 minutes)`. If the instance remains stable (no crashes) for longer than this window, `restartCount` resets to 0 and the next crash starts with immediate recreation again.
+
+### Default Behavior Change
+
+> **Note**: Before the backoff feature, pod crashes always triggered immediate recreation. With default settings (`baseDelaySeconds: 30`, `maxDelaySeconds: 600`), the second and
+> subsequent crashes within the stability window now receive 30s→600s exponential delays. All existing workloads using the default `RecreateRoleInstanceOnPodRestart` policy
+> automatically inherit this behavior.
+
+### Disabling Backoff
+
+To disable backoff entirely and restore the pre-backoff behavior (immediate recreation on every crash), set both `baseDelaySeconds` and `maxDelaySeconds` to `0`:
+
+```yaml
+restartPolicy:
+  type: RecreateRoleInstanceOnPodRestart
+  baseDelaySeconds: 0
+  maxDelaySeconds: 0
+```
+
+### Custom Backoff Configuration
+
+```yaml
+restartPolicy:
+  type: RecreateRoleInstanceOnPodRestart
+  baseDelaySeconds: 10
+  maxDelaySeconds: 120
+```
+
+With the above configuration: first crash is immediate, second crash delayed 10s, third 20s, fourth 40s, fifth 80s, sixth and beyond capped at 120s.
+
 ## Excluding Components from Restart Policy Trigger
 
 You can prevent specific pods from triggering the role's restart policy by setting an annotation on the pod template. This is useful for auxiliary components (e.g., monitoring, logging sidecars) whose failures should not affect the main workload. The annotation works with any deployment pattern (standalonePattern, leaderWorkerPattern, or customComponentsPattern).
@@ -74,7 +123,8 @@ spec:
     - name: engine
       replicas: 2
       customComponentsPattern:
-        restartPolicy: RecreateRoleInstanceOnPodRestart
+        restartPolicy:
+          type: RecreateRoleInstanceOnPodRestart
         components:
           # Main inference component - will trigger restart policy on pod failure
           - name: inference

--- a/doc/reference/api.md
+++ b/doc/reference/api.md
@@ -52,7 +52,7 @@ Leader + workers per instance (for tensor parallelism):
 | Field | Description |
 |-------|-------------|
 | `size` | *int32 — total pods per instance (1 leader + size-1 workers) |
-| `restartPolicy` | RestartPolicyType — restart behavior (default: `RecreateRoleInstanceOnPodRestart`) |
+| `restartPolicy` | RestartPolicyConfig — restart behavior config: `type` (default: `RecreateRoleInstanceOnPodRestart`), `baseDelaySeconds` (default: 30), `maxDelaySeconds` (default: 600) |
 | `template` | PodTemplateSpec — base pod template |
 | `templateRef` | *TemplateRef — reference to roleTemplate |
 | `leaderTemplatePatch` | runtime.RawExtension — patch for leader pod |
@@ -65,7 +65,7 @@ Heterogeneous pod groups per instance:
 | Field | Description |
 |-------|-------------|
 | `components` | []ComponentSpec — list of component definitions |
-| `restartPolicy` | RestartPolicyType — restart behavior (default: `RecreateRoleInstanceOnPodRestart`) |
+| `restartPolicy` | RestartPolicyConfig — restart behavior config: `type` (default: `RecreateRoleInstanceOnPodRestart`), `baseDelaySeconds` (default: 30), `maxDelaySeconds` (default: 600) |
 
 ### ComponentSpec
 

--- a/examples/basic/rbg/patterns/custom-components-pattern.yaml
+++ b/examples/basic/rbg/patterns/custom-components-pattern.yaml
@@ -25,7 +25,8 @@ spec:
           type: InPlaceIfPossible
       # customComponentsPattern: define heterogeneous components per instance
       customComponentsPattern:
-        restartPolicy: RecreateRoleInstanceOnPodRestart
+        restartPolicy:
+          type: RecreateRoleInstanceOnPodRestart
         components:
           - name: custom-component-1
             size: 1

--- a/examples/basic/rbg/patterns/leader-worker-pattern.yaml
+++ b/examples/basic/rbg/patterns/leader-worker-pattern.yaml
@@ -14,7 +14,8 @@ spec:
       # leaderWorkerPattern: each replica creates 1 leader + (size-1) workers
       leaderWorkerPattern:
         # restartPolicy defaults to RecreateRoleInstanceOnPodRestart
-        restartPolicy: RecreateRoleInstanceOnPodRestart
+        restartPolicy:
+          type: RecreateRoleInstanceOnPodRestart
         size: 4    # total pods per instance: 1 leader + 3 workers
         template:
           metadata:

--- a/examples/basic/rbg/restart-policy/restart-policy.yaml
+++ b/examples/basic/rbg/restart-policy/restart-policy.yaml
@@ -16,7 +16,8 @@ spec:
       replicas: 3
       leaderWorkerPattern:
         size: 2
-        restartPolicy: RecreateRoleInstanceOnPodRestart
+        restartPolicy:
+          type: RecreateRoleInstanceOnPodRestart
         template:
           metadata:
             labels:
@@ -33,7 +34,8 @@ spec:
       replicas: 1
       leaderWorkerPattern:
         size: 2
-        restartPolicy: None
+        restartPolicy:
+          type: None
         template:
           metadata:
             labels:

--- a/examples/inference/agg-leader-worker.yaml
+++ b/examples/inference/agg-leader-worker.yaml
@@ -43,7 +43,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 2   # 1 leader + 1 workers per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         template:
           metadata:
             labels:

--- a/examples/inference/ecosystem/dynamo/agg-multi-nodes.yaml
+++ b/examples/inference/ecosystem/dynamo/agg-multi-nodes.yaml
@@ -125,7 +125,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 2   # 1 leader + 1 worker per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         templateRef:
           name: dynamo-base
           patch:

--- a/examples/inference/ecosystem/dynamo/pd-disagg-multi-nodes.yaml
+++ b/examples/inference/ecosystem/dynamo/pd-disagg-multi-nodes.yaml
@@ -123,7 +123,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 2   # 1 leader + 1 worker per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         templateRef:
           name: dynamo-base
           patch:
@@ -188,7 +189,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 2   # 1 leader + 1 worker per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         templateRef:
           name: dynamo-base
           patch:

--- a/examples/inference/pd-disagg-leader-worker.yaml
+++ b/examples/inference/pd-disagg-leader-worker.yaml
@@ -76,7 +76,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 4   # 1 leader + 3 workers per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         template:
           metadata:
             labels:
@@ -140,7 +141,8 @@ spec:
           maxUnavailable: 1
       leaderWorkerPattern:
         size: 2   # 1 leader + 1 worker per instance
-        restartPolicy: None
+        restartPolicy:
+          type: None
         template:
           metadata:
             labels:

--- a/pkg/reconciler/roleinstance/instance_reconciler.go
+++ b/pkg/reconciler/roleinstance/instance_reconciler.go
@@ -82,6 +82,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	instance := new(workloadsv1alpha2.RoleInstance)
 	if err := r.Get(ctx, request.NamespacedName, instance); err != nil {
 		if apierrors.IsNotFound(err) {
+			r.syncControl.ClearRestarting(&workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: request.Namespace, Name: request.Name},
+			})
 			logger.Info("Instance has been deleted")
 			return reconcile.Result{}, nil
 		}
@@ -91,6 +94,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Skip reconcile if the instance is being deleted to avoid StorageError
 	// caused by precondition failures when the object's UID becomes empty during foreground deletion.
 	if instance.DeletionTimestamp != nil {
+		r.syncControl.ClearRestarting(instance)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/reconciler/roleinstance/instance_status.go
+++ b/pkg/reconciler/roleinstance/instance_status.go
@@ -371,6 +371,18 @@ func inconsistentRestartTime(old, new *metav1.Time) bool {
 	return !old.Equal(new)
 }
 
+// restartTrackingChanged detects whether updateRestartTracking ran this reconcile.
+// It returns true when newLastRestartTime differs from BOTH the informer-cached
+// value and the live API value, indicating an intentional write by updateRestartTracking
+// (which sets metav1.Now(), producing a timestamp that differs from both stale sources).
+func restartTrackingChanged(newLastRestartTime, instanceLastRestartTime, liveLastRestartTime *metav1.Time) bool {
+	return newLastRestartTime != nil &&
+		(instanceLastRestartTime == nil ||
+			!newLastRestartTime.Equal(instanceLastRestartTime)) &&
+		(liveLastRestartTime == nil ||
+			!newLastRestartTime.Equal(liveLastRestartTime))
+}
+
 func inconsistentComponentStatus(oldRoleStatus, newRoleStatus workloadsv1alpha2.RoleInstanceComponentStatus) bool {
 	return oldRoleStatus.Size != newRoleStatus.Size ||
 		oldRoleStatus.Name != newRoleStatus.Name ||
@@ -438,11 +450,7 @@ func (r *realStatusUpdater) updateStatus(ctx context.Context, instance *workload
 		// syncRestartTrackingFromAPI copies the API's timestamp, which equals the
 		// live value — so the double-check below correctly identifies that case as
 		// "not changed" and preserves the live (potentially reset) count.
-		restartTrackingChanged := newStatus.LastRestartTime != nil &&
-			(instance.Status.LastRestartTime == nil ||
-				!newStatus.LastRestartTime.Equal(instance.Status.LastRestartTime)) &&
-			(liveLastRestartTime == nil ||
-				!newStatus.LastRestartTime.Equal(liveLastRestartTime))
+		restartTrackingChanged := restartTrackingChanged(newStatus.LastRestartTime, instance.Status.LastRestartTime, liveLastRestartTime)
 		clone.Status = *newStatus
 		clone.Status.Conditions = append(clone.Status.Conditions, liveCustomConditions...)
 		if restartTrackingChanged {

--- a/pkg/reconciler/roleinstance/instance_status.go
+++ b/pkg/reconciler/roleinstance/instance_status.go
@@ -450,10 +450,10 @@ func (r *realStatusUpdater) updateStatus(ctx context.Context, instance *workload
 		// syncRestartTrackingFromAPI copies the API's timestamp, which equals the
 		// live value — so the double-check below correctly identifies that case as
 		// "not changed" and preserves the live (potentially reset) count.
-		restartTrackingChanged := restartTrackingChanged(newStatus.LastRestartTime, instance.Status.LastRestartTime, liveLastRestartTime)
+		restartTrackingModified := restartTrackingChanged(newStatus.LastRestartTime, instance.Status.LastRestartTime, liveLastRestartTime)
 		clone.Status = *newStatus
 		clone.Status.Conditions = append(clone.Status.Conditions, liveCustomConditions...)
-		if restartTrackingChanged {
+		if restartTrackingModified {
 			// updateRestartTracking ran this reconcile — trust newStatus values.
 			// This covers both increments (count goes up) and resets (count goes
 			// down after a stable period). The timestamp is always brand-new.

--- a/pkg/reconciler/roleinstance/instance_status_test.go
+++ b/pkg/reconciler/roleinstance/instance_status_test.go
@@ -18,8 +18,10 @@ package roleinstance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 )
@@ -126,6 +128,105 @@ func TestInconsistentBaselines(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := inconsistentBaselines(tt.old, tt.new)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRestartTrackingChanged(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	earlier := metav1.NewTime(now.Add(-1 * time.Minute))
+	later := metav1.NewTime(now.Add(1 * time.Minute))
+
+	tests := []struct {
+		name                  string
+		newLastRestartTime    *metav1.Time
+		instanceLastRestart   *metav1.Time
+		liveLastRestart       *metav1.Time
+		expectedChanged       bool
+	}{
+		{
+			name:                "new is nil: not changed",
+			newLastRestartTime:  nil,
+			instanceLastRestart: &now,
+			liveLastRestart:     &now,
+			expectedChanged:     false,
+		},
+		{
+			name:                "new differs from both informer and live: changed (updateRestartTracking ran)",
+			newLastRestartTime:  &later,
+			instanceLastRestart: &now,
+			liveLastRestart:     &now,
+			expectedChanged:     true,
+		},
+		{
+			name:                "new equals informer but differs from live: not changed (syncRestartTrackingFromAPI pass-through)",
+			newLastRestartTime:  &now,
+			instanceLastRestart: &now,
+			liveLastRestart:     &earlier,
+			expectedChanged:     false,
+		},
+		{
+			name:                "new equals live but differs from informer: not changed (informer stale, live matches)",
+			newLastRestartTime:  &now,
+			instanceLastRestart: &earlier,
+			liveLastRestart:     &now,
+			expectedChanged:     false,
+		},
+		{
+			name:                "new equals both: not changed",
+			newLastRestartTime:  &now,
+			instanceLastRestart: &now,
+			liveLastRestart:     &now,
+			expectedChanged:     false,
+		},
+		{
+			name:                "informer nil, live nil, new set: changed (first restart)",
+			newLastRestartTime:  &now,
+			instanceLastRestart: nil,
+			liveLastRestart:     nil,
+			expectedChanged:     true,
+		},
+		{
+			name:                "informer nil, new equals live: not changed",
+			newLastRestartTime:  &now,
+			instanceLastRestart: nil,
+			liveLastRestart:     &now,
+			expectedChanged:     false,
+		},
+		{
+			name:                "live nil, new differs from informer: changed",
+			newLastRestartTime:  &later,
+			instanceLastRestart: &now,
+			liveLastRestart:     nil,
+			expectedChanged:     true,
+		},
+		{
+			name:                "live nil, new equals informer: not changed",
+			newLastRestartTime:  &now,
+			instanceLastRestart: &now,
+			liveLastRestart:     nil,
+			expectedChanged:     false,
+		},
+		{
+			name:                "informer nil, live set, new differs from live: changed",
+			newLastRestartTime:  &later,
+			instanceLastRestart: nil,
+			liveLastRestart:     &now,
+			expectedChanged:     true,
+		},
+		{
+			name:                "informer nil, live set, new equals live: not changed",
+			newLastRestartTime:  &now,
+			instanceLastRestart: nil,
+			liveLastRestart:     &now,
+			expectedChanged:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := restartTrackingChanged(tt.newLastRestartTime, tt.instanceLastRestart, tt.liveLastRestart)
+			assert.Equal(t, tt.expectedChanged, result)
 		})
 	}
 }

--- a/pkg/reconciler/roleinstance/sync/api.go
+++ b/pkg/reconciler/roleinstance/sync/api.go
@@ -35,7 +35,7 @@ type Interface interface {
 	Scale(ctx context.Context, updateInstance *workloadsv1alpha2.RoleInstance, currentRevision, updateRevision *apps.ControllerRevision, revisions []*apps.ControllerRevision, pods []*v1.Pod, inactivePods []*v1.Pod) (bool, time.Duration, error)
 	Update(ctx context.Context, instance *workloadsv1alpha2.RoleInstance, newStatus *workloadsv1alpha2.RoleInstanceStatus, currentRevision, updateRevision *apps.ControllerRevision, revisions []*apps.ControllerRevision, pods []*v1.Pod) (time.Duration, error)
 	// ClearRestarting removes the instance from the in-memory restarting cache.
-	// Called when the instance transitions to Ready.
+	// Called when the instance transitions to Ready, or when it is deleted.
 	ClearRestarting(instance *workloadsv1alpha2.RoleInstance)
 }
 

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -475,7 +475,7 @@ func (c *realControl) checkRestartBackoff(instance *workloadsv1alpha2.RoleInstan
 // The first backoff (restartCount=1) equals baseDelay, then doubles each round.
 // When maxDelaySeconds is 0, no cap is applied (unbounded backoff).
 func calculateRestartDelay(baseDelaySeconds, maxDelaySeconds, restartCount int32) int32 {
-	if baseDelaySeconds == 0 || restartCount <= 0 {
+	if baseDelaySeconds <= 0 || restartCount <= 0 {
 		return 0
 	}
 	// Use (restartCount-1) so the first backoff equals baseDelay.

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -404,6 +404,12 @@ func (c *realControl) checkRestartBackoff(instance *workloadsv1alpha2.RoleInstan
 	// the instance status was just updated (Ready=False) from the previous
 	// reconcile, making wasInstanceReady() return false on the next reconcile,
 	// which would cause shouldRecreateInstance to skip the restart entirely.
+	// TODO: the slow path also applies backoff when shouldRecreateInstance
+	// returned false due to Generation != ObservedGeneration or
+	// CurrentRevision != UpdateRevision (rolling update / spec change in
+	// progress). This freezes updates until the backoff window expires.
+	// Fix: only apply slow-path backoff when shouldRecreateInstance returned
+	// false due to wasInstanceReady, not due to Generation/Revision mismatch.
 	if !shouldRecreateInstance(instance, allPods, instance.Status.InPlaceUpdateContainerBaselines) {
 		hasFailedPods := false
 		for _, p := range allPods {
@@ -546,8 +552,9 @@ func shouldRecreateInstance(instance *workloadsv1alpha2.RoleInstance, pods []*v1
 	// The instance may not yet be Ready (pods still Pending after recreation), so
 	// wasInstanceReady() would return false. We bypass to prevent deadlock where
 	// a pod crash before Ready would block recreation indefinitely.
-	// This bypass is bounded: RestartCount resets after a stable period
-	// (max(maxDelay*2, 10min)), and the normal Ready check resumes.
+	// TODO: this bypass is currently permanent — LastRestartTime is never cleared
+	// once set, so wasInstanceReady() never resumes after the first restart.
+	// Fix: clear LastRestartTime after a sustained Ready period (max(maxDelay*2, 10min)).
 	if (!wasInstanceReady(instance) && instance.Status.LastRestartTime == nil) ||
 		instance.Generation != instance.Status.ObservedGeneration {
 		return false

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -476,7 +476,9 @@ func (c *realControl) checkRestartBackoff(instance *workloadsv1alpha2.RoleInstan
 // calculateRestartDelay computes the exponential backoff delay for a restart attempt.
 // Formula: min(baseDelay * 2^(restartCount-1), maxDelay)
 // The first backoff (restartCount=1) equals baseDelay, then doubles each round.
-// When maxDelaySeconds is 0, no cap is applied (unbounded backoff).
+// A maxDelaySeconds of 0 is treated as no cap, but CEL validation requires
+// maxDelaySeconds >= baseDelaySeconds, so this only occurs when both are 0
+// (backoff disabled) — the no-cap branch is effectively unreachable for valid input.
 func calculateRestartDelay(baseDelaySeconds, maxDelaySeconds, restartCount int32) int32 {
 	if baseDelaySeconds <= 0 || restartCount <= 0 {
 		return 0

--- a/pkg/reconciler/roleinstance/sync/instance_scale.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale.go
@@ -404,13 +404,16 @@ func (c *realControl) checkRestartBackoff(instance *workloadsv1alpha2.RoleInstan
 	// the instance status was just updated (Ready=False) from the previous
 	// reconcile, making wasInstanceReady() return false on the next reconcile,
 	// which would cause shouldRecreateInstance to skip the restart entirely.
-	// TODO: the slow path also applies backoff when shouldRecreateInstance
-	// returned false due to Generation != ObservedGeneration or
-	// CurrentRevision != UpdateRevision (rolling update / spec change in
-	// progress). This freezes updates until the backoff window expires.
-	// Fix: only apply slow-path backoff when shouldRecreateInstance returned
-	// false due to wasInstanceReady, not due to Generation/Revision mismatch.
+	//
+	// However, when shouldRecreateInstance returned false due to a rolling
+	// update or spec change (Generation/Revision mismatch), we must NOT apply
+	// backoff — doing so would freeze updates until the backoff window expires.
 	if !shouldRecreateInstance(instance, allPods, instance.Status.InPlaceUpdateContainerBaselines) {
+		// Skip backoff when a spec change or rolling update is in progress
+		if instance.Generation != instance.Status.ObservedGeneration ||
+			instance.Status.CurrentRevision != instance.Status.UpdateRevision {
+			return 0
+		}
 		hasFailedPods := false
 		for _, p := range allPods {
 			if p.Status.Phase == v1.PodFailed && p.DeletionTimestamp == nil {
@@ -548,14 +551,14 @@ func shouldRecreateInstance(instance *workloadsv1alpha2.RoleInstance, pods []*v1
 	// Only trigger when Instance was previously Ready (stable state)
 	// and is NOT in the middle of any update.
 	// This avoids triggering recreate during initial creation, scaling up, or rolling/in-place updates.
-	// Exception: if LastRestartTime is set, a restart-policy recreation has occurred.
-	// The instance may not yet be Ready (pods still Pending after recreation), so
-	// wasInstanceReady() would return false. We bypass to prevent deadlock where
-	// a pod crash before Ready would block recreation indefinitely.
-	// TODO: this bypass is currently permanent — LastRestartTime is never cleared
-	// once set, so wasInstanceReady() never resumes after the first restart.
-	// Fix: clear LastRestartTime after a sustained Ready period (max(maxDelay*2, 10min)).
-	if (!wasInstanceReady(instance) && instance.Status.LastRestartTime == nil) ||
+	// Exception: if there was a recent restart (within the stable threshold), a restart-policy
+	// recreation has occurred. The instance may not yet be Ready (pods still Pending after
+	// recreation), so wasInstanceReady() would return false. We bypass to prevent deadlock
+	// where a pod crash before Ready would block recreation indefinitely.
+	// This bypass is bounded: after the stable threshold (max(maxDelay*2, 10min)) elapses
+	// without a restart, hasRecentRestart returns false and the normal wasInstanceReady
+	// check resumes. LastRestartTime is preserved as a historical record.
+	if (!wasInstanceReady(instance) && !hasRecentRestart(instance)) ||
 		instance.Generation != instance.Status.ObservedGeneration {
 		return false
 	}
@@ -702,6 +705,28 @@ func setRestartingCondition(instance *workloadsv1alpha2.RoleInstance) {
 	})
 }
 
+// stableThreshold returns the duration after which the instance is considered
+// stable: max(maxDelaySeconds*2, 10 minutes). Used by updateRestartTracking to
+// reset RestartCount and by hasRecentRestart to bound the wasInstanceReady bypass.
+func stableThreshold(maxDelaySeconds int32) time.Duration {
+	threshold := time.Duration(maxDelaySeconds) * 2 * time.Second
+	if threshold < 10*time.Minute {
+		threshold = 10 * time.Minute
+	}
+	return threshold
+}
+
+// hasRecentRestart reports whether the instance had a restart within the stable
+// threshold. Used by shouldRecreateInstance to bound the wasInstanceReady bypass:
+// the bypass only applies while a recent restart may still be recovering, not
+// permanently. LastRestartTime is never cleared, preserving the historical record.
+func hasRecentRestart(instance *workloadsv1alpha2.RoleInstance) bool {
+	if instance.Status.LastRestartTime == nil {
+		return false
+	}
+	return time.Since(instance.Status.LastRestartTime.Time) <= stableThreshold(instance.Spec.GetMaxDelaySeconds())
+}
+
 // updateRestartTracking increments RestartCount and updates LastRestartTime
 // on the instance status. Called when a restart-policy-triggered recreation
 // is about to happen. The updated values are used by checkRestartBackoff
@@ -714,12 +739,7 @@ func setRestartingCondition(instance *workloadsv1alpha2.RoleInstance) {
 func updateRestartTracking(instance *workloadsv1alpha2.RoleInstance) {
 	// Reset counter if the instance has been stable for a long period.
 	if instance.Status.LastRestartTime != nil {
-		maxDelay := instance.Spec.GetMaxDelaySeconds()
-		stableThreshold := time.Duration(maxDelay) * 2 * time.Second
-		if stableThreshold < 10*time.Minute {
-			stableThreshold = 10 * time.Minute
-		}
-		if time.Since(instance.Status.LastRestartTime.Time) > stableThreshold {
+		if time.Since(instance.Status.LastRestartTime.Time) > stableThreshold(instance.Spec.GetMaxDelaySeconds()) {
 			instance.Status.RestartCount = 0
 		}
 	}

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -1776,7 +1776,7 @@ func TestClearRestartingPreventsStaleBlock(t *testing.T) {
 // TestHasRecentRestart tests that hasRecentRestart correctly identifies whether
 // the last restart falls within the stable threshold.
 func TestHasRecentRestart(t *testing.T) {
-	oldRestartTime := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+	oldRestartTime := metav1.NewTime(time.Now().Add(-21 * time.Minute))
 	recentRestartTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
 
 	tests := []struct {
@@ -1806,7 +1806,7 @@ func TestHasRecentRestart(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "old restart (beyond default threshold 20min < 10min min): false",
+			name: "old restart (beyond default 20min threshold): false",
 			instance: &workloadsv1alpha2.RoleInstance{
 				Spec: workloadsv1alpha2.RoleInstanceSpec{
 					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -1773,6 +1773,74 @@ func TestClearRestartingPreventsStaleBlock(t *testing.T) {
 		"should not be restarting after cache cleared")
 }
 
+// TestHasRecentRestart tests that hasRecentRestart correctly identifies whether
+// the last restart falls within the stable threshold.
+func TestHasRecentRestart(t *testing.T) {
+	oldRestartTime := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+	recentRestartTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	tests := []struct {
+		name     string
+		instance *workloadsv1alpha2.RoleInstance
+		expected bool
+	}{
+		{
+			name: "nil LastRestartTime: false",
+			instance: &workloadsv1alpha2.RoleInstance{
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "recent restart (within default threshold): true",
+			instance: &workloadsv1alpha2.RoleInstance{
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},
+				},
+				Status: workloadsv1alpha2.RoleInstanceStatus{
+					LastRestartTime: &recentRestartTime,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "old restart (beyond default threshold 20min < 10min min): false",
+			instance: &workloadsv1alpha2.RoleInstance{
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},
+				},
+				Status: workloadsv1alpha2.RoleInstanceStatus{
+					LastRestartTime: &oldRestartTime,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "old restart with custom maxDelay=60 (threshold=10min): false",
+			instance: &workloadsv1alpha2.RoleInstance{
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{
+						Type:            workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
+						MaxDelaySeconds: ptr.To(int32(60)),
+					},
+				},
+				Status: workloadsv1alpha2.RoleInstanceStatus{
+					LastRestartTime: &oldRestartTime,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasRecentRestart(tt.instance))
+		})
+	}
+}
+
 // TestWasInstanceReady tests the wasInstanceReady helper function
 func TestWasInstanceReady(t *testing.T) {
 	tests := []struct {
@@ -3109,5 +3177,41 @@ func TestCheckRestartBackoff_Branches(t *testing.T) {
 
 		result := c.checkRestartBackoff(inst, fresh, []*corev1.Pod{failedPod}, nil)
 		assert.Equal(t, time.Duration(0), result, "fresh LastRestartTime=nil means no backoff")
+	})
+
+	t.Run("Generation mismatch with failed pods: returns 0 (no backoff freeze)", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 3
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+		// Simulate spec change: Generation > ObservedGeneration
+		inst.Generation = 2
+		inst.Status.ObservedGeneration = 1
+		// Not Ready so shouldRecreateInstance returns false
+		inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{}
+
+		result := c.checkRestartBackoff(inst, nil, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result,
+			"backoff should not freeze updates when Generation != ObservedGeneration")
+	})
+
+	t.Run("CurrentRevision != UpdateRevision with failed pods: returns 0 (no backoff freeze)", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 3
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+		// Simulate rolling update: revisions differ
+		inst.Status.CurrentRevision = "rev-1"
+		inst.Status.UpdateRevision = "rev-2"
+		// Not Ready so shouldRecreateInstance returns false
+		inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{}
+
+		result := c.checkRestartBackoff(inst, nil, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result,
+			"backoff should not freeze rolling updates when CurrentRevision != UpdateRevision")
 	})
 }

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 )
@@ -2397,5 +2399,677 @@ func TestCheckRestartBackoff(t *testing.T) {
 		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
 		result := c.checkRestartBackoff(inst, nil, []*corev1.Pod{failedPod}, nil)
 		assert.Equal(t, time.Duration(0), result)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// updateRestartTracking
+// ---------------------------------------------------------------------------
+
+func TestUpdateRestartTracking(t *testing.T) {
+	tests := []struct {
+		name            string
+		restartCount    int32
+		lastRestartTime *metav1.Time
+		maxDelaySeconds *int32
+		expectedCount   int32
+		desc            string
+	}{
+		{
+			name:            "first restart: count 0→1, LastRestartTime nil",
+			restartCount:    0,
+			lastRestartTime: nil,
+			maxDelaySeconds: nil,
+			expectedCount:   1,
+			desc:            "When LastRestartTime is nil, RestartCount increments from 0 to 1",
+		},
+		{
+			name:            "recent restart: count 5→6 (no reset, within stable period)",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-1 * time.Minute))),
+			maxDelaySeconds: nil, // default 600 → threshold = max(1200s, 600s) = 20min
+			expectedCount:   6,
+			desc:            "1 minute ago is within 20min threshold, no reset, count increments to 6",
+		},
+		{
+			name:            "old restart with default maxDelay: count 5→1 (reset after stable period)",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-25 * time.Minute))),
+			maxDelaySeconds: nil, // default 600 → threshold = max(1200s, 600s) = 20min
+			expectedCount:   1,
+			desc:            "25 minutes > 20min threshold, count resets to 0 then increments to 1",
+		},
+		{
+			name:            "within stable period with default maxDelay: count 5→6 (15min < 20min)",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-15 * time.Minute))),
+			maxDelaySeconds: nil,
+			expectedCount:   6,
+			desc:            "15 minutes < 20min threshold, no reset, count increments to 6",
+		},
+		{
+			name:            "small maxDelay: threshold = max(20s, 10min) = 10min, old restart resets",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-11 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(10)),
+			expectedCount:   1,
+			desc:            "maxDelay=10 → threshold=max(20s,10min)=10min, 11min > 10min, count resets to 1",
+		},
+		{
+			name:            "small maxDelay: threshold = 10min, within period no reset",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-5 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(10)),
+			expectedCount:   6,
+			desc:            "maxDelay=10 → threshold=10min, 5min < 10min, no reset, count increments to 6",
+		},
+		{
+			name:            "maxDelay=0: threshold = max(0, 10min) = 10min, old restart resets",
+			restartCount:    5,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-15 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(0)),
+			expectedCount:   1,
+			desc:            "maxDelay=0 → threshold=max(0,10min)=10min, 15min > 10min, count resets to 1",
+		},
+		{
+			name:            "maxDelay=0: threshold = 10min, within period no reset",
+			restartCount:    3,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-5 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(0)),
+			expectedCount:   4,
+			desc:            "maxDelay=0 → threshold=10min, 5min < 10min, no reset, count increments to 4",
+		},
+		{
+			name:            "large maxDelay: threshold = max(2000s, 600s) = 2000s ≈ 33min",
+			restartCount:    10,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-30 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(1000)),
+			expectedCount:   11,
+			desc:            "maxDelay=1000 → threshold=max(2000s,600s)=2000s≈33min, 30min < 33min, no reset",
+		},
+		{
+			name:            "large maxDelay: beyond threshold resets",
+			restartCount:    10,
+			lastRestartTime: ptr.To(metav1.NewTime(metav1.Now().Add(-35 * time.Minute))),
+			maxDelaySeconds: ptr.To(int32(1000)),
+			expectedCount:   1,
+			desc:            "maxDelay=1000 → threshold≈33min, 35min > 33min, count resets to 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{
+						Type:             workloadsv1alpha2.RecreateRoleInstanceOnPodRestart,
+						MaxDelaySeconds:  tt.maxDelaySeconds,
+					},
+				},
+				Status: workloadsv1alpha2.RoleInstanceStatus{
+					RestartCount:    tt.restartCount,
+					LastRestartTime: tt.lastRestartTime,
+				},
+			}
+
+			updateRestartTracking(instance)
+
+			assert.Equal(t, tt.expectedCount, instance.Status.RestartCount, tt.desc)
+			assert.NotNil(t, instance.Status.LastRestartTime, "LastRestartTime should always be set after updateRestartTracking")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncRestartTrackingFromAPI
+// ---------------------------------------------------------------------------
+
+func TestSyncRestartTrackingFromAPI(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = workloadsv1alpha2.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+	earlier := metav1.NewTime(now.Add(-2 * time.Minute))
+	later := metav1.NewTime(now.Add(2 * time.Minute))
+
+	// assertTimeEqual compares metav1.Time values using time.Time.Equal which
+	// ignores the monotonic clock reading stripped by fake client serialization.
+	assertTimeEqual := func(t *testing.T, expected, actual *metav1.Time, msgAndArgs ...interface{}) {
+		t.Helper()
+		if expected == nil {
+			assert.Nil(t, actual, msgAndArgs...)
+			return
+		}
+		if assert.NotNil(t, actual, msgAndArgs...) {
+			assert.True(t, actual.Time.Equal(expected.Time), msgAndArgs...)
+		}
+	}
+
+	t.Run("nil apiReader: returns nil, instance unchanged", func(t *testing.T) {
+		ctrl := &realControl{}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.Nil(t, result)
+		assert.Equal(t, int32(3), instance.Status.RestartCount)
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("API not found: returns nil, instance unchanged", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.Nil(t, result)
+		assert.Equal(t, int32(3), instance.Status.RestartCount)
+	})
+
+	t.Run("fresh timestamp newer, count lower (reset): adopt both", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    1,
+				LastRestartTime: &now,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    5,
+				LastRestartTime: &earlier,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(1), instance.Status.RestartCount, "should adopt fresh count (5→1 reset)")
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime, "should adopt fresh timestamp")
+	})
+
+	t.Run("fresh timestamp newer, count higher: adopt both", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    10,
+				LastRestartTime: &now,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &earlier,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(10), instance.Status.RestartCount)
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("fresh timestamp older: do not adopt timestamp, adopt count if higher", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    10,
+				LastRestartTime: &earlier,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(10), instance.Status.RestartCount, "should adopt higher count even when timestamp is older")
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("instance LastRestartTime nil, fresh has one: adopt both", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    2,
+				LastRestartTime: &now,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    0,
+				LastRestartTime: nil,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(2), instance.Status.RestartCount)
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("fresh LastRestartTime nil: do not adopt timestamp, adopt count if higher", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    7,
+				LastRestartTime: nil,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(7), instance.Status.RestartCount, "should adopt higher count even without timestamp")
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime, "should NOT change timestamp when fresh is nil")
+	})
+
+	t.Run("fresh LastRestartTime nil, count not higher: no change", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    2,
+				LastRestartTime: nil,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    5,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(5), instance.Status.RestartCount)
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("same timestamp, fresh count higher: adopt count only", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    8,
+				LastRestartTime: &now,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(8), instance.Status.RestartCount, "should adopt higher count with same timestamp")
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("same timestamp, same count: no change", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(3), instance.Status.RestartCount)
+		assertTimeEqual(t, &now, instance.Status.LastRestartTime)
+	})
+
+	t.Run("fresh timestamp newer (later): adopt both even if count same", func(t *testing.T) {
+		freshOnAPI := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &later,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(freshOnAPI).Build()
+		ctrl := &realControl{apiReader: fakeClient}
+		instance := &workloadsv1alpha2.RoleInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default"},
+			Status: workloadsv1alpha2.RoleInstanceStatus{
+				RestartCount:    3,
+				LastRestartTime: &now,
+			},
+		}
+		result := ctrl.syncRestartTrackingFromAPI(context.Background(), instance)
+		assert.NotNil(t, result)
+		assert.Equal(t, int32(3), instance.Status.RestartCount)
+		assertTimeEqual(t, &later, instance.Status.LastRestartTime, "should adopt newer timestamp even if count is same")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// shouldRecreateInstance bypass (LastRestartTime set + not Ready)
+// ---------------------------------------------------------------------------
+
+func TestShouldRecreateInstanceBypass(t *testing.T) {
+	someTime := metav1.NewTime(metav1.Now().Add(-1 * time.Minute))
+
+	baseInstance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-instance",
+			Generation: 1,
+		},
+		Spec: workloadsv1alpha2.RoleInstanceSpec{
+			RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},
+			Components: []workloadsv1alpha2.RoleInstanceComponent{
+				{Size: ptr.To[int32](1)},
+			},
+		},
+		Status: workloadsv1alpha2.RoleInstanceStatus{
+			ObservedGeneration: 1,
+			CurrentRevision:    "rev-1",
+			UpdateRevision:     "rev-1",
+		},
+	}
+
+	failedPod := []*corev1.Pod{
+		{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
+	}
+	runningPod := []*corev1.Pod{
+		{Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+	}
+	restartedPod := []*corev1.Pod{
+		{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "main", RestartCount: 1},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		modify   func(*workloadsv1alpha2.RoleInstance)
+		pods     []*corev1.Pod
+		expected bool
+		desc     string
+	}{
+		{
+			name: "not Ready + LastRestartTime nil + PodFailed: bypass does NOT apply",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = nil
+			},
+			pods:     failedPod,
+			expected: false,
+			desc:     "Without LastRestartTime, wasInstanceReady=False blocks recreation (no bypass)",
+		},
+		{
+			name: "not Ready + LastRestartTime set + PodFailed: bypass applies",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = &someTime
+			},
+			pods:     failedPod,
+			expected: true,
+			desc:     "LastRestartTime set bypasses wasInstanceReady=False check, PodFailed triggers recreate",
+		},
+		{
+			name: "not Ready + LastRestartTime set + container restart: bypass applies",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = &someTime
+			},
+			pods:     restartedPod,
+			expected: true,
+			desc:     "Bypass applies, container restart triggers recreate",
+		},
+		{
+			name: "not Ready + LastRestartTime set + all running: no crash to detect",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = &someTime
+			},
+			pods:     runningPod,
+			expected: false,
+			desc:     "Bypass applies but no PodFailed or container restart, so no recreate",
+		},
+		{
+			name: "not Ready + LastRestartTime set + Generation mismatch: Generation check still blocks",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = &someTime
+				inst.Generation = 2
+				inst.Status.ObservedGeneration = 1
+			},
+			pods:     failedPod,
+			expected: false,
+			desc:     "Even with bypass, Generation != ObservedGeneration blocks recreation",
+		},
+		{
+			name: "not Ready + LastRestartTime set + revision mismatch: revision check still blocks",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionFalse},
+				}
+				inst.Status.LastRestartTime = &someTime
+				inst.Status.CurrentRevision = "rev-1"
+				inst.Status.UpdateRevision = "rev-2"
+			},
+			pods:     failedPod,
+			expected: false,
+			desc:     "Even with bypass, CurrentRevision != UpdateRevision blocks recreation",
+		},
+		{
+			name: "Ready + LastRestartTime nil + PodFailed: normal case (no bypass needed)",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionTrue},
+				}
+				inst.Status.LastRestartTime = nil
+			},
+			pods:     failedPod,
+			expected: true,
+			desc:     "wasInstanceReady=True, normal recreation triggered by PodFailed",
+		},
+		{
+			name: "Ready + LastRestartTime set + PodFailed: both conditions satisfied",
+			modify: func(inst *workloadsv1alpha2.RoleInstance) {
+				inst.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+					{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionTrue},
+				}
+				inst.Status.LastRestartTime = &someTime
+			},
+			pods:     failedPod,
+			expected: true,
+			desc:     "Ready=True and LastRestartTime set, PodFailed triggers recreate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := baseInstance.DeepCopy()
+			tt.modify(inst)
+			result := shouldRecreateInstance(inst, tt.pods, nil)
+			assert.Equal(t, tt.expected, result, tt.desc)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkRestartBackoff branches: fresh != nil, restarting == true, baseDelay == 0
+// ---------------------------------------------------------------------------
+
+func TestCheckRestartBackoff_Branches(t *testing.T) {
+	c := &realControl{}
+
+	baseInstance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: "default", Generation: 1},
+		Spec: workloadsv1alpha2.RoleInstanceSpec{
+			RestartPolicy: workloadsv1alpha2.RestartPolicyConfig{Type: workloadsv1alpha2.RecreateRoleInstanceOnPodRestart},
+			Components: []workloadsv1alpha2.RoleInstanceComponent{
+				{Name: "main", Size: ptr.To(int32(1))},
+			},
+		},
+		Status: workloadsv1alpha2.RoleInstanceStatus{
+			ObservedGeneration: 1,
+			CurrentRevision:    "rev-1",
+			UpdateRevision:     "rev-1",
+			Conditions: []workloadsv1alpha2.RoleInstanceCondition{
+				{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+
+	t.Run("restarting == true (from fresh): returns 0", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 1
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+
+		fresh := inst.DeepCopy()
+		fresh.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+			{Type: workloadsv1alpha2.RoleInstanceRestarting, Status: corev1.ConditionTrue},
+		}
+
+		result := c.checkRestartBackoff(inst, fresh, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result, "fresh Restarting=True should skip backoff")
+	})
+
+	t.Run("restarting == true (from informer, fresh == nil): returns 0", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 1
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+		inst.Status.Conditions = append(inst.Status.Conditions, workloadsv1alpha2.RoleInstanceCondition{
+			Type:   workloadsv1alpha2.RoleInstanceRestarting,
+			Status: corev1.ConditionTrue,
+		})
+
+		result := c.checkRestartBackoff(inst, nil, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result, "informer Restarting=True should skip backoff")
+	})
+
+	t.Run("restarting == true from informer overridden by fresh == false: proceeds with backoff", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 1
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+		inst.Status.Conditions = append(inst.Status.Conditions, workloadsv1alpha2.RoleInstanceCondition{
+			Type:   workloadsv1alpha2.RoleInstanceRestarting,
+			Status: corev1.ConditionTrue,
+		})
+
+		fresh := inst.DeepCopy()
+		fresh.Status.Conditions = []workloadsv1alpha2.RoleInstanceCondition{
+			{Type: workloadsv1alpha2.RoleInstanceReady, Status: corev1.ConditionTrue},
+		}
+
+		result := c.checkRestartBackoff(inst, fresh, []*corev1.Pod{failedPod}, nil)
+		assert.Greater(t, result, time.Duration(0), "fresh Restarting=False should override stale informer Restarting=True")
+	})
+
+	t.Run("baseDelay == 0 && maxDelay == 0: returns 0 (disabled)", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 5
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(0))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(0))
+
+		result := c.checkRestartBackoff(inst, nil, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result, "backoff disabled when baseDelay=0 and maxDelay=0")
+	})
+
+	t.Run("fresh != nil: uses fresh RestartCount for delay calculation", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 5
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+
+		fresh := inst.DeepCopy()
+		fresh.Status.RestartCount = 1
+
+		result := c.checkRestartBackoff(inst, fresh, []*corev1.Pod{failedPod}, nil)
+		assert.Greater(t, result, time.Duration(0))
+		assert.LessOrEqual(t, result, 30*time.Second,
+			"with fresh RestartCount=1, delay should be ~30s (not 480s from informer's count=5)")
+	})
+
+	t.Run("fresh != nil with nil LastRestartTime: returns 0", func(t *testing.T) {
+		inst := baseInstance.DeepCopy()
+		now := metav1.Now()
+		inst.Status.LastRestartTime = &now
+		inst.Status.RestartCount = 1
+		inst.Spec.RestartPolicy.BaseDelaySeconds = ptr.To(int32(30))
+		inst.Spec.RestartPolicy.MaxDelaySeconds = ptr.To(int32(600))
+
+		fresh := inst.DeepCopy()
+		fresh.Status.LastRestartTime = nil
+
+		result := c.checkRestartBackoff(inst, fresh, []*corev1.Pod{failedPod}, nil)
+		assert.Equal(t, time.Duration(0), result, "fresh LastRestartTime=nil means no backoff")
 	})
 }

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -2351,6 +2351,8 @@ func TestCalculateRestartDelay(t *testing.T) {
 		{name: "int64 overflow at 62: capped at max", baseDelay: 30, maxDelay: 600, restartCount: 62, expectedDelay: 600},
 		{name: "int64 overflow uncapped at 60", baseDelay: 10, maxDelay: 0, restartCount: 60, expectedDelay: 0x7FFFFFFF},
 		{name: "maxDelay=0: no cap", baseDelay: 10, maxDelay: 0, restartCount: 5, expectedDelay: 160},
+		{name: "negative baseDelay returns 0", baseDelay: -1, maxDelay: 600, restartCount: 3, expectedDelay: 0},
+		{name: "negative baseDelay with negative maxDelay returns 0", baseDelay: -30, maxDelay: -1, restartCount: 2, expectedDelay: 0},
 	}
 
 	for _, tt := range tests {

--- a/pkg/reconciler/roleinstance/sync/instance_scale_test.go
+++ b/pkg/reconciler/roleinstance/sync/instance_scale_test.go
@@ -1737,6 +1737,42 @@ func TestSetRestartingCondition(t *testing.T) {
 	})
 }
 
+// TestClearRestarting tests that ClearRestarting removes the instance from the
+// in-memory cache, preventing stale entries from blocking new instances.
+func TestClearRestarting(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-instance"},
+	}
+	ctrl := &realControl{}
+
+	// Seed the cache
+	restartingCache.Store(instanceKey(instance), true)
+	_, ok := restartingCache.Load(instanceKey(instance))
+	assert.True(t, ok, "cache should have entry before clear")
+
+	ctrl.ClearRestarting(instance)
+
+	_, ok = restartingCache.Load(instanceKey(instance))
+	assert.False(t, ok, "cache should not have entry after clear")
+}
+
+// TestClearRestartingPreventsStaleBlock verifies that after ClearRestarting,
+// isAlreadyRestarting does not return true from a stale cache entry.
+func TestClearRestartingPreventsStaleBlock(t *testing.T) {
+	instance := &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-instance"},
+	}
+	ctrl := &realControl{}
+
+	// Simulate restart trigger then deletion cleanup
+	setRestartingCondition(instance)
+	ctrl.ClearRestarting(instance)
+
+	// With nil apiReader, isAlreadyRestarting should return false
+	assert.False(t, ctrl.isAlreadyRestarting(context.Background(), instance),
+		"should not be restarting after cache cleared")
+}
+
 // TestWasInstanceReady tests the wasInstanceReady helper function
 func TestWasInstanceReady(t *testing.T) {
 	tests := []struct {

--- a/test/e2e/testcase/v1alpha2/restart_policy_stability.go
+++ b/test/e2e/testcase/v1alpha2/restart_policy_stability.go
@@ -35,6 +35,7 @@ func RunRestartPolicyStabilityTestCases(f *framework.Framework) {
 		runRestartPolicyNoneReplaceTest(f)
 		runRestartBackoffDelayTest(f)
 		runRestartBackoffPropagationTest(f)
+		runRestartBackoffSpecChangeTest(f)
 	})
 }
 
@@ -410,6 +411,146 @@ func runRestartBackoffPropagationTest(f *framework.Framework) {
 				ri.Spec.RestartPolicy.MaxDelaySeconds != nil && *ri.Spec.RestartPolicy.MaxDelaySeconds == 120
 		}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(),
 			"BaseDelaySeconds=10 and MaxDelaySeconds=120 should propagate from RBG to RoleInstance")
+	})
+}
+
+// runRestartBackoffSpecChangeTest verifies that a spec change (rolling update)
+// during an active backoff window is not frozen by the backoff delay.
+// The slow-path backoff check must skip when a Generation/Revision mismatch
+// indicates a spec change or rolling update is in progress.
+func runRestartBackoffSpecChangeTest(f *framework.Framework) {
+	ginkgo.It("RecreateRoleInstanceOnPodRestart rolling update proceeds during backoff", func() {
+		// baseDelay=120 ensures the backoff window (120s) is much longer than
+		// the time needed for spec propagation and pod creation, so the test
+		// can reliably distinguish between frozen (old behavior) and proceeding
+		// (fixed behavior) within a 30s window.
+		rbg := wrappersv2.BuildBasicRoleBasedGroup("e2e-backoff-spec", f.Namespace).WithRoles(
+			[]workloadsv1alpha2.RoleSpec{
+				wrappersv2.BuildLeaderWorkerRole("role-1").
+					WithReplicas(1).
+					WithRestartPolicy(workloadsv1alpha2.RecreateRoleInstanceOnPodRestart).
+					WithBaseDelaySeconds(120).
+					WithMaxDelaySeconds(300).
+					Obj(),
+			}).Obj()
+
+		f.RegisterDebugFn(func() { dumpDebugInfo(f, rbg) })
+
+		gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
+		f.ExpectRbgV2Equal(rbg)
+
+		podList := &corev1.PodList{}
+		gomega.Expect(f.Client.List(f.Ctx, podList,
+			client.InNamespace(f.Namespace),
+			client.MatchingLabels{
+				constants.GroupNameLabelKey: rbg.Name,
+				constants.RoleNameLabelKey:  "role-1",
+			})).Should(gomega.Succeed())
+		gomega.Expect(podList.Items).ShouldNot(gomega.BeEmpty())
+
+		targetInstanceName := podList.Items[0].Labels[constants.RoleInstanceNameLabelKey]
+		waitForInstanceReady(f, targetInstanceName)
+
+		// --- First crash: no backoff (RestartCount=0) ---
+		gomega.Expect(f.Client.List(f.Ctx, podList,
+			client.InNamespace(f.Namespace),
+			client.MatchingLabels{
+				constants.GroupNameLabelKey:        rbg.Name,
+				constants.RoleInstanceNameLabelKey: targetInstanceName,
+			})).Should(gomega.Succeed())
+		firstUIDs := make(map[string]types.UID)
+		for _, p := range podList.Items {
+			firstUIDs[p.Name] = p.UID
+		}
+
+		targetPod := &corev1.Pod{}
+		gomega.Expect(f.Client.Get(f.Ctx, client.ObjectKey{
+			Namespace: f.Namespace,
+			Name:      podList.Items[0].Name,
+		}, targetPod)).Should(gomega.Succeed())
+		gomega.Expect(utils.SetPodFailed(f.Ctx, f.Client, targetPod)).Should(gomega.Succeed())
+
+		waitForInstancePodsRecreated(f, rbg, targetInstanceName, firstUIDs)
+		f.ExpectRbgV2Equal(rbg)
+		waitForInstanceFullyRecovered(f, targetInstanceName)
+
+		// --- Second crash: backoff should be active (120s delay) ---
+		gomega.Expect(f.Client.List(f.Ctx, podList,
+			client.InNamespace(f.Namespace),
+			client.MatchingLabels{
+				constants.GroupNameLabelKey:        rbg.Name,
+				constants.RoleInstanceNameLabelKey: targetInstanceName,
+			})).Should(gomega.Succeed())
+		secondUIDs := make(map[string]types.UID)
+		for _, p := range podList.Items {
+			secondUIDs[p.Name] = p.UID
+		}
+
+		gomega.Expect(f.Client.Get(f.Ctx, client.ObjectKey{
+			Namespace: f.Namespace,
+			Name:      podList.Items[0].Name,
+		}, targetPod)).Should(gomega.Succeed())
+		gomega.Expect(utils.SetPodFailed(f.Ctx, f.Client, targetPod)).Should(gomega.Succeed())
+
+		// Verify backoff is active: pods NOT recreated for 15s
+		gomega.Consistently(func() bool {
+			pods := &corev1.PodList{}
+			if err := f.Client.List(f.Ctx, pods,
+				client.InNamespace(f.Namespace),
+				client.MatchingLabels{
+					constants.GroupNameLabelKey:        rbg.Name,
+					constants.RoleInstanceNameLabelKey: targetInstanceName,
+				}); err != nil {
+				return false
+			}
+			for _, p := range pods.Items {
+				if p.DeletionTimestamp != nil {
+					continue
+				}
+				if secondUIDs[p.Name] != p.UID {
+					return false
+				}
+			}
+			return true
+		}, 15, 2).Should(gomega.BeTrue(),
+			"pod should NOT be recreated during backoff window")
+
+		// --- Update spec during backoff: add env var to trigger rolling update ---
+		updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+			rbg.Spec.Roles[0].Pattern.LeaderWorkerPattern.TemplateSource.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+				{Name: "BACKOFF_E2E", Value: "v2"},
+			}
+		})
+
+		// Verify the rolling update proceeds despite backoff.
+		// A new pod with the updated env var should appear within 30s.
+		// The backoff window (120s) is much longer than 30s, so if the
+		// backoff froze the update, no new pod would appear in time.
+		gomega.Eventually(func() bool {
+			pods := &corev1.PodList{}
+			if err := f.Client.List(f.Ctx, pods,
+				client.InNamespace(f.Namespace),
+				client.MatchingLabels{
+					constants.GroupNameLabelKey:        rbg.Name,
+					constants.RoleInstanceNameLabelKey: targetInstanceName,
+				}); err != nil {
+				return false
+			}
+			for _, p := range pods.Items {
+				if p.DeletionTimestamp != nil {
+					continue
+				}
+				for _, c := range p.Spec.Containers {
+					for _, env := range c.Env {
+						if env.Name == "BACKOFF_E2E" && env.Value == "v2" {
+							return true
+						}
+					}
+				}
+			}
+			return false
+		}, 30, 2).Should(gomega.BeTrue(),
+			"rolling update should proceed during backoff (new pod with updated env var should be created)")
 	})
 }
 

--- a/test/envtest/testcase/restart_policy/restart_policy_test.go
+++ b/test/envtest/testcase/restart_policy/restart_policy_test.go
@@ -1103,5 +1103,233 @@ var _ = Describe("RestartPolicy Controller Integration", func() {
 			}, timeout, interval).Should(Equal(int32(1)),
 				"RestartCount should reset to 1 after long stable period (not continue from previous value)")
 		})
+
+		It("should not bypass wasInstanceReady check after stable threshold", func() {
+			rbgName := "test-bypass-bound"
+			roleName := defaultRoleName
+
+			rbg := wrappersv2.BuildBasicRoleBasedGroup(rbgName, testNs).WithRoles(
+				[]workloadsv1alpha2.RoleSpec{
+					wrappersv2.BuildLeaderWorkerRole(roleName).
+						WithReplicas(1).
+						WithSize(2).
+						WithRestartPolicy(workloadsv1alpha2.RecreateRoleInstanceOnPodRestart).
+						WithBaseDelaySeconds(1).
+						WithMaxDelaySeconds(2).
+						Obj(),
+				}).Obj()
+
+			Expect(testutil.K8sClient.Create(testutil.Ctx, rbg)).Should(Succeed())
+
+			waitForPods(rbgName, roleName, 2)
+			makePodsReady(rbgName, roleName)
+			waitForRoleInstanceReady(rbgName, roleName)
+
+			// Trigger first recreation to set LastRestartTime and RestartCount=1
+			podList := listRolePods(rbgName, roleName)
+			originalUIDs := getPodUIDs(podList)
+			freshPod := &corev1.Pod{}
+			Expect(testutil.K8sClient.Get(testutil.Ctx,
+				client.ObjectKeyFromObject(&podList.Items[0]), freshPod)).Should(Succeed())
+			freshPod.Status.Phase = corev1.PodFailed
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, freshPod)).Should(Succeed())
+
+			// Wait for recreation (both pods recreated)
+			Eventually(func() bool {
+				podList := listRolePods(rbgName, roleName)
+				active := getActivePods(podList)
+				if len(active) < 2 {
+					return false
+				}
+				for _, p := range active {
+					if originalUIDs[p.Name] == p.UID {
+						return false
+					}
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			// Recover: make pods Ready, wait for Restarting condition cleared
+			makePodsReady(rbgName, roleName)
+			waitForRoleInstanceReady(rbgName, roleName)
+
+			// Verify RestartCount=1 and LastRestartTime is set
+			Eventually(func() int32 {
+				ri := getRoleInstance(rbgName, roleName)
+				if ri == nil {
+					return 0
+				}
+				return ri.Status.RestartCount
+			}, timeout, interval).Should(Equal(int32(1)))
+
+			// Backdate LastRestartTime past the stable threshold.
+			// stableThreshold = max(maxDelaySeconds*2, 10min) = max(4, 600) = 600s = 10min.
+			// Setting to 11 minutes ago exceeds this threshold, making hasRecentRestart return false.
+			ri := getRoleInstance(rbgName, roleName)
+			Expect(ri).NotTo(BeNil())
+			ri.Status.LastRestartTime.Time = time.Now().Add(-11 * time.Minute)
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, ri)).Should(Succeed())
+
+			// Make pods not Ready so wasInstanceReady returns false.
+			// Set phase to Pending (IsRunningAndAvailable requires Phase==Running).
+			podList = listRolePods(rbgName, roleName)
+			for i := range podList.Items {
+				freshPod := &corev1.Pod{}
+				Expect(testutil.K8sClient.Get(testutil.Ctx,
+					client.ObjectKeyFromObject(&podList.Items[i]), freshPod)).Should(Succeed())
+				freshPod.Status.Phase = corev1.PodPending
+				freshPod.Status.Conditions = nil
+				Expect(testutil.K8sClient.Status().Update(testutil.Ctx, freshPod)).Should(Succeed())
+			}
+
+			// Wait for RoleInstance to become not Ready (wasInstanceReady will return false)
+			Eventually(func() bool {
+				ri := getRoleInstance(rbgName, roleName)
+				if ri == nil {
+					return false
+				}
+				for _, cond := range ri.Status.Conditions {
+					if cond.Type == workloadsv1alpha2.RoleInstanceReady && cond.Status == corev1.ConditionTrue {
+						return false
+					}
+				}
+				return true
+			}, timeout, interval).Should(BeTrue(),
+				"RoleInstance should become not Ready after pods are set to Pending")
+
+			// Now fail one pod. With the fix:
+			//   wasInstanceReady=false, hasRecentRestart=false → shouldRecreateInstance returns false
+			//   → no recreation, survivor pod should NOT be deleted.
+			// Without the fix (permanent bypass):
+			//   wasInstanceReady=false but LastRestartTime!=nil → bypass applies
+			//   → shouldRecreateInstance returns true → recreation happens, survivor deleted.
+			podList = listRolePods(rbgName, roleName)
+			Expect(podList.Items).Should(HaveLen(2))
+			survivorName := podList.Items[1].Name
+			survivorUID := podList.Items[1].UID
+
+			freshPod = &corev1.Pod{}
+			Expect(testutil.K8sClient.Get(testutil.Ctx,
+				client.ObjectKeyFromObject(&podList.Items[0]), freshPod)).Should(Succeed())
+			freshPod.Status.Phase = corev1.PodFailed
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, freshPod)).Should(Succeed())
+
+			// Verify the survivor pod is NOT deleted
+			Consistently(func() types.UID {
+				pod := &corev1.Pod{}
+				if err := testutil.K8sClient.Get(testutil.Ctx,
+					types.NamespacedName{Name: survivorName, Namespace: testNs}, pod); err != nil {
+					return ""
+				}
+				return pod.UID
+			}, 10*time.Second, interval).Should(Equal(survivorUID),
+				"survivor pod should NOT be deleted when wasInstanceReady=false and hasRecentRestart=false")
+		})
+
+		It("should not freeze rolling update when revision mismatch occurs during backoff", func() {
+			// When shouldRecreateInstance returns false due to
+			// CurrentRevision != UpdateRevision (rolling update in progress), the
+			// slow path in checkRestartBackoff must skip the backoff and return 0.
+			// Without the fix, the slow path computes backoff and returns a requeue,
+			// freezing all scaling until the backoff expires.
+			//
+			// The RoleInstance controller only watches RoleInstance and Pod (not
+			// RoleInstanceSet), so a spec change on the RBG doesn't directly trigger
+			// a RoleInstance reconcile. Instead, we simulate the revision mismatch
+			// by setting UpdateRevision in the RoleInstance status, which is what
+			// the controller would observe after a real spec change propagates.
+			rbgName := "test-backoff-rev-mismatch"
+			roleName := defaultRoleName
+
+			rbg := wrappersv2.BuildBasicRoleBasedGroup(rbgName, testNs).WithRoles(
+				[]workloadsv1alpha2.RoleSpec{
+					wrappersv2.BuildLeaderWorkerRole(roleName).
+						WithReplicas(1).
+						WithSize(1).
+						WithRestartPolicy(workloadsv1alpha2.RecreateRoleInstanceOnPodRestart).
+						WithBaseDelaySeconds(120).
+						WithMaxDelaySeconds(300).
+						Obj(),
+				}).Obj()
+
+			Expect(testutil.K8sClient.Create(testutil.Ctx, rbg)).Should(Succeed())
+
+			waitForPods(rbgName, roleName, 1)
+			makePodsReady(rbgName, roleName)
+			waitForRoleInstanceReady(rbgName, roleName)
+
+			// --- First crash: no backoff (RestartCount=0) ---
+			podList := listRolePods(rbgName, roleName)
+			firstUID := podList.Items[0].UID
+			freshPod := &corev1.Pod{}
+			Expect(testutil.K8sClient.Get(testutil.Ctx,
+				client.ObjectKeyFromObject(&podList.Items[0]), freshPod)).Should(Succeed())
+			freshPod.Status.Phase = corev1.PodFailed
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, freshPod)).Should(Succeed())
+
+			// Wait for first recreation
+			Eventually(func() bool {
+				podList := listRolePods(rbgName, roleName)
+				active := getActivePods(podList)
+				for _, p := range active {
+					if p.UID == firstUID {
+						return false
+					}
+				}
+				return len(active) >= 1
+			}, timeout, interval).Should(BeTrue())
+
+			// Recover
+			makePodsReady(rbgName, roleName)
+			waitForRoleInstanceReady(rbgName, roleName)
+
+			// Verify RestartCount=1
+			Eventually(func() int32 {
+				ri := getRoleInstance(rbgName, roleName)
+				if ri == nil {
+					return 0
+				}
+				return ri.Status.RestartCount
+			}, timeout, interval).Should(Equal(int32(1)))
+
+			// --- Second crash: backoff should be active (120s delay) ---
+			podList = listRolePods(rbgName, roleName)
+			secondUID := podList.Items[0].UID
+			Expect(testutil.K8sClient.Get(testutil.Ctx,
+				client.ObjectKeyFromObject(&podList.Items[0]), freshPod)).Should(Succeed())
+			freshPod.Status.Phase = corev1.PodFailed
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, freshPod)).Should(Succeed())
+
+			// Verify backoff is active: pod should NOT be recreated for 5s
+			Consistently(func() bool {
+				podList := listRolePods(rbgName, roleName)
+				for i := range podList.Items {
+					if podList.Items[i].UID == secondUID {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Second, interval).Should(BeTrue(),
+				"pod should NOT be recreated during backoff window")
+
+			// Simulate a revision mismatch by setting UpdateRevision to a different
+			// value. This triggers a reconcile where shouldRecreateInstance returns
+			// false (CurrentRevision != UpdateRevision). The slow path must skip
+			// the backoff (return 0) to allow replacement pod creation.
+			ri := getRoleInstance(rbgName, roleName)
+			Expect(ri).NotTo(BeNil())
+			ri.Status.UpdateRevision = "fake-revision-during-backoff"
+			Expect(testutil.K8sClient.Status().Update(testutil.Ctx, ri)).Should(Succeed())
+
+			// With the fix: slow path detects revision mismatch → returns 0
+			// → controller creates a replacement pod.
+			// Without the fix: slow path computes backoff (120s) → returns requeue
+			// → all scaling frozen, no replacement pod within 30s.
+			Eventually(func() int {
+				podList := listRolePods(rbgName, roleName)
+				return len(getActivePods(podList))
+			}, 30*time.Second, interval).Should(BeNumerically(">=", 1),
+				"replacement pod should be created when revision mismatch overrides backoff")
+		})
 	})
 })


### PR DESCRIPTION
## Summary

This PR addresses review feedback from #394 by improving the restart policy backoff feature across tests, bug fixes, documentation, and API validation:

- **Unit tests**: Add comprehensive unit test coverage for 4 core backoff functions (`syncRestartTrackingFromAPI`, `updateRestartTracking`,
`shouldRecreateInstance` bypass logic, `restartTrackingChanged`) and `checkRestartBackoff` branch paths that previously had zero test coverage
- **Bug fix**: Clear `restartingCache` on instance deletion (IsNotFound and DeletionTimestamp paths) to prevent stale cache entries from blocking newly
created instances with the same name
- **Examples**: Update all 7 v1alpha2 example YAMLs to use the new `restartPolicy` object format (`type:` field) instead of the old string format
- **API validation**: Add `+kubebuilder:default=30`/`+kubebuilder:default=600` annotations for `kubectl explain` and server-side apply support, plus CEL
 XValidation rule enforcing `maxDelaySeconds >= baseDelaySeconds`
- **Documentation**: Update `failure-handling.md` with Exponential Backoff section (formula, stability window, default behavior change, disable/custom
config), update `api.md` and best-practice docs to reflect the new object format
- **TODOs**: Mark two known issues with TODO comments — permanent `LastRestartTime` bypass, slow-path backoff bypasses rolling
update protections

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Tests | `instance_scale_test.go`, `instance_status_test.go` | +811 lines of unit tests for backoff core functions |
| Bug fix | `instance_reconciler.go`, `sync/api.go` | Clear `restartingCache` on instance deletion |
| Examples | 7 YAML files | Migrate `restartPolicy` from string to object format |
| API | `rolebasedgroup_types.go`, 3 CRD YAMLs | Add kubebuilder defaults and CEL validation |
| Docs | `failure-handling.md`, `api.md`, 2 best-practice docs | Document backoff behavior and update field references |
| TODOs | `instance_scale.go` | Mark two issue for future fixes |