### PR TITLE
chore: add rbg-inference-deploy agent skill and CLAUDE.md

### DIFF
--- a/.claude/skills/rbg-inference-deploy/SKILL.md
+++ b/.claude/skills/rbg-inference-deploy/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: rbg-inference-deploy
+description: Interactive wizard for deploying LLM inference services on Kubernetes using RoleBasedGroup (RBG). Guides users through prerequisites checks (k8s cluster, RBG installation, llmctl CLI), deployment configuration (engine, model, GPU, SLO), deployment pattern analysis, RBG YAML generation, deployment, testing, and benchmarking. Use when users want to deploy LLM/AI inference services with RBG, need help creating RBG deployment YAML, or want to configure SGLang/vLLM inference on Kubernetes.
+---
+
+# RBG Inference Deployment Wizard / RBG 推理服务部署向导
+
+## 🌐 Language / 语言
+
+**Default language: English.**
+
+Language switching rules:
+- Detect user's language from each message
+- If the user writes in **Chinese** (contains Chinese characters 一-鿿), switch to **Chinese** for ALL subsequent responses
+- If the user writes in **English**, switch to **English** for ALL subsequent responses
+- Apply consistently to: questions, tables, status messages, YAML comments, error messages, and all user-facing output
+- You may explicitly say: `"Switching to Chinese / 切换为中文"` when language changes
+
+---
+
+## Overview / 概述
+
+**EN**: An interactive wizard that guides you through end-to-end deployment of LLM inference services on Kubernetes via conversation. Executes in 5 sequential phases.
+
+**ZH**: 一个交互式向导，帮助用户通过对话完成 LLM 推理服务在 Kubernetes 上的端到端部署。分为 5 个阶段依次执行。
+
+**Before starting**: Read [prerequisites.md](prerequisites.md), [deployment-analysis.md](deployment-analysis.md), [yaml-rules.md](yaml-rules.md), [benchmark.md](benchmark.md) for full context.
+
+---
+
+## Phase 1: Prerequisites Check / 前置环境检查
+
+> Details: see [prerequisites.md](prerequisites.md)
+
+### 1.1 Check Kubernetes Cluster / 检查 Kubernetes 集群连通性
+
+```bash
+kubectl cluster-info 2>/dev/null
+kubectl get nodes 2>/dev/null
+```
+
+**Result handling / 结果处理**:
+- **Success / 成功**: proceed to 1.2
+- **Failed / 失败**:
+  - EN: "No reachable k8s cluster detected. Switching to Dry Run mode — YAML will be generated but not deployed."
+  - ZH: "未检测到可用 k8s 集群，将以 Dry Run 模式生成 YAML，无法真实部署。"
+  - Record `DRY_RUN=true`, skip 1.2, proceed to Phase 2
+
+### 1.2 Check RBG Controller / 检查 RBG Controller 是否已安装
+
+```bash
+kubectl get deployment rbgs-controller-manager -n rbgs-system 2>/dev/null
+kubectl get crd rolebasedgroups.workloads.x-k8s.io 2>/dev/null
+```
+
+**Result handling / 结果处理**:
+- **Installed & Ready / 已安装且 Ready**: proceed to 1.3
+- **Not installed / 未安装**: prompt user, ask whether to install now
+  - **Yes / 是**: run install flow (see [prerequisites.md](prerequisites.md) § RBG Installation)
+  - **No / 否**: record `DRY_RUN=true`, proceed to 1.3
+
+### 1.3 Check llmctl / 检查 llmctl 是否已安装
+
+```bash
+which llmctl 2>/dev/null || llmctl --help 2>/dev/null
+```
+
+**Result handling / 结果处理**:
+- **Installed / 已安装**: record `LLMCTL_AVAILABLE=true`, proceed to Phase 2
+- **Not installed / 未安装**: show the prompt below (in detected language), ask whether to install:
+
+  **EN prompt**:
+  > `llmctl` is the RBG inference extension CLI offering:
+  > - **Model management**: Auto-download from HuggingFace/ModelScope to PVC
+  > - **Auto-Benchmark**: Automated parameter search + SLO evaluation to find optimal config (tp_size, max_num_seqs, etc.)
+  > - **Benchmark**: One-click load testing with visual Dashboard
+  > - **Service management**: One-click deploy/list/delete
+  >
+  > **Without it**: Model path must be provided manually; deployment params will be estimated via Cookbook instead of empirically tuned.
+
+  **ZH prompt**:
+  > `llmctl` 是 RBG 的推理服务扩展 CLI，提供以下能力：
+  > - **模型管理**：从 HuggingFace/ModelScope 自动下载模型到 PVC
+  > - **Auto-Benchmark**：自动化参数搜索 + SLO 评估，找到最优部署方案
+  > - **Benchmark**：一键对已部署服务进行压测，可视化结果 Dashboard
+  > - **服务管理**：一键 deploy/list/delete 推理服务
+  >
+  > **不安装的影响**：模型需用户自行提供 PVC 路径；部署参数将通过引擎 Cookbook 估算而非实测调优。
+
+  - **Install / 选择安装**: run install (see [prerequisites.md](prerequisites.md) § llmctl installation), record `LLMCTL_AVAILABLE=true`
+  - **Skip / 暂不安装**: record `LLMCTL_AVAILABLE=false`, proceed to Phase 2
+
+---
+
+## Phase 2: Deployment Requirements / 部署需求采集
+
+> Ask one item at a time, confirm before proceeding / 逐步询问用户，每项确认后再进入下一项
+
+### 2.1 Namespace
+
+Ask for the target namespace (default: `default`). If cluster is reachable, check whether it exists; if not, ask whether to create it.
+
+> ZH: 询问目标 namespace（默认 `default`）。若集群可用，检查是否存在，不存在则询问是否自动创建。
+
+```bash
+kubectl get namespace <ns> 2>/dev/null || kubectl create namespace <ns>
+```
+
+### 2.2 Inference Engine & Image / 推理引擎 & 镜像
+
+Ask which inference engine to use / 询问使用哪种推理引擎：
+- **SGLang**: default image `lmsysorg/sglang:latest`, see recommended versions in [deployment-analysis.md](deployment-analysis.md)
+- **vLLM**: default image `vllm/vllm-openai:latest`, see recommended versions in [deployment-analysis.md](deployment-analysis.md)
+
+If the provided image tag is outdated (below minimum recommended version), suggest upgrading but do not block. / 若用户提供的镜像 tag 明显过旧，输出升级建议但不强制。
+
+### 2.3 Model / 模型
+
+Ask how the model will be provided / 询问模型获取方式：
+
+| Method / 方式 | Condition / 条件 | Action / 操作 |
+|------|------|------|
+| Existing PVC / 用户已有 PVC | Always / 始终可用 | Ask PVC name and model subpath / 询问 PVC 名称和模型子路径 |
+| HuggingFace/ModelScope ID | `LLMCTL_AVAILABLE=true` | Download via `llmctl model pull <model-id>` |
+| Manual model-path / 手动提供 | `LLMCTL_AVAILABLE=false` | Record model-path string (e.g. `Qwen/Qwen3-8B`, engine can download online) |
+
+Record: `MODEL_ID`, `MODEL_PATH_ARG` (container path or HF ID), `MODEL_PVC` (optional)
+
+### 2.4 Node Label, Taint & GPU Type / 节点 Label、Taint & GPU 型号
+
+Ask for the target node NodeSelector label, then **auto-detect GPU node Taints** / 询问目标节点 NodeSelector label，然后**自动检测 GPU 节点的 Taints**：
+
+```bash
+# 检测节点 label、GPU 数量、Taint
+kubectl get nodes -o json | jq -r '
+  .items[] |
+  select(.status.allocatable["nvidia.com/gpu"] != null) |
+  [.metadata.name,
+   (.status.allocatable["nvidia.com/gpu"]),
+   (.spec.taints // [] | map(.key+"="+(.value//"")+":"+.effect) | join("|"))
+  ] | @tsv'
+```
+
+Show node/GPU count/Taint to user for confirmation, and **record all Taints to `NODE_TAINTS`** for automatic toleration injection during YAML generation.
+
+> ZH: 展示节点/GPU数/Taint，让用户确认，并**记录所有 Taint 到 `NODE_TAINTS` 列表**，后续 YAML 生成时自动写入 tolerations。
+
+Ask for GPU type (for SLO estimation) / 询问 GPU 型号（用于 SLO 估算）。
+
+### 2.5 Resource Budget & SLO / 资源预算 & SLO 要求
+
+Ask / 询问：
+- Max total GPU count / 最多使用 GPU 总数
+- TTFT P99 requirement (ms, e.g. 2000) / TTFT P99 要求
+- TPOT P99 requirement (ms, e.g. 50) / TPOT P99 要求
+- Expected concurrent requests (optional) / 预期并发请求数（可选）
+
+---
+
+## Phase 3: Deployment Plan Analysis / 方案分析与推荐
+
+> Details: see [deployment-analysis.md](deployment-analysis.md)
+
+### 3.1 Memory Feasibility Estimation / 显存可行性估算
+
+Estimate minimum GPU count based on model size + GPU type (see [deployment-analysis.md](deployment-analysis.md) § Memory estimation), compare with user budget:
+
+- **Budget sufficient / 预算充足**: continue
+- **Budget insufficient / 预算不足**: warn user, suggest smaller model or increase budget, ask whether to continue
+
+### 3.2 SLO Feasibility Assessment / SLO 可行性评估
+
+Estimate SLO achievability based on GPU type + model size + community Cookbook data (see [deployment-analysis.md](deployment-analysis.md) § SLO reference).
+
+### 3.3 Deployment Plan Selection / 部署方案获取
+
+Ask user to choose one of three options / 询问用户选择三种方式之一：
+
+**Option A / 选项 A: User-provided / 用户自行提供**
+- Ask whether to use PD disaggregation / 询问是否采用 PD 分离
+- If yes: ask Prefill replicas/tp-size, Decode replicas/tp-size, whether Router is needed
+- If no: ask backend replicas/tp-size
+- Ask extra launch flags (e.g. `--mem-fraction-static`, `--max-running-requests`)
+
+**Option B / 选项 B: llmctl Auto-Benchmark** (requires `LLMCTL_AVAILABLE=true` and cluster available)
+- See [deployment-analysis.md](deployment-analysis.md) § Auto-Benchmark
+- Run autobenchmark, wait, parse results
+
+**Option C / 选项 C: Cookbook Estimation / Cookbook 估算** (default / 默认)
+- See [deployment-analysis.md](deployment-analysis.md) § Cookbook reference
+- Look up recommended config by engine/model/GPU type
+
+### 3.4 Plan Confirmation / 方案确认
+
+Display deployment plan summary in a table; user can adjust via conversation until confirmed / 以表格形式展示最终部署方案，用户可调整直到确认：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      部署方案摘要                            │
+```
+┌─────────────────┬───────────────────────────────────────────────┐
+│ Architecture    │ PD Disaggregated / Aggregated                 │
+│ Engine          │ SGLang / vLLM                                  │
+│ Image           │ lmsysorg/sglang:v0.4.6.post4                  │
+│ Model           │ Qwen/Qwen3-8B                                  │
+├─────────────────┼───────────────────────────────────────────────┤
+│ Router          │ replicas=1, standalone, CPU-only               │
+│ Prefill         │ replicas=2, tp-size=4 (8 GPU total)            │
+│ Decode          │ replicas=4, tp-size=2 (8 GPU total)            │
+├─────────────────┼───────────────────────────────────────────────┤
+│ Total GPU       │ 16                                             │
+│ Est. TTFT       │ ~800ms P99                                     │
+│ Est. TPOT       │ ~40ms P99                                      │
+└─────────────────┴───────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 4: RBG YAML Generation / RBG YAML 生成与配置
+
+> YAML generation rules: see [yaml-rules.md](yaml-rules.md)
+
+### 4.1 Generate Base YAML / 生成基础 YAML
+
+Generate RBG YAML based on confirmed deployment plan, following these rules / 根据确认的部署方案生成 RBG YAML，遵循以下规则：
+
+**roleTemplates conditions** (all must be met) / **roleTemplates 适用条件**（全部满足才使用）：
+- Multiple roles share the same image **and** / 多角色共用相同镜像 **且**
+- **No Taints on target nodes** (`NODE_TAINTS` is empty) / **目标节点无 Taint**（`NODE_TAINTS` 为空）
+- If Taints exist, **must use direct `template`** (not `templateRef`) — tolerations are silently dropped by RBG controller when going through templateRef (verified in source code)
+  / 若有 Taint，必须用直接 `template`，否则 tolerations 不会被 RBG controller 写入 Pod（已通过源码确认）
+
+**Other rules / 其他规则**:
+- leaderWorkerPattern: inject `$(RBG_LWP_LEADER_ADDRESS)` etc.
+- PD disaggregated Router address: use auto-generated Headless Service DNS
+- **Do NOT write `initContainers: []` in patch** (causes unintended override)
+
+### 4.2 Configure Extra Features / 配置额外功能
+
+Ask user whether to enable each optional feature (with explanation) / 依次询问是否启用以下功能（给出说明）：
+
+**4.2.1 In-Place Update / 原地升级**（recommended / 推荐开启）
+> EN: Image updates replace containers without recreating Pods, preserving GPU memory state.
+> ZH: 镜像更新时原地替换容器而不重建 Pod，保留 GPU 显存状态，升级更快更稳定。
+
+```yaml
+rolloutStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    type: InPlaceIfPossible
+    maxUnavailable: 1
+    inPlaceUpdateStrategy:
+      gracePeriodSeconds: 30
+```
+
+**4.2.2 CoordinatedPolicy / 协调策略**
+> EN: Cross-role coordinated rolling update to prevent Prefill/Decode upgrade skew from causing service instability. Requires a separate `CoordinatedPolicy` CR.
+> ZH: 多角色联合控制升级进度，防止 Prefill/Decode 升级进度偏差过大导致服务抖动。需要创建独立的 `CoordinatedPolicy` CR。
+
+**4.2.3 Gang Scheduling / Gang 调度**（Volcano）
+> EN: Atomic scheduling for all Pods, prevents deadlock when partial GPUs are allocated but others can't be scheduled. Recommended for large TP sizes.
+> ZH: 所有 Pod 原子性调度，适合大规模张量并行。
+> Annotation: `rbg.workloads.x-k8s.io/scheduling-backend: volcano`
+
+**4.2.4 ScalingAdapter / 弹性伸缩**
+> EN: Automatically creates `RoleBasedGroupScalingAdapter` CR compatible with HPA for autoscaling.
+> ZH: 自动创建弹性伸缩适配器，支持与 HPA 联动。
+> Field: `scalingAdapter.enable: true`
+
+**4.2.5 RestartPolicy** (leaderWorkerPattern only)
+> `RecreateRoleInstanceOnPodRestart` (default): Recreate entire instance group on any Pod failure
+> `None`: Do not handle Pod restart (for fault-tolerant frameworks)
+
+### 4.3 YAML Preview & Confirm / YAML 预览与确认
+
+Show user the complete final YAML (RBG + CoordinatedPolicy if any), allow adjustments via conversation until confirmed / 展示完整的最终 YAML，用户可通过对话调整直到确认。
+
+---
+
+## Phase 5: Deploy, Verify & Test / 部署、验证与测试
+
+### 5.1 Deployment Decision / 部署决策
+
+Ask user / 询问用户：
+- **Deploy directly / 直接部署**: `kubectl apply -f <yaml>` → run 5.2
+- **Save YAML / 保存 YAML**: ask for save path, write file and end
+
+### 5.2 Execute Deployment / 执行部署
+
+```bash
+# Create namespace if needed / 若 namespace 需要创建
+kubectl create namespace <ns> --dry-run=client -o yaml | kubectl apply -f -
+
+# Deploy RBG / 部署 RBG
+kubectl apply -f rbg-deployment.yaml -n <ns>
+```
+
+### 5.3 Wait for Ready + Smart Diagnosis / 等待 Ready + 智能诊断
+
+Poll every 15s, show readyReplicas per role / 每 15 秒轮询一次，展示各角色 readyReplicas：
+```bash
+kubectl get rbg <name> -n <ns> -o wide
+kubectl get pods -n <ns> -o wide
+```
+
+**If Pod stays Pending > 60s, run diagnosis immediately / 若 Pod 持续 Pending 超过 60 秒，立即执行诊断**：
+
+```bash
+# 获取 Pending Pod 的调度失败原因
+kubectl describe pod <pending-pod> -n <ns> | grep -A 10 'Events:'
+```
+
+Map error keywords to actions (respond in user's language) / 根据关键词给出对应处理建议：
+
+| Error keyword | Cause / 原因 | Suggestion / 建议 |
+|-----------|------|------|
+| `untolerated taint` | Pod missing taint toleration / Pod 没有对应污点容忍 | Check and fill tolerations in template.spec / 检查并补全 tolerations |
+| `Insufficient nvidia.com/gpu` | GPU resources exhausted / GPU 资源不足 | Reduce replicas or wait / 减少副本数或等待资源 |
+| `didn't match node affinity` | nodeSelector mismatch / nodeSelector 不匹配 | Verify node labels / 检查节点 label |
+| `no nodes available` | No schedulable nodes / 无可调度节点 | Check node status and resources / 检查节点状态和资源 |
+
+**If Pod is ImagePullBackOff / 若 Pod 为 ImagePullBackOff**:
+```bash
+kubectl describe pod <pod> -n <ns> | grep -A 5 'Failed\|Back-off'
+```
+Prompt user to verify image tag and registry network access / 提示用户检查镜像 tag 是否正确、网络是否可以访问镜像仓库。
+
+**Wait for full readiness (timeout 10 min) / 等待完全就绪**（超时 10 分钟）：
+```bash
+kubectl wait rbg/<name> -n <ns> --for=condition=Ready --timeout=600s
+```
+
+### 5.4 Smoke Test / 冒烟测试
+
+Port-forward and run a quick test / port-forward 并进行快速测试：
+
+```bash
+# For PD disaggregated: forward Router / 对于 PD 分离：转发 Router
+kubectl port-forward svc/s-<rbg-name>-router -n <ns> 8000:8000
+
+# Health check / 健康检查
+curl http://localhost:8000/health
+
+# Quick inference test / 快速推理测试
+curl -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "<MODEL_ID>", "prompt": "Hello", "max_tokens": 20}'
+```
+
+Report result to user in detected language / 向用户报告测试结果。
+
+### 5.5 Benchmark (Optional) / 性能压测（可选）
+
+Ask whether to run benchmark / 询问是否进行 Benchmark 测试：
+
+- **Yes / 是**（`LLMCTL_AVAILABLE=true`）: see [benchmark.md](benchmark.md) for full benchmark workflow
+- **No / 否**: End of wizard / 向导结束
+
+Use `llmctl benchmark run` to generate a visual report / 执行 `llmctl benchmark run` 并生成可视化报告。
+
+---
+
+## Execution Notes / 执行注意事项
+
+1. **Always confirm before executing / 始终确认再执行**: Show command to user before any cluster-modifying operation
+2. **Preserve context / 保留上下文**: Record all confirmed options (`DRY_RUN`, `LLMCTL_AVAILABLE`, `NS`, `ENGINE`, `MODEL`, etc.), avoid re-asking
+3. **Graceful degradation / 友好降级**: If a step fails, offer fallback (e.g. switch from autobenchmark to Cookbook estimation)
+4. **Dry Run mode / Dry Run 模式**: When `DRY_RUN=true`, all kubectl commands use `--dry-run=client` or generate YAML only
+5. **Language consistency / 语言一致性**: Respond entirely in detected language; never mix languages within a single response

