### PR TITLE
feat: add --enable-legacy-workloads flag to conditionally disable leg…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen kustomize ## Generate WebhookConfiguration, CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) crd:allowDangerousTypes=true,crdVersions=v1,generateEmbeddedObjectMeta=true,ignoreUnexportedFields=true,maxDescLen=200 rbac:roleName=controller-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
-	cp config/rbac/role.yaml deploy/helm/rbgs/templates/rbac/clusterrole.yaml
-	sed -i.bak 's/name: controller-role/name: rbgs-controller-role/' deploy/helm/rbgs/templates/rbac/clusterrole.yaml && rm -f deploy/helm/rbgs/templates/rbac/clusterrole.yaml.bak
+	# NOTE: The Helm chart's clusterrole.yaml is manually maintained with
+	# Helm conditionals for legacy workload permissions. Do NOT overwrite it.
+	# Keep it in sync with config/rbac/role.yaml when adding new permissions.
 	$(KUSTOMIZE) build config/default > deploy/kubectl/manifests.yaml
 
 .PHONY: generate

--- a/cmd/rbgs/main.go
+++ b/cmd/rbgs/main.go
@@ -149,6 +149,8 @@ func main() {
 		// Pprof profiling
 		enablePprof bool
 		pprofAddr   string
+		// Legacy workloads (Deployment, StatefulSet, LeaderWorkerSet) support
+		enableLegacyWorkloads bool
 	)
 	flag.StringVar(
 		&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -207,6 +209,13 @@ func main() {
 	)
 	flag.BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof profiling server for performance debugging.")
 	flag.StringVar(&pprofAddr, "pprof-bind-address", ":6060", "The address the pprof endpoint binds to.")
+	flag.BoolVar(
+		&enableLegacyWorkloads, "enable-legacy-workloads", false,
+		"Enable legacy workload types (Deployment, StatefulSet, LeaderWorkerSet). "+
+			"Set to false to disable watching and reconciling these workload types, "+
+			"reducing required RBAC permissions. Only RoleInstanceSet-based workloads "+
+			"will be managed when disabled.",
+	)
 
 	// Register logger flags before Parse so that zap flags (--zap-log-level etc.) are recognized.
 	opts := zap.Options{
@@ -318,7 +327,7 @@ func main() {
 	restConfig.Burst = kubeAPIBurst
 
 	mgr, err := ctrl.NewManager(
-		restConfig, newManagerOptions(webhookMode, webhookServer, metricsServerOptions, probeAddr, enableLeaderElection),
+		restConfig, newManagerOptions(webhookMode, webhookServer, metricsServerOptions, probeAddr, enableLeaderElection, enableLegacyWorkloads),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -352,7 +361,7 @@ func main() {
 	// controller (for recording and injection during reconcile).
 	nodeBindings := instancesync.NewNodeBindingStore()
 
-	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.SchedulerPluginType(schedulerName), nodeBindings)
+	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.SchedulerPluginType(schedulerName), nodeBindings, enableLegacyWorkloads)
 	if err != nil {
 		setupLog.Error(err, "unable to create rbg controller", "controller", "RoleBasedGroup")
 		os.Exit(1)
@@ -497,7 +506,7 @@ func newWebhookServer(webhookMode string, tlsOpts []func(*tls.Config)) webhook.S
 // newManagerOptions builds the controller-runtime manager options.
 // When webhooks are disabled (enable-webhooks=none), webhook server and leader
 // election are disabled, and metrics are served insecurely.
-func newManagerOptions(webhookMode string, webhookServer webhook.Server, metricsOpts metricsserver.Options, probeAddr string, enableLeaderElection bool) ctrl.Options {
+func newManagerOptions(webhookMode string, webhookServer webhook.Server, metricsOpts metricsserver.Options, probeAddr string, enableLeaderElection bool, enableLegacyWorkloads bool) ctrl.Options {
 	opts := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsOpts,
@@ -505,7 +514,7 @@ func newManagerOptions(webhookMode string, webhookServer webhook.Server, metrics
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       constants.ControllerName,
-		Cache:                  cacheOptions(),
+		Cache:                  cacheOptions(enableLegacyWorkloads),
 	}
 	if !webhooksEnabled(webhookMode) {
 		setupLog.Info("Webhooks disabled: forcing LeaderElection=false, Metrics.SecureServing=false")
@@ -619,25 +628,27 @@ func startPprofServer(ctx context.Context, pprofAddr string) error {
 	return nil
 }
 
-func cacheOptions() cache.Options {
+func cacheOptions(enableLegacyWorkloads bool) cache.Options {
 	keyExistsRequirement, err := labels.NewRequirement(constants.GroupNameLabelKey, selection.Exists, nil)
 	if err != nil {
 		panic(err)
 	}
 	keyExistsSelector := labels.NewSelector().Add(*keyExistsRequirement)
 
-	return cache.Options{
-		Scheme: scheme,
-		ByObject: map[client.Object]cache.ByObject{
-			&appsv1.StatefulSet{}: {
-				Label: keyExistsSelector,
-			},
-			&appsv1.Deployment{}: {
-				Label: keyExistsSelector,
-			},
-			&corev1.Service{}: {
-				Label: keyExistsSelector,
-			},
+	byObject := map[client.Object]cache.ByObject{
+		&corev1.Service{}: {
+			Label: keyExistsSelector,
 		},
+	}
+
+	// Only cache StatefulSet and Deployment when legacy workloads are enabled.
+	if enableLegacyWorkloads {
+		byObject[&appsv1.StatefulSet{}] = cache.ByObject{Label: keyExistsSelector}
+		byObject[&appsv1.Deployment{}] = cache.ByObject{Label: keyExistsSelector}
+	}
+
+	return cache.Options{
+		Scheme:   scheme,
+		ByObject: byObject,
 	}
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
             - --metrics-bind-address=:8443
             - --leader-elect
             - --health-probe-bind-address=:8081
+            - --enable-legacy-workloads=true
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/helm/rbgs/templates/manager/manager.yaml
+++ b/deploy/helm/rbgs/templates/manager/manager.yaml
@@ -48,6 +48,8 @@ spec:
             {{- end }}
             {{- $gangScheduling := $features.gangScheduling | default dict }}
             - --scheduler-name={{ $gangScheduling.schedulerName | default "scheduler-plugins" }}
+            {{- $legacyWorkloads := $features.legacyWorkloads | default dict }}
+            - --enable-legacy-workloads={{ if hasKey $legacyWorkloads "enabled" }}{{ $legacyWorkloads.enabled }}{{ else }}true{{ end }}
             {{- if $pprof.enabled }}
             - --enable-pprof=true
             - --pprof-bind-address={{ $pprof.bindAddress | default ":6060" }}

--- a/deploy/helm/rbgs/templates/rbac/clusterrole.yaml
+++ b/deploy/helm/rbgs/templates/rbac/clusterrole.yaml
@@ -1,4 +1,8 @@
 ---
+# NOTE: This file is manually maintained with Helm conditionals for legacy
+# workload permissions. Keep it in sync with config/rbac/role.yaml (generated
+# by controller-gen from kubebuilder annotations). When adding new permissions
+# to the controller, update both files.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -53,10 +57,33 @@ rules:
   - list
   - patch
   - watch
+# controllerrevisions is always required for revision management.
 - apiGroups:
   - apps
   resources:
   - controllerrevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- if .Values.controller.features.legacyWorkloads.enabled }}
+# Legacy workload permissions (Deployment, StatefulSet) — only included when
+# controller.features.legacyWorkloads.enabled is true.
+- apiGroups:
+  - apps
+  resources:
   - deployments
   - statefulsets
   verbs:
@@ -70,7 +97,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - controllerrevisions/status
   - deployments/status
   - statefulsets/status
   verbs:
@@ -84,6 +110,7 @@ rules:
   - statefulsets/finalizers
   verbs:
   - update
+{{- end }}
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -96,6 +123,9 @@ rules:
   - patch
   - update
   - watch
+{{- if .Values.controller.features.legacyWorkloads.enabled }}
+# Legacy workload permissions (LeaderWorkerSet) — only included when
+# controller.features.legacyWorkloads.enabled is true.
 - apiGroups:
   - leaderworkerset.x-k8s.io
   resources:
@@ -116,6 +146,7 @@ rules:
   - get
   - patch
   - update
+{{- end }}
 - apiGroups:
   - scheduling.volcano.sh
   - scheduling.x-k8s.io

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -55,6 +55,15 @@ controller:
     gangScheduling:
       # schedulerName selects the gang scheduling scheduler: scheduler-plugins | volcano.
       schedulerName: scheduler-plugins
+    # legacyWorkloads controls support for legacy workload types
+    # (Deployment, StatefulSet, LeaderWorkerSet).
+    # When enabled (default), the controller watches and reconciles these
+    # workload types and the ClusterRole includes the corresponding RBAC
+    # permissions. Set to false to disable legacy workload management and
+    # reduce the RBAC footprint — only RoleInstanceSet-based workloads
+    # will be managed.
+    legacyWorkloads:
+      enabled: true
     # portAllocator configures dynamic port allocation to pods.
     portAllocator:
       # Whether to enable the port allocator feature.

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -98692,6 +98692,7 @@ spec:
         - --metrics-bind-address=:8443
         - --leader-elect
         - --health-probe-bind-address=:8081
+        - --enable-legacy-workloads=true
         command:
         - /manager
         env:

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -89,26 +89,32 @@ type RoleBasedGroupReconciler struct {
 	workloadReconciler map[string]reconciler.WorkloadReconciler
 	reconcilerMu       sync.RWMutex
 	podGroupManager    scheduler.PodGroupManager
+	// enableLegacyWorkloads controls whether the controller watches and
+	// reconciles legacy workload types (Deployment, StatefulSet,
+	// LeaderWorkerSet). When false, only RoleInstanceSet-based workloads
+	// are managed, reducing the required RBAC permissions.
+	enableLegacyWorkloads bool
 	// NodeBindings is the in-place scheduling binding store, shared with
 	// the RoleInstance reconciler. Injected at wire-up time so both consumers
 	// operate on the same instance.
 	NodeBindings *instancesync.NodeBindingStore
 }
 
-func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType, bindings *instancesync.NodeBindingStore) (*RoleBasedGroupReconciler, error) {
+func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType, bindings *instancesync.NodeBindingStore, enableLegacyWorkloads bool) (*RoleBasedGroupReconciler, error) {
 	c := utilclient.NewClientWithUserAgent(mgr, "rolebasedgroup")
 	podGroupManager, err := scheduler.NewPodGroupManager(schedulerName, c)
 	if err != nil {
 		return nil, err
 	}
 	return &RoleBasedGroupReconciler{
-		client:             c,
-		apiReader:          mgr.GetAPIReader(),
-		scheme:             mgr.GetScheme(),
-		recorder:           mgr.GetEventRecorderFor("RoleBasedGroup"),
-		workloadReconciler: make(map[string]reconciler.WorkloadReconciler),
-		podGroupManager:    podGroupManager,
-		NodeBindings:       bindings,
+		client:                c,
+		apiReader:             mgr.GetAPIReader(),
+		scheme:                mgr.GetScheme(),
+		recorder:              mgr.GetEventRecorderFor("RoleBasedGroup"),
+		workloadReconciler:    make(map[string]reconciler.WorkloadReconciler),
+		podGroupManager:       podGroupManager,
+		enableLegacyWorkloads: enableLegacyWorkloads,
+		NodeBindings:          bindings,
 	}, nil
 }
 
@@ -607,6 +613,23 @@ func (r *RoleBasedGroupReconciler) getOrCreateWorkloadReconciler(
 		return rec, nil
 	}
 
+	// Reject legacy workload types when legacy workloads are disabled.
+	// This prevents the controller from creating reconcilers that would
+	// attempt to manage Deployment/StatefulSet/LeaderWorkerSet resources,
+	// which would fail with Forbidden errors if the corresponding RBAC
+	// permissions have been removed.
+	if !r.enableLegacyWorkloads {
+		switch workloadType {
+		case constants.DeploymentWorkloadType,
+			constants.StatefulSetWorkloadType,
+			constants.LeaderWorkerSetWorkloadType:
+			return nil, fmt.Errorf(
+				"legacy workload type %s is not supported when legacy workloads are disabled",
+				workloadType,
+			)
+		}
+	}
+
 	// first check whether watch lws cr
 	dynamicWatchCustomCRD(ctx, workloadSpec.Kind)
 
@@ -673,19 +696,25 @@ func (r *RoleBasedGroupReconciler) constructAndUpdateRoleStatuses(
 
 func (r *RoleBasedGroupReconciler) deleteOrphanRoles(ctx context.Context, rbg *workloadsv1alpha2.RoleBasedGroup) error {
 	errs := make([]error, 0)
-	deployRecon := reconciler.NewDeploymentReconciler(r.scheme, r.client)
-	if err := deployRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
-		errs = append(errs, err)
-	}
 
-	stsRecon := reconciler.NewStatefulSetReconciler(r.scheme, r.client)
-	if err := stsRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
-		errs = append(errs, err)
-	}
+	// Only clean up legacy workload types when legacy workloads are enabled.
+	// When legacy workloads are disabled, the controller does not manage
+	// Deployment/StatefulSet/LeaderWorkerSet resources, so cleanup is skipped.
+	if r.enableLegacyWorkloads {
+		deployRecon := reconciler.NewDeploymentReconciler(r.scheme, r.client)
+		if err := deployRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
+			errs = append(errs, err)
+		}
 
-	lwsRecon := reconciler.NewLeaderWorkerSetReconciler(r.scheme, r.client)
-	if err := lwsRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
-		errs = append(errs, err)
+		stsRecon := reconciler.NewStatefulSetReconciler(r.scheme, r.client)
+		if err := stsRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
+			errs = append(errs, err)
+		}
+
+		lwsRecon := reconciler.NewLeaderWorkerSetReconciler(r.scheme, r.client)
+		if err := lwsRecon.CleanupOrphanedWorkloads(ctx, rbg); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	roleInstanceSetRecon := reconciler.NewRoleInstanceSetReconciler(r.scheme, r.client)
@@ -1016,8 +1045,6 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 	runtimeController = ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		For(&workloadsv1alpha2.RoleBasedGroup{}, builder.WithPredicates(RBGPredicate())).
-		Owns(&appsv1.StatefulSet{}, builder.WithPredicates(WorkloadPredicate())).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(WorkloadPredicate())).
 		Owns(&workloadsv1alpha2.RoleInstanceSet{}, builder.WithPredicates(WorkloadPredicate())).
 		Owns(&corev1.Service{}).
 		Owns(&workloadsv1alpha2.RoleBasedGroupScalingAdapter{}, builder.MatchEveryOwner, builder.WithPredicates(RBGScalingAdapterPredicate())).
@@ -1040,12 +1067,20 @@ func (r *RoleBasedGroupReconciler) SetupWithManager(mgr ctrl.Manager, options co
 		}).
 		Named("workloads-rolebasedgroup")
 
-	err := utils.CheckCrdExists(r.apiReader, utils.LwsCrdName)
-	if err == nil {
-		watchedWorkload.LoadOrStore(utils.LwsCrdName, struct{}{})
-		runtimeController.Owns(&lwsv1.LeaderWorkerSet{}, builder.WithPredicates(WorkloadPredicate()))
+	// Only watch legacy workload types (StatefulSet, Deployment,
+	// LeaderWorkerSet) when legacy workloads are enabled.
+	if r.enableLegacyWorkloads {
+		runtimeController.Owns(&appsv1.StatefulSet{}, builder.WithPredicates(WorkloadPredicate()))
+		runtimeController.Owns(&appsv1.Deployment{}, builder.WithPredicates(WorkloadPredicate()))
+
+		err := utils.CheckCrdExists(r.apiReader, utils.LwsCrdName)
+		if err == nil {
+			watchedWorkload.LoadOrStore(utils.LwsCrdName, struct{}{})
+			runtimeController.Owns(&lwsv1.LeaderWorkerSet{}, builder.WithPredicates(WorkloadPredicate()))
+		}
 	}
-	err = utils.CheckCrdExists(r.apiReader, scheduler.KubePodGroupCrdName)
+
+	err := utils.CheckCrdExists(r.apiReader, scheduler.KubePodGroupCrdName)
 	if err == nil {
 		watchedWorkload.LoadOrStore(scheduler.KubePodGroupCrdName, struct{}{})
 		runtimeController.Owns(&schev1alpha1.PodGroup{})

--- a/test/envtest/testutil/setup.go
+++ b/test/envtest/testutil/setup.go
@@ -202,7 +202,7 @@ func SetupManager(ctx context.Context) (manager.Manager, error) {
 
 // SetupRBGController sets up the RoleBasedGroup controller
 func SetupRBGController(mgr manager.Manager, bindings *instancesync.NodeBindingStore) error {
-	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.KubeSchedulerPlugin, bindings)
+	rbgReconciler, err := workloadscontroller.NewRoleBasedGroupReconciler(mgr, scheduler.KubeSchedulerPlugin, bindings, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The RBG controller previously managed pods indirectly through Deployment,
StatefulSet, and LeaderWorkerSet resources. This required broad RBAC
permissions for those resource types. Now that RoleInstance/RoleInstanceSet
is the primary workload management mechanism, these legacy resources are
only needed for backward compatibility.

Add a `--enable-legacy-workloads` controller flag (default: false) that
controls whether the controller watches and reconciles Deployment,
StatefulSet, and LeaderWorkerSet resources. When disabled, the controller
only manages RoleInstanceSet-based workloads, reducing the required RBAC
footprint.

In the Helm chart, add `controller.features.legacyWorkloads.enabled`
(default: true) which:
- Conditionally includes RBAC rules for deployments, statefulsets, and
  leaderworkersets in the ClusterRole
- Passes the corresponding flag to the controller manager

The controllerrevisions RBAC permission is always retained since it is
used for revision management regardless of legacy workload support.

The Helm chart's clusterrole.yaml is now manually maintained (instead of
being auto-generated from config/rbac/role.yaml via the Makefile) to
support the conditional inclusion of legacy workload permissions.