### PR TITLE
e2e: warmup merge multi-role actions - roles may be scheduled onto di…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/cli-runtime v0.34.1
 	k8s.io/client-go v0.34.1
 	k8s.io/code-generator v0.34.1
+	k8s.io/component-helpers v0.33.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubernetes v1.34.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
@@ -118,7 +119,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.34.1 // indirect
 	k8s.io/component-base v0.34.1 // indirect
-	k8s.io/component-helpers v0.33.3 // indirect
 	k8s.io/controller-manager v0.32.7 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/test/e2e/testcase/v1alpha2/warmup.go
+++ b/test/e2e/testcase/v1alpha2/warmup.go
@@ -135,33 +135,33 @@ func RunWarmupTestCases(f *framework.Framework) {
 				}).Obj()
 			gomega.Expect(f.Client.Create(f.Ctx, rbg)).Should(gomega.Succeed())
 
-			// Wait for RBG pods to be scheduled
-			ginkgo.By("Waiting for RBG pods to be scheduled")
-			gomega.Eventually(func() bool {
+			// Wait until exactly the two role pods the controller will act on are scheduled.
+			// Terminating pods are filtered out to mirror getDesiredNodesToWarmup, so a pod being
+			// replaced cannot make the co-location check below fail on a count instead of on
+			// placement. The snapshot is reused so both are decided from the same observation.
+			ginkgo.By("Waiting for both role pods to be scheduled")
+			var scheduledPods []corev1.Pod
+			gomega.Eventually(func() []corev1.Pod {
+				scheduledPods = nil
 				podList := &corev1.PodList{}
-				err := f.Client.List(f.Ctx, podList,
+				if err := f.Client.List(f.Ctx, podList,
 					client.InNamespace(f.Namespace),
-					client.MatchingLabels{constants.GroupNameLabelKey: rbg.Name})
-				if err != nil || len(podList.Items) < 2 {
-					return false
+					client.MatchingLabels{constants.GroupNameLabelKey: rbg.Name}); err != nil {
+					return nil
 				}
-				for _, p := range podList.Items {
-					if p.Spec.NodeName == "" {
-						return false
+				for _, pod := range podList.Items {
+					if pod.Spec.NodeName == "" || pod.DeletionTimestamp != nil {
+						continue
 					}
+					scheduledPods = append(scheduledPods, pod)
 				}
-				return true
-			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(), "RBG pods should be scheduled")
+				return scheduledPods
+			}, utils.Timeout, utils.Interval).Should(gomega.HaveLen(2), "both RBG role pods should be scheduled")
 
 			// Guard the premise of this case: both roles must have landed on the pinned node,
 			// otherwise the merge behaviour below is not what is being exercised.
 			ginkgo.By("Verifying both roles were scheduled on the same node")
-			podList := &corev1.PodList{}
-			gomega.Expect(f.Client.List(f.Ctx, podList,
-				client.InNamespace(f.Namespace),
-				client.MatchingLabels{constants.GroupNameLabelKey: rbg.Name})).Should(gomega.Succeed())
-			gomega.Expect(podList.Items).To(gomega.HaveLen(2))
-			for _, pod := range podList.Items {
+			for _, pod := range scheduledPods {
 				gomega.Expect(pod.Spec.NodeName).To(gomega.Equal(nodeName),
 					"pod %s should be pinned to node %s", pod.Name, nodeName)
 			}

--- a/test/e2e/testcase/v1alpha2/warmup.go
+++ b/test/e2e/testcase/v1alpha2/warmup.go
@@ -101,8 +101,15 @@ func RunWarmupTestCases(f *framework.Framework) {
 		})
 
 		ginkgo.It("should complete warmup job with targetRoleBasedGroup mode and merge multi-role actions", func() {
-			ginkgo.By("Creating RBG with 2 roles")
+			ginkgo.By("Creating RBG with 2 roles pinned to the same node")
+			// This case verifies action merging: when several roles of the RBG sit on one node, the
+			// controller must create a single warmup Pod there holding every role's action. Both
+			// roles are therefore pinned to one node with a nodeSelector. Mutually required pod
+			// affinity cannot be used for this: neither pod could ever be scheduled, since each
+			// would wait for the other to already exist on the node.
+			nodeName := getFirstAvailableNodeName(f)
 			podTemplate := buildWarmupPodTemplate()
+			podTemplate.Spec.NodeSelector = map[string]string{corev1.LabelHostname: nodeName}
 			rbg := wrappersv2.BuildBasicRoleBasedGroup("warmup-rbg-test", f.Namespace).
 				WithRoles([]workloadsv1alpha2.RoleSpec{
 					{
@@ -146,13 +153,18 @@ func RunWarmupTestCases(f *framework.Framework) {
 				return true
 			}, utils.Timeout, utils.Interval).Should(gomega.BeTrue(), "RBG pods should be scheduled")
 
-			// Get the node where both pods are running
-			ginkgo.By("Getting node name from RBG pods")
+			// Guard the premise of this case: both roles must have landed on the pinned node,
+			// otherwise the merge behaviour below is not what is being exercised.
+			ginkgo.By("Verifying both roles were scheduled on the same node")
 			podList := &corev1.PodList{}
 			gomega.Expect(f.Client.List(f.Ctx, podList,
 				client.InNamespace(f.Namespace),
 				client.MatchingLabels{constants.GroupNameLabelKey: rbg.Name})).Should(gomega.Succeed())
-			nodeName := podList.Items[0].Spec.NodeName
+			gomega.Expect(podList.Items).To(gomega.HaveLen(2))
+			for _, pod := range podList.Items {
+				gomega.Expect(pod.Spec.NodeName).To(gomega.Equal(nodeName),
+					"pod %s should be pinned to node %s", pod.Name, nodeName)
+			}
 
 			ginkgo.By("Creating warmup CR with targetRoleBasedGroup mode")
 			warmup := &workloadsv1alpha2.RoleBasedGroupWarmup{

--- a/test/e2e/testcase/v1alpha2/warmup.go
+++ b/test/e2e/testcase/v1alpha2/warmup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -472,23 +473,64 @@ func RunWarmupTestCases(f *framework.Framework) {
 	})
 }
 
-// getFirstAvailableNodeName returns the name of the first available node.
+// defaultPodTolerations mirrors the default NoExecute tolerations injected by
+// the DefaultTolerationSeconds admission plugin for pods without tolerations.
+var defaultPodTolerations = []corev1.Toleration{
+	{
+		Key:               corev1.TaintNodeNotReady,
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: ptr.To[int64](300),
+	},
+	{
+		Key:               corev1.TaintNodeUnreachable,
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: ptr.To[int64](300),
+	},
+}
+
+// isNodeAvailable reports whether the node is schedulable for a pod without
+// custom tolerations: it must be Ready, not cordoned, not being deleted, and
+// carry no taint that the default pod tolerations cannot tolerate.
+func isNodeAvailable(node *corev1.Node) bool {
+	if node.Spec.Unschedulable || !node.DeletionTimestamp.IsZero() {
+		return false
+	}
+	if _, untolerated := corev1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, defaultPodTolerations, nil); untolerated {
+		return false
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// getFirstAvailableNodeName returns the name of the first available node,
+// which must be Ready and schedulable (not cordoned).
 func getFirstAvailableNodeName(f *framework.Framework) string {
 	nodeList := &corev1.NodeList{}
 	gomega.Expect(f.Client.List(f.Ctx, nodeList)).Should(gomega.Succeed())
 
-	// First try to find a worker node
-	for _, node := range nodeList.Items {
+	// First try to find a Ready and schedulable worker node
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
 		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
 			continue
 		}
-		return node.Name
+		if isNodeAvailable(node) {
+			return node.Name
+		}
 	}
-	// Fallback: use any available node
-	if len(nodeList.Items) > 0 {
-		return nodeList.Items[0].Name
+	// Fallback: any Ready and schedulable node (e.g. control-plane)
+	for i := range nodeList.Items {
+		if isNodeAvailable(&nodeList.Items[i]) {
+			return nodeList.Items[i].Name
+		}
 	}
-	ginkgo.Fail("no nodes found in the cluster")
+	ginkgo.Fail("no Ready and schedulable nodes found in the cluster")
 	return ""
 }
 


### PR DESCRIPTION
### Ⅰ. Motivation

The e2e case `warmup / should complete warmup job with targetRoleBasedGroup mode and merge multi-role actions` fails on any cluster with more than one schedulable node.

The case is meant to verify **action merging**: when several roles of an RBG are scheduled onto the *same* node and each role declares a different warmup action, the controller must create exactly **one** warmup Pod on that node containing every role's action. To assert that, it hard-codes `warmupPodList.Items == 1`, `Desired == 1` and `Succeeded == 1`.

However nothing in the case makes the two roles co-locate — the pod template carries no `nodeSelector`, `nodeName` or affinity, and the expected node was simply read from `podList.Items[0].Spec.NodeName`. On a multi-node cluster the scheduler is free to spread `prefill` and `decode`, which yields one warmup Pod per node and fails the assertions:

```
[FAILED] in [It] - test/e2e/testcase/v1alpha2/warmup.go:215
Warmup debug info {"name": "warmup-targetrbg-test", "phase": "Completed", "desired": 2,
  "succeeded": 2, "conditions": "[... Reason:WarmupCompleted Message:2/2 nodes warmed up successfully]"}
Warmup pod {"name": "warmup-targetrbg-test-cn6xz", "node": "cn-hongkong.10.90.173.36"}
Warmup pod {"name": "warmup-targetrbg-test-q97hb", "node": "cn-hongkong.10.131.210.163"}
```

Note the warmup feature itself behaved correctly here (`2/2 nodes warmed up successfully`) — only the case's implicit single-node assumption was violated. The remaining warmup cases are unaffected because they all target an explicit node through `TargetNodes{NodeNames: []string{nodeName}}`.

### Ⅱ. Modifications

`test/e2e/testcase/v1alpha2/warmup.go` — make the co-location premise explicit instead of relying on the cluster having a single schedulable node:

- Pin both roles to one node by setting `podTemplate.Spec.NodeSelector = {kubernetes.io/hostname: <node>}`, reusing the existing `getFirstAvailableNodeName(f)` helper that the sibling cases already use.
- Replace "read the node from the first pod" with an explicit premise guard asserting that both RBG pods really landed on the pinned node, so a scheduling surprise reports itself clearly instead of surfacing as a confusing count mismatch further down.
- The merge assertions (1 warmup Pod on that node, 2 containers, `Desired`/`Succeeded == 1`) are kept **unchanged** — the intent of the case is preserved, only its premise is now enforced.

Mutually required inter-pod affinity was considered and rejected: two pods that each require the other to already be present on the node can never be scheduled (deadlock). A one-directional affinity (`decode` → `prefill`) would work but depends on creation order and costs an extra scheduling round-trip, so a `nodeSelector` is used for a deterministic, single-shot placement.