--- a/.claude/skills/rbg-inference-deploy/benchmark.md
+++ b/.claude/skills/rbg-inference-deploy/benchmark.md
@@ -1,0 +1,192 @@
+# Benchmark 指南
+
+## 概述
+
+部署完成后，可通过 `llmctl benchmark` 对推理服务进行压测，评估真实性能。
+
+---
+
+## 前置准备
+
+### 创建 Benchmark 输出 PVC
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: benchmark-output
+  namespace: <namespace>
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+EOF
+```
+
+> **注意**：PVC 需支持 `ReadWriteMany`（如 NFS、OSS、CephFS 等），不支持 ReadWriteOnce（如本地 hostPath）。若集群无 RWX PVC，请告知用户需要先创建合适的存储资源。
+
+---
+
+## 参数采集
+
+向用户询问以下 Benchmark 参数：
+
+| 参数 | 说明 | 默认值 | 示例 |
+|------|------|--------|------|
+| `--model-tokenizer` | 模型 tokenizer（HF ID 或 PVC 路径） | 必填 | `Qwen/Qwen3-8B` |
+| `--traffic-scenario` | 流量场景（可多个） | 推荐 `D(512,256)` | `D(100,1000)` `D(500,500)` |
+| `--num-concurrency` | 并发数列表 | `1,2,4,8` | `1,4,8,16` |
+| `--max-time-per-run` | 每次测试最大时间（分钟） | `15` | `10` |
+| `--max-requests-per-run` | 每次最大请求数 | `100` | `500` |
+
+**流量场景格式说明**：
+- `D(input_tokens, output_tokens)`：固定输入输出 token 数
+- 例如 `D(512, 256)` = 输入 512 tokens，输出 256 tokens
+
+**常见测试组合**：
+```
+短输入短输出：D(128,128)
+短输入长输出：D(128,1024)
+长输入短输出：D(1024,128)
+代码生成场景：D(512,512)
+长文档摘要：D(2048,256)
+```
+
+---
+
+## 运行 Benchmark
+
+```bash
+# 基础运行
+llmctl benchmark run <rbg-name> \
+  --model-tokenizer <model-id> \
+  --experiment-base-dir pvc://benchmark-output/rbg-benchmark \
+  --traffic-scenario "D(512,256)" \
+  --num-concurrency 1,2,4,8
+
+# 多场景运行
+llmctl benchmark run <rbg-name> \
+  --model-tokenizer <model-id> \
+  --experiment-base-dir pvc://benchmark-output/rbg-benchmark \
+  --traffic-scenario "D(128,128)" \
+  --traffic-scenario "D(512,256)" \
+  --traffic-scenario "D(1024,128)" \
+  --num-concurrency 1,4,8,16 \
+  --max-time-per-run 10
+
+# 同步等待完成（实时输出日志）
+llmctl benchmark run <rbg-name> \
+  --model-tokenizer <model-id> \
+  --experiment-base-dir pvc://benchmark-output/rbg-benchmark \
+  --traffic-scenario "D(512,256)" \
+  --num-concurrency 1,4,8 \
+  --wait
+```
+
+### 使用 YAML 配置文件
+
+```yaml
+# benchmark-config.yaml
+modelTokenizer: <model-id>
+experimentBaseDir: pvc://benchmark-output/rbg-benchmark
+trafficScenarios:
+  - "D(128,128)"
+  - "D(512,256)"
+  - "D(1024,128)"
+numConcurrency:
+  - 1
+  - 4
+  - 8
+  - 16
+maxTimePerRun: 10
+maxRequestsPerRun: 300
+```
+
+```bash
+llmctl benchmark run <rbg-name> -f benchmark-config.yaml
+```
+
+---
+
+## 查看结果
+
+### 命令行查看
+
+```bash
+# 列出所有 Benchmark Job
+llmctl benchmark list <rbg-name>
+
+# 查看 Job 日志
+llmctl benchmark logs <rbg-name> --job <job-name>
+
+# 不 follow（查看历史日志）
+llmctl benchmark logs <rbg-name> --job <job-name> -f=false
+
+# 查看 Job 配置
+llmctl benchmark get <rbg-name> --job <job-name>
+```
+
+### Web Dashboard
+
+```bash
+# 启动 Dashboard（自动 port-forward 并打开浏览器）
+llmctl benchmark dashboard \
+  --experiment-base-dir pvc://benchmark-output/rbg-benchmark
+
+# 指定本地端口
+llmctl benchmark dashboard \
+  --experiment-base-dir pvc://benchmark-output/rbg-benchmark \
+  --port 18888
+```
+
+Dashboard 提供：
+- 各场景的 TTFT/TPOT/吞吐量 P50/P90/P99 指标
+- 不同并发数下的性能曲线
+- 与 SLO 目标的对比
+
+---
+
+## 结果解读
+
+### 关键指标
+
+| 指标 | 说明 | SLO 对应 |
+|------|------|---------|
+| TTFT (Time To First Token) | 首 token 延迟 | `ttftP99MaxMs` |
+| TPOT (Time Per Output Token) | 每输出 token 延迟 | `tpotP99MaxMs` |
+| Output Throughput | 输出 token/秒 | 吞吐量目标 |
+| Error Rate | 错误率 | 通常要求 < 1% |
+
+### 性能调优建议
+
+**TTFT 过高**（超过目标 TTFT）：
+- 考虑 PD 分离（降低 Prefill 阶段等待时间）
+- 增加 Prefill 实例数
+- 降低 `--max-running-requests` / `--max-num-seqs`（减少排队）
+
+**TPOT 过高**（超过目标 TPOT）：
+- 增加 Decode 实例数
+- 调整 `--mem-fraction-static` 增加 KV Cache 空间
+- 检查 GPU 显存是否充足（避免 KV Cache 溢出）
+
+**吞吐量不足**：
+- 增加 replicas
+- 启用 ScalingAdapter + HPA 自动扩容
+- 提高 `--max-running-requests` / `--max-num-seqs`
+
+**Error Rate 过高**：
+- 检查 OOM（增加显存或减小 batch size）
+- 检查 context length 是否超限
+- 查看 Pod 日志排查具体错误
+
+---
+
+## 清理
+
+```bash
+# 删除 Benchmark Job
+llmctl benchmark delete <rbg-name> --job <job-name>
+```

--- a/.claude/skills/rbg-inference-deploy/deployment-analysis.md
+++ b/.claude/skills/rbg-inference-deploy/deployment-analysis.md
@@ -1,0 +1,270 @@
+# 部署方案分析
+
+## 引擎版本建议
+
+通过引擎官方发布页判断用户镜像版本是否过旧。若用户提供的版本明显落后，输出建议但不阻断流程。
+
+| 引擎 | 官方文档 | 推荐镜像获取方式 |
+|------|----------|-----------------|
+| SGLang | https://docs.sglang.ai / https://github.com/sgl-project/sglang/releases | `docker pull lmsysorg/sglang:latest` |
+| vLLM | https://docs.vllm.ai / https://github.com/vllm-project/vllm/releases | `docker pull vllm/vllm-openai:latest` |
+
+**建议升级场景**：
+- 用户 tag 为 `latest` 但实际 digest 已超过 6 个月
+- 用户 tag 版本号低于 GitHub releases 最新版 2 个以上 minor 版本
+- 用户使用 `v0.x.x` 且当前已发布 `v0.(x+3)` 以上
+
+若需检查版本，可访问：
+- SGLang: `curl -s https://api.github.com/repos/sgl-project/sglang/releases/latest | jq .tag_name`
+- vLLM: `curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq .tag_name`
+
+---
+
+## 显存估算公式
+
+### 模型权重显存（粗估）
+
+| 精度 | 每 10 亿参数显存 |
+|------|-----------------|
+| FP16 / BF16 | ~2 GB |
+| INT8 | ~1 GB |
+| INT4 / AWQ / GPTQ | ~0.5 GB |
+
+**公式**：`model_vram_GB = params_B × per_param_GB`
+
+### 总显存需求（含 KV Cache）
+
+| 用途 | 估算 |
+|------|------|
+| 模型权重 | 见上表 |
+| KV Cache | 约为模型权重的 20%~50%（取决于 batch size 和 context length） |
+| 框架开销 | 约 1~2 GB |
+
+**最低 GPU 数 = ceil(总显存需求 / 单卡显存 × 1.15)**（15% 安全冗余）
+
+### 常见模型 + 常见 GPU 最少卡数参考
+
+| 模型参数量 | GPU 型号 | 精度 | 最少卡数 |
+|-----------|---------|------|---------|
+| 7B | A100 80G | BF16 | 1 |
+| 7B | L20 48G | BF16 | 1 |
+| 7B | A10 24G | BF16 | 1（紧张） |
+| 13B | A100 80G | BF16 | 1 |
+| 14B | L20 48G | BF16 | 1（需开 kv cache 量化） |
+| 32B | A100 80G | BF16 | 1（紧张）/ 2（推荐） |
+| 32B | L20 48G | BF16 | 2 |
+| 70B | A100 80G | BF16 | 2 |
+| 70B | H100 80G | BF16 | 2 |
+| 72B | A100 80G | BF16 | 2 |
+| 235B (MoE) | H100 80G | BF16 | 4~8 |
+
+> **注意**：以上为粗估，实际需结合 batch size、context length、框架 overhead 综合判断。
+
+---
+
+## SLO 参考数据
+
+> 以下数据来自社区测试，仅供初步评估参考，实际结果因集群环境、负载分布差异较大。
+
+### SGLang 参考（单实例，`--tp-size` 对应卡数）
+
+| 模型 | GPU | tp-size | TTFT P99 参考 | TPOT P99 参考 | 并发 |
+|------|-----|---------|--------------|--------------|------|
+| Qwen3-7B | A100 80G | 1 | ~300ms | ~20ms | 32 |
+| Qwen3-14B | A100 80G | 1 | ~500ms | ~30ms | 16 |
+| Qwen3-32B | A100 80G | 2 | ~800ms | ~40ms | 8 |
+| Qwen3-72B | A100 80G | 2 | ~1500ms | ~60ms | 4 |
+| Llama-3-8B | A100 80G | 1 | ~250ms | ~15ms | 32 |
+
+> **评估逻辑**：若用户 SLO 要求低于参考 TTFT 的 50%，建议增加实例数（replicas）而非张量并行度，或使用 PD 分离降低 Prefill 阶段延迟。
+
+---
+
+## Cookbook 参考
+
+### SGLang 官方部署建议
+
+参考：https://docs.sglang.ai/backend/server_arguments.html
+
+**关键参数**：
+- `--tp-size N`：张量并行度，等于实例内 GPU 数
+- `--mem-fraction-static F`：静态显存比例（默认 0.88），控制 KV Cache 空间
+- `--max-running-requests N`：最大并发请求数
+- `--chunked-prefill-size N`：Chunked Prefill 大小（建议 4096~8192）
+- `--disable-radix-cache`：关闭 Radix Cache（节省显存但降低命中率）
+
+**PD 分离额外参数**：
+- Prefill 角色：`--disaggregation-mode prefill`
+- Decode 角色：`--disaggregation-mode decode`
+
+**常见优化组合**：
+```bash
+# 高吞吐场景（牺牲延迟）
+--mem-fraction-static 0.92 --max-running-requests 512
+
+# 低延迟场景（牺牲吞吐）
+--mem-fraction-static 0.80 --max-running-requests 32 --chunked-prefill-size 4096
+```
+
+### vLLM 官方部署建议
+
+参考：https://docs.vllm.ai/en/stable/serving/engine_args.html
+
+**关键参数**：
+- `--tensor-parallel-size N`：张量并行度
+- `--gpu-memory-utilization F`：GPU 显存利用率（默认 0.90）
+- `--max-num-seqs N`：最大并发序列数
+- `--max-model-len N`：最大上下文长度
+- `--enforce-eager`：关闭 CUDA graph（节省显存）
+
+**vLLM 启动命令**：
+```bash
+python3 -m vllm.entrypoints.openai.api_server \
+  --model /models/Qwen3-8B \
+  --tensor-parallel-size 2 \
+  --gpu-memory-utilization 0.90 \
+  --max-num-seqs 256 \
+  --port 8000
+```
+
+---
+
+## Auto-Benchmark 流程
+
+> 需要 `LLMCTL_AVAILABLE=true` 且集群可用，且已有 RBG 部署（或先用 Cookbook 初始部署）
+
+### 准备 Benchmark 输出 PVC
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: benchmark-output
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+EOF
+```
+
+### 生成 Auto-Benchmark 配置
+
+根据用户的 SLO 要求和模型信息，生成如下配置文件（`autobench-config.yaml`）：
+
+```yaml
+name: <rbg-name>-autobench
+
+# 部署模板（引用用户生成的 RBG YAML 作为模板）
+templates:
+  - name: baseline
+    template: ./rbg-deployment.yaml
+
+backend: sglang  # 或 vllm
+
+# 搜索空间（根据 GPU 数量和模型大小调整）
+searchSpace:
+  default:
+    # 搜索最优的 max_num_seqs / max-running-requests
+    maxNumSeqs:
+      type: categorical
+      values: [64, 128, 256, 512]
+    # 若需要，搜索显存分配比例
+    # gpuMemoryUtilization:
+    #   type: categorical
+    #   values: [0.85, 0.90, 0.95]
+
+# 基准测试场景
+scenario:
+  name: <workload-name>
+  workload: "normal(512,256/256,128)"  # 或根据用户业务调整
+  concurrency: 8
+  maxRequests: 500
+
+# SLO 目标
+objectives:
+  sla:
+    ttftP99MaxMs: <用户提供的 TTFT 要求>
+    tpotP99MaxMs: <用户提供的 TPOT 要求>
+    errorRateMax: 0.01
+  optimize: outputThroughput  # 在满足 SLO 前提下最大化吞吐
+
+# 搜索策略
+strategy:
+  algorithm: tpe   # Optuna TPE 算法，自动高效搜索
+  maxTrialsPerTemplate: 10
+
+evaluator:
+  type: inference-perf
+  config:
+    tokenizerSource: <model-id>
+    baseSeed: 42
+    apiType: completion
+    streaming: true
+
+results:
+  pvc: benchmark-output
+  subPath: <rbg-name>-autobench
+```
+
+### 运行 Auto-Benchmark
+
+```bash
+# 运行 autobenchmark（异步，返回 job name）
+llmctl autobenchmark run autobench-config.yaml
+
+# 或等待完成
+llmctl autobenchmark run autobench-config.yaml --wait
+
+# 查看进度
+llmctl autobenchmark list
+
+# 查看日志
+llmctl autobenchmark logs <job-name>
+```
+
+### 查看结果
+
+```bash
+# 启动 Dashboard 查看可视化结果
+llmctl autobenchmark dashboard \
+  --experiment-base-dir pvc://benchmark-output/<rbg-name>-autobench
+```
+
+### 解析最优参数
+
+Auto-Benchmark 完成后，从结果中提取满足 SLO 的最优参数组合（在满足 TTFT/TPOT P99 约束下，outputThroughput 最高的参数组合），更新到 RBG YAML 的容器启动参数中。
+
+---
+
+## 部署架构决策树
+
+```
+用户有 GPU 预算 N 张
+│
+├─ N < 最少卡数 → 警告：建议换小模型或增加预算
+│
+├─ 模型 > 单卡显存
+│   └─ 使用 leaderWorkerPattern，tp-size = ceil(model_vram / gpu_vram)
+│
+├─ 模型 ≤ 单卡显存
+│   └─ 使用 standalonePattern
+│
+├─ 用户有 SLO 要求 AND N 足够分离
+│   ├─ 对 TTFT 要求严格（<500ms P99）→ 考虑 PD 分离（Prefill 减少排队延迟）
+│   └─ 对吞吐量要求高 → 多副本 + scalingAdapter + HPA
+│
+└─ 简单场景 → 聚合部署（单角色）
+```
+
+### PD 分离典型比例参考
+
+| 场景 | Prefill 实例 | Decode 实例 | Prefill tp-size | Decode tp-size |
+|------|-------------|------------|----------------|----------------|
+| 低延迟优先 | 1 | 2~4 | = model min GPU | = model min GPU |
+| 高吞吐优先 | 1 | 6~8 | 大（减少队列）| 小（增加并行） |
+| 均衡 | 2 | 4 | 2 | 2 |
+
+> **经验法则**：Decode 实例数通常是 Prefill 的 2~4 倍（Decode 阶段是内存带宽瓶颈，多副本效果好）。

--- a/.claude/skills/rbg-inference-deploy/prerequisites.md
+++ b/.claude/skills/rbg-inference-deploy/prerequisites.md
@@ -1,0 +1,166 @@
+# 前置检查详情
+
+## RBG 安装
+
+### 方式一：Helm（推荐）
+
+```bash
+# 安装最新发布版
+VERSION=$(curl -sL https://api.github.com/repos/sgl-project/rbg/releases/latest \
+  | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+
+helm upgrade --install rbgs \
+  https://github.com/sgl-project/rbg/releases/download/v${VERSION}/rbgs-${VERSION}.tgz \
+  --namespace rbgs-system \
+  --create-namespace \
+  --wait
+
+# 验证安装
+kubectl wait deploy/rbgs-controller-manager -n rbgs-system \
+  --for=condition=available --timeout=5m
+```
+
+### 方式二：本地源码（开发环境）
+
+```bash
+# 若在 rbg 项目目录下
+helm upgrade --install rbgs deploy/helm/rbgs \
+  --create-namespace \
+  --namespace rbgs-system \
+  --wait
+```
+
+### 验证安装成功
+
+```bash
+kubectl get crd rolebasedgroups.workloads.x-k8s.io
+kubectl get deploy rbgs-controller-manager -n rbgs-system
+# 期望输出：AVAILABLE=1
+```
+
+---
+
+## llmctl 安装
+
+### 方式一：从源码构建（推荐）
+
+```bash
+git clone https://github.com/rolebasedgroup/inference-ext-cli.git
+cd inference-ext-cli
+
+# 构建当前平台的 CLI binary
+make build-cli
+
+# 安装到系统 PATH
+make install       # 安装到 $GOPATH/bin
+# 或
+chmod +x llmctl
+sudo mv llmctl /usr/local/bin/
+```
+
+> **前提**：需要 Go 1.26+，可通过 `go version` 检查
+
+### 验证安装成功
+
+```bash
+llmctl --help
+# 期望输出显示 service/model/benchmark 等子命令
+```
+
+### 初始化配置
+
+安装后需要配置存储和数据源才能使用模型下载功能：
+
+```bash
+# 交互式向导（推荐）
+llmctl config init
+
+# 或手动配置
+# 配置 HuggingFace 数据源
+llmctl config add-source huggingface --type huggingface --config token=hf_xxx
+
+# 配置 ModelScope 数据源
+llmctl config add-source modelscope --type modelscope --config token=<token>
+
+# 配置 PVC 存储（需要集群中已存在的 PVC）
+llmctl config add-storage my-models --type pvc --config pvcName=model-pvc
+
+# 查看配置
+llmctl config view
+```
+
+---
+
+## 模型下载
+
+> 需要 `LLMCTL_AVAILABLE=true` 且集群可用
+
+### 下载模型到 PVC
+
+```bash
+# 交互式（先执行 config init 完成存储/数据源配置）
+llmctl model pull Qwen/Qwen3-8B
+
+# 指定来源和存储
+llmctl model pull Qwen/Qwen3-8B \
+  --source huggingface \
+  --storage my-models
+
+# 不等待完成（异步）
+llmctl model pull Qwen/Qwen3-8B --wait=false
+```
+
+### 查看已下载的模型
+
+```bash
+llmctl model list
+llmctl model list --storage my-models
+```
+
+### 在 RBG YAML 中使用已下载的模型
+
+```yaml
+# 容器中挂载 PVC
+volumes:
+  - name: model-storage
+    persistentVolumeClaim:
+      claimName: model-pvc
+containers:
+  - name: engine
+    volumeMounts:
+      - name: model-storage
+        mountPath: /models
+    command:
+      - python3
+      - -m
+      - sglang.launch_server
+      - --model-path
+      - /models/Qwen/Qwen3-8B   # PVC 挂载路径
+```
+
+---
+
+## 节点 GPU 检查命令参考
+
+```bash
+# 列出所有 GPU 节点
+kubectl get nodes -l nvidia.com/gpu -o wide
+
+# 按 label 过滤节点
+kubectl get nodes -l <node-selector-key>=<value> \
+  -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable."nvidia\.com/gpu"
+
+# 查看节点详细信息（包括 GPU 型号 label）
+kubectl describe node <node-name> | grep -E "nvidia.com/gpu|Labels"
+
+# 统计可用 GPU 总数
+kubectl get nodes -l <selector> -o json | \
+  jq '[.items[].status.allocatable["nvidia.com/gpu"] | tonumber] | add'
+
+# 检查常见 GPU 型号 label（NVIDIA Device Plugin 注入）
+# nvidia.com/gpu.product: A100-SXM4-80GB
+# nvidia.com/gpu.product: H100-SXM5-80GB
+# nvidia.com/gpu.product: Tesla-V100-SXM2-32GB
+kubectl get nodes -o json | \
+  jq '.items[] | {name:.metadata.name, gpu_product:.metadata.labels["nvidia.com/gpu.product"]}'
+```

--- a/.claude/skills/rbg-inference-deploy/yaml-rules.md
+++ b/.claude/skills/rbg-inference-deploy/yaml-rules.md
@@ -1,0 +1,577 @@
+# RBG YAML 生成规则
+
+## 核心原则
+
+1. **roleTemplates 仅适用于无 Taint 节点**：多角色共用相同镜像且目标节点无 Taint 时，才提取公共部分到 `spec.roleTemplates`，各角色通过 `templateRef` 引用并用 `patch` 差异化。
+2. **有 Taint 时必须用直接 `template`**：`tolerations` 字段**无法**通过 `templateRef.patch` 传递到 Pod（RBG controller 已知行为限制，已通过源码验证）。只要节点有 Taint，该角色必须使用直接 `template`，在 `spec.tolerations` 中显式写入容忍规则。
+3. **templateRef.patch 必须设置**：即使无覆盖也需设置为 `patch: {}`。
+4. **templateRef 与 template 互斥**：一个角色只能选其一。
+5. **PD 分离时 Router DNS 地址由 RBG 自动生成**，格式见下方。
+6. **patch 中禁止写 `initContainers: []`**，会覆盖 base 模板中的 initContainers 导致意外行为。
+
+---
+
+## API 版本与 Kind
+
+```yaml
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: <rbg-name>
+  namespace: <namespace>
+  labels:
+    app: <app-label>
+```
+
+---
+
+## DNS 命名规则
+
+RBG Controller 为每个 Role 自动创建 Headless Service，DNS 格式：
+
+```
+{rbgName}-{roleName}-{ordinal}.s-{rbgName}-{roleName}.{namespace}.svc.cluster.local
+```
+
+**示例**（RBG name=`pd-inference`，namespace=`default`）：
+- Prefill 实例 0：`pd-inference-prefill-0.s-pd-inference-prefill.default.svc.cluster.local`
+- Decode 实例 0：`pd-inference-decode-0.s-pd-inference-decode.default.svc.cluster.local`
+
+在 Router 启动参数中可省略 namespace 后缀（同 namespace 内）：
+```
+http://pd-inference-prefill-0.s-pd-inference-prefill:8000
+```
+
+---
+
+## 模式一：聚合单卡（standalonePattern）
+
+```yaml
+spec:
+  roles:
+    - name: backend
+      replicas: <N>
+      standalonePattern:
+        template:
+          spec:
+            containers:
+              - name: engine
+                image: lmsysorg/sglang:<tag>
+                command:
+                  - python3
+                  - -m
+                  - sglang.launch_server
+                  - --model-path
+                  - "<model-path>"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                  - --tp-size
+                  - "1"
+                  # 追加用户额外参数
+                ports:
+                  - name: http
+                    containerPort: 8000
+                resources:
+                  requests:
+                    nvidia.com/gpu: "1"
+                  limits:
+                    nvidia.com/gpu: "1"
+                volumeMounts:
+                  - name: dshm
+                    mountPath: /dev/shm
+            volumes:
+              - name: dshm
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 30Gi
+```
+
+---
+
+## 模式二：聚合张量并行（leaderWorkerPattern）
+
+```yaml
+spec:
+  roles:
+    - name: backend
+      replicas: <N>
+      leaderWorkerPattern:
+        size: <TP_SIZE>        # 1 Leader + (TP_SIZE-1) Workers
+        restartPolicy: RecreateRoleInstanceOnPodRestart
+        template:
+          spec:
+            containers:
+              - name: engine
+                image: lmsysorg/sglang:<tag>
+                command:
+                  - python3
+                  - -m
+                  - sglang.launch_server
+                  - --model-path
+                  - "<model-path>"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                  - --tp-size
+                  - "<TP_SIZE>"
+                  - --dist-init-addr
+                  - $(RBG_LWP_LEADER_ADDRESS):6379
+                  - --nnodes
+                  - $(RBG_LWP_GROUP_SIZE)
+                  - --node-rank
+                  - $(RBG_LWP_WORKER_INDEX)
+                ports:
+                  - name: http
+                    containerPort: 8000
+                resources:
+                  requests:
+                    nvidia.com/gpu: "1"   # 每 Pod 1 张 GPU
+                  limits:
+                    nvidia.com/gpu: "1"
+                volumeMounts:
+                  - name: dshm
+                    mountPath: /dev/shm
+            volumes:
+              - name: dshm
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 30Gi
+        leaderTemplatePatch:     # 可选：为 Leader 添加差异化配置
+          metadata:
+            labels:
+              role: leader
+        workerTemplatePatch:     # 可选：为 Worker 添加差异化配置
+          metadata:
+            labels:
+              role: worker
+```
+
+**vLLM 张量并行的环境变量注入**：vLLM 使用不同的分布式初始化参数，通过环境变量传入：
+```yaml
+env:
+  - name: VLLM_HOST_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
+command:
+  - python3
+  - -m
+  - vllm.entrypoints.openai.api_server
+  - --tensor-parallel-size
+  - "$(RBG_LWP_GROUP_SIZE)"
+  # vLLM Ray 会自动发现节点，RBG 注入的变量提供地址信息
+```
+
+---
+
+## 模式三：PD 分离（多角色）
+
+> **选择规则**：
+> - GPU 节点**有 Taint** → 用「直接 template 方案」（Section 3.1）
+> - GPU 节点**无 Taint** → 可用「roleTemplates 方案」（Section 3.2）
+
+### 3.1 有 Taint 节点 - 直接 template 方案（推荐用于云厂商 GPU 集群）
+
+```yaml
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: <rbg-name>
+  namespace: <namespace>
+spec:
+  roles:
+    - name: router
+      replicas: 1
+      standalonePattern:
+        template:
+          spec:
+            containers:
+              - name: router
+                image: lmsysorg/sglang-router:<same-version>  # 与 engine 同系列版本
+                command:
+                  - python3
+                  - -m
+                  - sglang_router.launch_router
+                  - --pd-disaggregation
+                  - --prefill
+                  - "http://<rbg-name>-prefill-0.s-<rbg-name>-prefill:8000"
+                  - --decode
+                  - "http://<rbg-name>-decode-0.s-<rbg-name>-decode:8000"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                ports:
+                  - name: http
+                    containerPort: 8000
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+                  limits:
+                    cpu: "4"
+                    memory: "8Gi"
+
+    - name: prefill
+      replicas: <PREFILL_REPLICAS>
+      standalonePattern:
+        template:
+          spec:
+            # 有 Taint 时必须在此处直接写 tolerations
+            tolerations:
+              - key: "<taint-key>"        # 从 NODE_TAINTS 中填入
+                operator: "Exists"         # 或 Equal + value
+                effect: "NoSchedule"       # 或 NoExecute / PreferNoSchedule
+            nodeSelector:
+              <label-key>: <label-value>
+            containers:
+              - name: engine
+                image: lmsysorg/sglang:<tag>
+                command:
+                  - python3
+                  - -m
+                  - sglang.launch_server
+                  - --model-path
+                  - "<model-path>"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                  - --disaggregation-mode
+                  - "prefill"
+                  - --tp-size
+                  - "<TP_SIZE>"
+                resources:
+                  requests:
+                    nvidia.com/gpu: "1"
+                  limits:
+                    nvidia.com/gpu: "1"
+                volumeMounts:
+                  - name: dshm
+                    mountPath: /dev/shm
+            volumes:
+              - name: dshm
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 30Gi
+
+    - name: decode
+      replicas: <DECODE_REPLICAS>
+      standalonePattern:
+        template:
+          spec:
+            tolerations:
+              - key: "<taint-key>"
+                operator: "Exists"
+                effect: "NoSchedule"
+            nodeSelector:
+              <label-key>: <label-value>
+            containers:
+              - name: engine
+                image: lmsysorg/sglang:<tag>
+                command:
+                  - python3
+                  - -m
+                  - sglang.launch_server
+                  - --model-path
+                  - "<model-path>"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                  - --disaggregation-mode
+                  - "decode"
+                  - --tp-size
+                  - "<TP_SIZE>"
+                resources:
+                  requests:
+                    nvidia.com/gpu: "1"
+                  limits:
+                    nvidia.com/gpu: "1"
+                volumeMounts:
+                  - name: dshm
+                    mountPath: /dev/shm
+            volumes:
+              - name: dshm
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 30Gi
+```
+
+### 3.2 无 Taint 节点 - 使用 roleTemplates 的完整示例
+
+```yaml
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: RoleBasedGroup
+metadata:
+  name: <rbg-name>
+  namespace: <namespace>
+spec:
+  # 公共模板：Prefill 和 Decode 共用相同的引擎镜像和资源
+  roleTemplates:
+    - name: engine-base
+      template:
+        spec:
+          containers:
+            - name: engine
+              image: lmsysorg/sglang:<tag>
+              ports:
+                - name: http
+                  containerPort: 8000
+              resources:
+                requests:
+                  nvidia.com/gpu: "1"
+                limits:
+                  nvidia.com/gpu: "1"
+              volumeMounts:
+                - name: dshm
+                  mountPath: /dev/shm
+          volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 30Gi
+
+  roles:
+    # Router：CPU-only，不使用公共模板（资源差异大）
+    - name: router
+      replicas: 1
+      standalonePattern:
+        template:
+          spec:
+            containers:
+              - name: router
+                image: lmsysorg/sglang-router:<tag>
+                command:
+                  - python3
+                  - -m
+                  - sglang_router.launch_router
+                  - --pd-disaggregation
+                  - --prefill
+                  - "http://<rbg-name>-prefill-0.s-<rbg-name>-prefill:8000"
+                  - --decode
+                  - "http://<rbg-name>-decode-0.s-<rbg-name>-decode:8000"
+                  # 若 replicas > 1，逐个列出：
+                  # - --prefill
+                  # - "http://<rbg-name>-prefill-1.s-<rbg-name>-prefill:8000"
+                  - --host
+                  - "0.0.0.0"
+                  - --port
+                  - "8000"
+                ports:
+                  - name: http
+                    containerPort: 8000
+                resources:
+                  requests:
+                    cpu: "2"
+                    memory: "4Gi"
+                  limits:
+                    cpu: "4"
+                    memory: "8Gi"
+
+    # Prefill：引用公共模板，patch 添加 PD 分离参数
+    - name: prefill
+      replicas: <PREFILL_REPLICAS>
+      standalonePattern:           # 或 leaderWorkerPattern（张量并行时）
+        templateRef:
+          name: engine-base
+          patch:
+            spec:
+              containers:
+                - name: engine
+                  command:
+                    - python3
+                    - -m
+                    - sglang.launch_server
+                    - --model-path
+                    - "<model-path>"
+                    - --host
+                    - "0.0.0.0"
+                    - --port
+                    - "8000"
+                    - --disaggregation-mode
+                    - "prefill"
+                    - --tp-size
+                    - "<TP_SIZE>"
+
+    # Decode：引用公共模板，patch 添加 PD 分离参数
+    - name: decode
+      replicas: <DECODE_REPLICAS>
+      standalonePattern:           # 或 leaderWorkerPattern
+        templateRef:
+          name: engine-base
+          patch:
+            spec:
+              containers:
+                - name: engine
+                  command:
+                    - python3
+                    - -m
+                    - sglang.launch_server
+                    - --model-path
+                    - "<model-path>"
+                    - --host
+                    - "0.0.0.0"
+                    - --port
+                    - "8000"
+                    - --disaggregation-mode
+                    - "decode"
+                    - --tp-size
+                    - "<TP_SIZE>"
+```
+
+> **Router 地址列表**：若 prefill 或 decode replicas > 1，需在 Router 的 `--prefill` / `--decode` 参数中逐个列出每个实例的 DNS 地址（ordinal 从 0 到 N-1）。
+
+---
+
+## 附加功能配置
+
+### 滚动升级策略（推荐）
+
+```yaml
+# 在 RoleSpec 中添加
+rolloutStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    type: InPlaceIfPossible      # 优先原地升级
+    maxUnavailable: 1
+    inPlaceUpdateStrategy:
+      gracePeriodSeconds: 30     # 原地升级前的 grace period
+```
+
+### ScalingAdapter（HPA 集成）
+
+```yaml
+# 在 RoleSpec 中添加
+scalingAdapter:
+  enable: true
+```
+
+RBG Controller 自动创建 `RoleBasedGroupScalingAdapter` CR，配置 HPA：
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: decode-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: workloads.x-k8s.io/v1alpha2
+    kind: RoleBasedGroupScalingAdapter
+    name: <rbg-name>-decode    # 格式：{rbgName}-{roleName}
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: custom_metric
+        target:
+          type: AverageValue
+          averageValue: "100"
+```
+
+### Gang 调度（Volcano）
+
+```yaml
+# 在 RoleSpec 的 annotations 中添加
+annotations:
+  rbg.workloads.x-k8s.io/scheduling-backend: volcano
+```
+
+### CoordinatedPolicy（协调升级/扩缩容）
+
+创建独立的 `CoordinatedPolicy` CR，与 RBG 同名同 namespace：
+
+```yaml
+apiVersion: workloads.x-k8s.io/v1alpha2
+kind: CoordinatedPolicy
+metadata:
+  name: <rbg-name>          # 必须与 RBG 同名
+  namespace: <namespace>
+spec:
+  policies:
+    - name: pd-coordination
+      roles:
+        - prefill
+        - decode
+      strategy:
+        # 协调滚动更新（与 rolloutStrategy 二选一时：此处控制跨角色协调）
+        rollingUpdate:
+          maxSkew: 1          # 两角色升级进度差不超过 1 个实例
+          maxUnavailable: 1
+        # 协调扩缩容
+        scaling:
+          maxSkew: 2          # 扩缩容时两角色差不超过 2 个实例
+          progression: OrderReady   # 等待前一个 Ready 再扩下一个
+```
+
+> **注意**：`rolloutStrategy` 控制单角色的升级细节（type/maxUnavailable），`CoordinatedPolicy` 控制多角色之间的协调约束（maxSkew），两者可以共存。
+
+### NodeSelector
+
+```yaml
+# 在 template.spec 中添加
+spec:
+  nodeSelector:
+    <label-key>: <label-value>
+    # 例如：nvidia.com/gpu.product: A100-SXM4-80GB
+```
+
+### PVC 挂载（模型存储）
+
+```yaml
+# 在 template.spec 中添加
+volumes:
+  - name: model-storage
+    persistentVolumeClaim:
+      claimName: <pvc-name>
+containers:
+  - name: engine
+    volumeMounts:
+      - name: model-storage
+        mountPath: /models
+    command:
+      - --model-path
+      - /models/<model-subpath>
+```
+
+### ReadinessProbe & LivenessProbe
+
+```yaml
+containers:
+  - name: engine
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      initialDelaySeconds: 60
+      periodSeconds: 10
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      initialDelaySeconds: 120
+      periodSeconds: 30
+```
+
+---
+
+## Patch 合并规则速查
+
+| 字段类型 | 合并行为 |
+|---------|----------|
+| 标量（string/int/bool） | 覆盖 |
+| containers 列表 | 按 `name` 字段匹配，递归合并 |
+| volumes 列表 | 按 `name` 字段匹配，递归合并 |
+| map（labels/annotations/resources） | 递归合并（patch 中的 key 覆盖模板中的同名 key） |
+| **tolerations 列表** | **⚠️ 不会被 patch 传递**，controller 转换时丢失，必须用直接 template |
+
+**适用顺序**：`roleTemplates` → `templateRef.patch` → `leaderTemplatePatch` / `workerTemplatePatch`
+
+**patch 中禁止出现的字段**：
+- `tolerations`（无效，会被丢弃）
+- `initContainers: []`（会清空 base 模板的 initContainers）
+- `affinity`（行为未经充分验证，谨慎使用）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RoleBasedGroup (RBG) is a Kubernetes API for orchestrating distributed, stateful AI inference workloads with multi-role collaboration and built-in service discovery. It treats an inference service as a role-based group — a topologized, stateful, coordinated multi-role organism managed as a single unit.
+
+## Build and Development Commands
+
+### Building
+```bash
+make build          # Build controller binary (outputs to bin/manager)
+make build-cli      # Build CLI binary (outputs to bin/kubectl-rbg)
+make build-cli-all  # Build CLI for all platforms (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
+```
+
+### Code Generation
+```bash
+make manifests      # Generate CRDs, RBAC, and WebhookConfiguration
+make generate       # Generate DeepCopy methods and client code
+```
+
+### Testing
+```bash
+make test           # Run unit tests (api, cmd, internal, pkg)
+make test-envtest   # Run envtest integration tests (requires KUBEBUILDER_ASSETS)
+make test-e2e       # Run e2e tests (requires Kind cluster)
+```
+
+### Linting
+```bash
+make lint           # Run golangci-lint
+make lint-fix       # Run golangci-lint with auto-fix
+```
+
+### Copyright Headers
+```bash
+make copyright-check  # Check copyright headers on changed Go files
+make copyright-fix    # Add missing copyright headers
+```
+
+### Running Locally
+```bash
+make run            # Run controller with webhooks enabled
+make run-local      # Run controller in local debug mode (webhooks disabled, no leader election)
+```
+
+### Docker Images
+```bash
+make docker-build       # Build controller and CRD upgrader images
+make docker-push        # Push images to registry
+make docker-buildx-push # Build and push multi-arch images
+```
+
+### Deployment
+```bash
+make install         # Install CRDs into cluster
+make uninstall       # Uninstall CRDs from cluster
+make deploy          # Deploy controller to cluster
+make undeploy        # Undeploy controller from cluster
+make helm-deploy     # Deploy via Helm
+make helm-undeploy   # Undeploy via Helm
+```
+
+## Architecture
+
+### API Versions
+- `v1alpha1`: Legacy API (being deprecated)
+- `v1alpha2`: Current storage version with conversion webhooks
+
+### Core CRDs (api/workloads/v1alpha2/)
+- **RoleBasedGroup**: Primary CRD — defines a group of roles forming one logical service
+- **RoleInstance**: Collection of Pods with tightly bound lifecycle, supports in-place updates
+- **RoleInstanceSet**: Manages a set of RoleInstances
+- **CoordinatedPolicy**: Controls coordinated operations across roles (maxSkew, progression)
+- **RoleBasedGroupScalingAdapter**: HPA integration for auto-scaling
+- **ClusterEngineRuntimeProfile**: Engine runtime configuration profiles
+
+### Controllers (internal/controller/workloads/)
+- `rolebasedgroup_controller.go`: Main RBG reconciler — orchestrates role creation, dependencies, and status
+- `roleinstance_controller.go`: Manages individual role instances
+- `roleinstanceset_controller.go`: Manages RoleInstanceSet lifecycle
+- `pod_controller.go`: Handles Pod events and RBG-level restart policies
+- `rolebasedgroupscalingadapter_controller.go`: Auto-created scaling adapter management
+- `rolebasedgroupset_controller.go`: RoleBasedGroupSet controller
+
+### Reconcilers (pkg/reconciler/)
+- `deploy_reconciler.go`: Deployment creation/updates
+- `sts_reconciler.go`: StatefulSet management
+- `lws_reconciler.go`: LeaderWorkerSet integration
+- `roleinstanceset_reconciler.go`: RoleInstanceSet management
+- `svc_reconciler.go`: Service creation
+- `pod_reconciler.go`: Pod-level operations
+
+### Key Packages
+- `pkg/discovery/`: Service discovery and topology awareness
+- `pkg/dependency/`: Role dependency resolution
+- `pkg/scheduler/`: Gang scheduling integration (Volcano, scheduler-plugins)
+- `pkg/port-allocator/`: Dynamic port allocation
+- `pkg/inplace/`: In-place update support
+- `pkg/coordination/`: Cross-role coordination logic
+
+### Deployment Patterns
+Each role in a RoleBasedGroup uses one of three patterns:
+1. **standalonePattern**: Single pod per instance (single-GPU)
+2. **leaderWorkerPattern**: Leader + workers for tensor parallelism (multi-GPU)
+3. **customComponentsPattern**: Custom multi-component deployment
+
+## Key Concepts
+
+### Role Dependencies
+Roles can declare `dependencies` on other roles, ensuring ordered startup. The controller waits for dependency roles to be ready before starting dependent roles.
+
+### Rollout Strategy
+- `RollingUpdate`: Incremental pod replacement
+- Supports `partition`, `maxUnavailable`, `maxSurge`
+- In-place update strategies: `RecreatePod`, `InPlaceIfPossible`, `InPlaceOnly`
+
+### Restart Policy
+- `None`: Default pod restart behavior
+- `RecreateRBGOnPodRestart`: Entire RBG recreation on pod failure
+- `RecreateRoleInstanceOnPodRestart`: Role instance recreation on pod failure
+
+### Gang Scheduling
+Integrated with Volcano and scheduler-plugins for coordinated pod scheduling across roles.
+
+## CLI (kubectl-rbg)
+
+The CLI is in `cmd/cli/` and provides LLM-focused commands:
+- `kubectl rbg llm config init`: Initialize configuration
+- `kubectl rbg llm model pull MODEL_ID`: Pull model to storage
+- `kubectl rbg llm svc run NAME MODEL_ID`: Deploy inference service
+- `kubectl rbg llm svc chat NAME`: Chat with deployed model
+- `kubectl rbg llm benchmark run RBG_NAME`: Run benchmarks
+
+## Testing Guidelines
+
+- Unit tests use standard Go testing with Ginkgo/Gomega for controller tests
+- Envtest tests require `KUBEBUILDER_ASSETS` pointing to envtest binaries
+- E2E tests assume a Kind cluster with RBG installed
+- Test command excludes vendor directory
+
+## Code Style
+
+- Follow standard Go conventions
+- All Go files must have Apache 2.0 copyright headers
+- Use `make lint` before submitting PRs
+- DCO sign-off required on all commits (`git commit -s`)
+
+## Environment Variables
+
+Key controller flags (see `cmd/rbgs/main.go`):
+- `--enable-webhooks`: `all` or `none` (for local debugging)
+- `--scheduler-name`: `scheduler-plugins` or `volcano`
+- `--enable-port-allocator`: Enable dynamic port allocation
+- `--max-concurrent-reconciles`: Controller worker count (default: 10)
+
+Injected into pods:
+- `RBG_ROLE_NAME`: Current role name
+- `RBG_ROLE_INDEX`: Role ordinal index
+- `RBG_GROUP_NAME`: RBG name


### PR DESCRIPTION
## Summary

Add an interactive deployment wizard skill for deploying LLM inference services on Kubernetes using RoleBasedGroup (RBG), along with a CLAUDE.md for project guidance.

## What's included

### CLAUDE.md
Project-level guidance file for Claude Code, describing build commands, architecture, and development conventions for this repository.

### .claude/skills/rbg-inference-deploy/
An interactive 5-phase deployment wizard that guides users through end-to-end LLM inference service deployment via conversation.

**Phases:**
1. **Prerequisites check** - k8s cluster connectivity, RBG controller status, llmctl CLI availability
2. **Requirement collection** - namespace, engine, model, GPU node labels/taints, resource budget, SLO
3. **Deployment plan analysis** - memory estimation, SLO feasibility, Auto-Benchmark or Cookbook-based config
4. **YAML generation** - RBG YAML with roleTemplates/direct template selection, optional features (InPlaceIfPossible, ScalingAdapter, CoordinatedPolicy, Gang scheduling)
5. **Deploy & verify** - apply, smart Pod Pending diagnosis, smoke test, optional benchmark

**Key design decisions:**
- Default language English; auto-detects Chinese input and switches language for all responses
- Automatically detects GPU node taints before YAML generation; uses direct `template` (not `templateRef`) when taints exist, since `tolerations` are silently dropped by the RBG controller during `templateRef` patch conversion (verified in source code)
- Smart Pod diagnosis: maps scheduler error keywords (`untolerated taint`, `Insufficient nvidia.com/gpu`, etc.) to actionable fixes

## Files
```
CLAUDE.md
.claude/skills/rbg-inference-deploy/
├── SKILL.md               # Main wizard workflow (5 phases)
├── prerequisites.md       # Env check details and installation guides
├── deployment-analysis.md # GPU memory estimation, SLO reference, Auto-Benchmark flow
├── yaml-rules.md          # YAML generation rules with roleTemplates constraints
└── benchmark.md           # Benchmark guide using llmctl
```
