### PR TITLE
fix: worker pods get no DNS identity under sharedServiceSelection=All

### DIFF
--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -274,9 +274,8 @@ func (r *RoleSpec) GetWorkerTemplatePatch() *runtime.RawExtension {
 	return r.LeaderWorkerPattern.WorkerTemplatePatch
 }
 
-// GetSharedServiceSelection returns the effective shared service selection policy. It mirrors
-// the CRD default (LeaderOnly), so patterns built in process resolve the same way as patterns
-// defaulted by the API server.
+// GetSharedServiceSelection returns the effective shared service selection policy, applying the
+// LeaderOnly default when the field is unset.
 func (lwp *LeaderWorkerPattern) GetSharedServiceSelection() SharedServiceSelectionPolicy {
 	if lwp == nil || lwp.SharedServiceSelection == nil {
 		return SharedServiceSelectionLeaderOnly

--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -274,13 +274,28 @@ func (r *RoleSpec) GetWorkerTemplatePatch() *runtime.RawExtension {
 	return r.LeaderWorkerPattern.WorkerTemplatePatch
 }
 
-// GetSharedServiceSelection returns the effective shared service selection policy, applying the
-// LeaderOnly default when the field is unset.
-func (lwp *LeaderWorkerPattern) GetSharedServiceSelection() SharedServiceSelectionPolicy {
-	if lwp == nil || lwp.SharedServiceSelection == nil {
-		return SharedServiceSelectionLeaderOnly
+// GetSharedServiceSelection returns the effective shared service selection policy of the role,
+// resolved in this order:
+//
+//   - a role without leaderWorkerPattern, or on any workload type other than RoleInstanceSet,
+//     resolves to All. The policy is only supported for RoleInstanceSet + leaderWorkerPattern, and
+//     the Pods of other workload types never carry the component-name label, so honouring a stored
+//     LeaderOnly would leave the shared Service matching no Pod at all. The CEL rule on RoleSpec
+//     already rejects that value at admission, but it cannot protect a cluster whose CRDs lag the
+//     controller.
+//   - otherwise the stored value, when set.
+//   - otherwise LeaderOnly.
+func (r *RoleSpec) GetSharedServiceSelection() SharedServiceSelectionPolicy {
+	if r == nil || r.LeaderWorkerPattern == nil {
+		return SharedServiceSelectionAll
 	}
-	return *lwp.SharedServiceSelection
+	if r.GetWorkloadType() != constants.RoleInstanceSetWorkloadType {
+		return SharedServiceSelectionAll
+	}
+	if r.LeaderWorkerPattern.SharedServiceSelection != nil {
+		return *r.LeaderWorkerPattern.SharedServiceSelection
+	}
+	return SharedServiceSelectionLeaderOnly
 }
 
 // GetRestartPolicyConfig returns the effective RestartPolicyConfig for this role based on its pattern.

--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -274,6 +274,16 @@ func (r *RoleSpec) GetWorkerTemplatePatch() *runtime.RawExtension {
 	return r.LeaderWorkerPattern.WorkerTemplatePatch
 }
 
+// GetSharedServiceSelection returns the effective shared service selection policy. It mirrors
+// the CRD default (LeaderOnly), so patterns built in process resolve the same way as patterns
+// defaulted by the API server.
+func (lwp *LeaderWorkerPattern) GetSharedServiceSelection() SharedServiceSelectionPolicy {
+	if lwp == nil || lwp.SharedServiceSelection == nil {
+		return SharedServiceSelectionLeaderOnly
+	}
+	return *lwp.SharedServiceSelection
+}
+
 // GetRestartPolicyConfig returns the effective RestartPolicyConfig for this role based on its pattern.
 func (r *RoleSpec) GetRestartPolicyConfig() RestartPolicyConfig {
 	if r == nil {

--- a/api/workloads/v1alpha2/helper_test.go
+++ b/api/workloads/v1alpha2/helper_test.go
@@ -520,6 +520,49 @@ func TestRoleSpec_GetWorkloadSpec(t *testing.T) {
 	}
 }
 
+// TestLeaderWorkerPattern_GetSharedServiceSelection tests the GetSharedServiceSelection
+// method, which resolves the effective policy and mirrors the CRD default (LeaderOnly).
+func TestLeaderWorkerPattern_GetSharedServiceSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		lwp      *LeaderWorkerPattern
+		expected SharedServiceSelectionPolicy
+	}{
+		{
+			name:     "nil pattern falls back to LeaderOnly",
+			lwp:      nil,
+			expected: SharedServiceSelectionLeaderOnly,
+		},
+		{
+			name:     "unset policy falls back to LeaderOnly",
+			lwp:      &LeaderWorkerPattern{Size: ptr.To(int32(2))},
+			expected: SharedServiceSelectionLeaderOnly,
+		},
+		{
+			name: "explicit All is honored",
+			lwp: &LeaderWorkerPattern{
+				Size:                   ptr.To(int32(2)),
+				SharedServiceSelection: ptr.To(SharedServiceSelectionAll),
+			},
+			expected: SharedServiceSelectionAll,
+		},
+		{
+			name: "explicit LeaderOnly is honored",
+			lwp: &LeaderWorkerPattern{
+				Size:                   ptr.To(int32(2)),
+				SharedServiceSelection: ptr.To(SharedServiceSelectionLeaderOnly),
+			},
+			expected: SharedServiceSelectionLeaderOnly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.lwp.GetSharedServiceSelection())
+		})
+	}
+}
+
 func TestValidateRollingUpdate_AllowsReplicasZero(t *testing.T) {
 	rbg := &RoleBasedGroup{
 		Spec: RoleBasedGroupSpec{

--- a/api/workloads/v1alpha2/helper_test.go
+++ b/api/workloads/v1alpha2/helper_test.go
@@ -520,45 +520,81 @@ func TestRoleSpec_GetWorkloadSpec(t *testing.T) {
 	}
 }
 
-// TestLeaderWorkerPattern_GetSharedServiceSelection tests the GetSharedServiceSelection
-// method, which resolves the effective policy and mirrors the CRD default (LeaderOnly).
-func TestLeaderWorkerPattern_GetSharedServiceSelection(t *testing.T) {
+// TestRoleSpec_GetSharedServiceSelection tests the GetSharedServiceSelection method, which
+// resolves the effective policy: LeaderOnly for an unset field on a RoleInstanceSet role, All
+// everywhere else, and the stored value whenever it is set.
+func TestRoleSpec_GetSharedServiceSelection(t *testing.T) {
+	lwpRole := func(policy *SharedServiceSelectionPolicy, workloadType string) *RoleSpec {
+		role := &RoleSpec{
+			Name: "role",
+			Pattern: Pattern{
+				LeaderWorkerPattern: &LeaderWorkerPattern{
+					Size:                   ptr.To(int32(2)),
+					SharedServiceSelection: policy,
+				},
+			},
+		}
+		if workloadType != "" {
+			role.Annotations = map[string]string{constants.RoleWorkloadTypeAnnotationKey: workloadType}
+		}
+		return role
+	}
+
 	tests := []struct {
 		name     string
-		lwp      *LeaderWorkerPattern
+		role     *RoleSpec
 		expected SharedServiceSelectionPolicy
 	}{
 		{
-			name:     "nil pattern falls back to LeaderOnly",
-			lwp:      nil,
-			expected: SharedServiceSelectionLeaderOnly,
-		},
-		{
-			name:     "unset policy falls back to LeaderOnly",
-			lwp:      &LeaderWorkerPattern{Size: ptr.To(int32(2))},
-			expected: SharedServiceSelectionLeaderOnly,
-		},
-		{
-			name: "explicit All is honored",
-			lwp: &LeaderWorkerPattern{
-				Size:                   ptr.To(int32(2)),
-				SharedServiceSelection: ptr.To(SharedServiceSelectionAll),
-			},
+			name:     "nil role falls back to All",
+			role:     nil,
 			expected: SharedServiceSelectionAll,
 		},
 		{
-			name: "explicit LeaderOnly is honored",
-			lwp: &LeaderWorkerPattern{
-				Size:                   ptr.To(int32(2)),
-				SharedServiceSelection: ptr.To(SharedServiceSelectionLeaderOnly),
-			},
+			name:     "role without leaderWorkerPattern falls back to All",
+			role:     &RoleSpec{Name: "role"},
+			expected: SharedServiceSelectionAll,
+		},
+		{
+			name:     "unset policy on an implicit RoleInstanceSet role falls back to LeaderOnly",
+			role:     lwpRole(nil, ""),
 			expected: SharedServiceSelectionLeaderOnly,
+		},
+		{
+			name:     "unset policy on an explicit RoleInstanceSet role falls back to LeaderOnly",
+			role:     lwpRole(nil, constants.RoleInstanceSetWorkloadType),
+			expected: SharedServiceSelectionLeaderOnly,
+		},
+		{
+			name:     "unset policy on a StatefulSet role keeps All",
+			role:     lwpRole(nil, "apps/v1/StatefulSet"),
+			expected: SharedServiceSelectionAll,
+		},
+		{
+			name:     "unset policy on a LeaderWorkerSet role keeps All",
+			role:     lwpRole(nil, "leaderworkerset.x-k8s.io/v1/LeaderWorkerSet"),
+			expected: SharedServiceSelectionAll,
+		},
+		{
+			name:     "explicit All is honored",
+			role:     lwpRole(ptr.To(SharedServiceSelectionAll), ""),
+			expected: SharedServiceSelectionAll,
+		},
+		{
+			name:     "explicit LeaderOnly is honored",
+			role:     lwpRole(ptr.To(SharedServiceSelectionLeaderOnly), ""),
+			expected: SharedServiceSelectionLeaderOnly,
+		},
+		{
+			name:     "explicit LeaderOnly is ignored on an unsupported workload type",
+			role:     lwpRole(ptr.To(SharedServiceSelectionLeaderOnly), "apps/v1/StatefulSet"),
+			expected: SharedServiceSelectionAll,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.lwp.GetSharedServiceSelection())
+			assert.Equal(t, tt.expected, tt.role.GetSharedServiceSelection())
 		})
 	}
 }

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -187,16 +187,17 @@ type RestartPolicyConfig struct {
 type SharedServiceSelectionPolicy string
 
 const (
-	// SharedServiceSelectionAll - All pods would be routed to
+	// SharedServiceSelectionAll - All pods would be routed to, and every component of the role
+	// instance gets a serviceName, so each pod is addressable at <pod-name>.<service-name>
 	SharedServiceSelectionAll SharedServiceSelectionPolicy = "All"
 
-	// SharedServiceSelectionLeaderOnly - The headless service would only target at the leaders
+	// SharedServiceSelectionLeaderOnly - The headless service would only target at the leaders,
+	// and only the leader component gets a serviceName
 	SharedServiceSelectionLeaderOnly SharedServiceSelectionPolicy = "LeaderOnly"
 )
 
 // RoleSpec defines the specification for a role in the group
 // +kubebuilder:validation:XValidation:rule="!(has(self.standalonePattern) && has(self.leaderWorkerPattern))",message="standalonePattern and leaderWorkerPattern are mutually exclusive"
-// +kubebuilder:validation:XValidation:rule="!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection) || self.leaderWorkerPattern.sharedServiceSelection != 'LeaderOnly' || !has(self.annotations) || !('rbg.workloads.x-k8s.io/role-workload-type' in self.annotations) || self.annotations['rbg.workloads.x-k8s.io/role-workload-type'] == 'workloads.x-k8s.io/v1alpha2/RoleInstanceSet'",message="leaderWorkerPattern.sharedServiceSelection=LeaderOnly is only supported for RoleInstanceSet + leaderWorkerPattern"
 type RoleSpec struct {
 	// Unique identifier for the role
 	// +kubebuilder:validation:Required
@@ -352,8 +353,11 @@ type LeaderWorkerPattern struct {
 	// +kubebuilder:validation:Schemaless
 	WorkerTemplatePatch *runtime.RawExtension `json:"workerTemplatePatch,omitempty"`
 
-	// SharedServiceSelection indicates the service policy of the role
+	// SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly.
+	// Switching the policy changes pod hostname/subdomain, which are immutable fields, so it
+	// triggers a rolling replacement of the role instances.
 	// +optional
+	// +kubebuilder:default=LeaderOnly
 	// +kubebuilder:validation:Enum=All;LeaderOnly
 	SharedServiceSelection *SharedServiceSelectionPolicy `json:"sharedServiceSelection,omitempty"`
 

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -354,13 +354,14 @@ type LeaderWorkerPattern struct {
 	// +kubebuilder:validation:Schemaless
 	WorkerTemplatePatch *runtime.RawExtension `json:"workerTemplatePatch,omitempty"`
 
-	// SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
-	// which the controller applies when the field is unset (see
-	// LeaderWorkerPattern.GetSharedServiceSelection). The default is deliberately not a CRD
-	// default: defaulting runs before validation, so a stored LeaderOnly would be rejected by
-	// the RoleSpec validation rule on every role that uses another workload type.
-	// Switching the policy changes pod hostname/subdomain, which are immutable fields, so it
-	// triggers a rolling replacement of the role instances.
+	// SharedServiceSelection indicates the service policy of the role. When unset, a RoleInstanceSet
+	// role resolves to LeaderOnly and any other workload type resolves to All. Switching the policy
+	// changes pod hostname/subdomain, which are immutable fields, so it triggers a rolling
+	// replacement of the role instances.
+	//
+	// The default is applied by the controller rather than by a CRD default: CRD defaulting runs
+	// before validation, so a stored LeaderOnly would be rejected by the RoleSpec validation rule on
+	// every role that uses another workload type. See RoleSpec GetSharedServiceSelection.
 	// +optional
 	// +kubebuilder:validation:Enum=All;LeaderOnly
 	SharedServiceSelection *SharedServiceSelectionPolicy `json:"sharedServiceSelection,omitempty"`

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -198,6 +198,7 @@ const (
 
 // RoleSpec defines the specification for a role in the group
 // +kubebuilder:validation:XValidation:rule="!(has(self.standalonePattern) && has(self.leaderWorkerPattern))",message="standalonePattern and leaderWorkerPattern are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection) || self.leaderWorkerPattern.sharedServiceSelection != 'LeaderOnly' || !has(self.annotations) || !('rbg.workloads.x-k8s.io/role-workload-type' in self.annotations) || self.annotations['rbg.workloads.x-k8s.io/role-workload-type'] == 'workloads.x-k8s.io/v1alpha2/RoleInstanceSet'",message="leaderWorkerPattern.sharedServiceSelection=LeaderOnly is only supported for RoleInstanceSet + leaderWorkerPattern"
 type RoleSpec struct {
 	// Unique identifier for the role
 	// +kubebuilder:validation:Required
@@ -353,11 +354,14 @@ type LeaderWorkerPattern struct {
 	// +kubebuilder:validation:Schemaless
 	WorkerTemplatePatch *runtime.RawExtension `json:"workerTemplatePatch,omitempty"`
 
-	// SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly.
+	// SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
+	// which the controller applies when the field is unset (see
+	// LeaderWorkerPattern.GetSharedServiceSelection). The default is deliberately not a CRD
+	// default: defaulting runs before validation, so a stored LeaderOnly would be rejected by
+	// the RoleSpec validation rule on every role that uses another workload type.
 	// Switching the policy changes pod hostname/subdomain, which are immutable fields, so it
 	// triggers a rolling replacement of the role instances.
 	// +optional
-	// +kubebuilder:default=LeaderOnly
 	// +kubebuilder:validation:Enum=All;LeaderOnly
 	SharedServiceSelection *SharedServiceSelectionPolicy `json:"sharedServiceSelection,omitempty"`
 

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -25408,8 +25408,9 @@ spec:
                               type: string
                           type: object
                         sharedServiceSelection:
+                          default: LeaderOnly
                           description: SharedServiceSelection indicates the service
-                            policy of the role
+                            policy of the role. Defaults to LeaderOnly.
                           enum:
                           - All
                           - LeaderOnly
@@ -40469,13 +40470,6 @@ spec:
                   - message: standalonePattern and leaderWorkerPattern are mutually
                       exclusive
                     rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
-                  - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
-                      is only supported for RoleInstanceSet + leaderWorkerPattern
-                    rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
-                      || self.leaderWorkerPattern.sharedServiceSelection != ''LeaderOnly''
-                      || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
-                      in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
-                      == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -25409,9 +25409,8 @@ spec:
                           type: object
                         sharedServiceSelection:
                           description: |-
-                            SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
-                            which the controller applies when the field is unset (see
-                            LeaderWorkerPattern.GetSharedServiceSelection).
+                            SharedServiceSelection indicates the service policy of the role. When unset, a RoleInstanceSet
+                            role resolves to LeaderOnly and any other workload type resolves to All.
                           enum:
                           - All
                           - LeaderOnly

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -25408,9 +25408,10 @@ spec:
                               type: string
                           type: object
                         sharedServiceSelection:
-                          default: LeaderOnly
-                          description: SharedServiceSelection indicates the service
-                            policy of the role. Defaults to LeaderOnly.
+                          description: |-
+                            SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
+                            which the controller applies when the field is unset (see
+                            LeaderWorkerPattern.GetSharedServiceSelection).
                           enum:
                           - All
                           - LeaderOnly
@@ -40470,6 +40471,13 @@ spec:
                   - message: standalonePattern and leaderWorkerPattern are mutually
                       exclusive
                     rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
+                  - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
+                      is only supported for RoleInstanceSet + leaderWorkerPattern
+                    rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
+                      || self.leaderWorkerPattern.sharedServiceSelection != ''LeaderOnly''
+                      || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
+                      in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
+                      == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -25938,9 +25938,8 @@ spec:
                                   type: object
                                 sharedServiceSelection:
                                   description: |-
-                                    SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
-                                    which the controller applies when the field is unset (see
-                                    LeaderWorkerPattern.GetSharedServiceSelection).
+                                    SharedServiceSelection indicates the service policy of the role. When unset, a RoleInstanceSet
+                                    role resolves to LeaderOnly and any other workload type resolves to All.
                                   enum:
                                   - All
                                   - LeaderOnly

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -25937,8 +25937,9 @@ spec:
                                       type: string
                                   type: object
                                 sharedServiceSelection:
+                                  default: LeaderOnly
                                   description: SharedServiceSelection indicates the
-                                    service policy of the role
+                                    service policy of the role. Defaults to LeaderOnly.
                                   enum:
                                   - All
                                   - LeaderOnly
@@ -41569,13 +41570,6 @@ spec:
                           - message: standalonePattern and leaderWorkerPattern are
                               mutually exclusive
                             rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
-                          - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
-                              is only supported for RoleInstanceSet + leaderWorkerPattern
-                            rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
-                              || self.leaderWorkerPattern.sharedServiceSelection !=
-                              ''LeaderOnly'' || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
-                              in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
-                              == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -25937,9 +25937,10 @@ spec:
                                       type: string
                                   type: object
                                 sharedServiceSelection:
-                                  default: LeaderOnly
-                                  description: SharedServiceSelection indicates the
-                                    service policy of the role. Defaults to LeaderOnly.
+                                  description: |-
+                                    SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
+                                    which the controller applies when the field is unset (see
+                                    LeaderWorkerPattern.GetSharedServiceSelection).
                                   enum:
                                   - All
                                   - LeaderOnly
@@ -41570,6 +41571,13 @@ spec:
                           - message: standalonePattern and leaderWorkerPattern are
                               mutually exclusive
                             rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
+                          - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
+                              is only supported for RoleInstanceSet + leaderWorkerPattern
+                            rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
+                              || self.leaderWorkerPattern.sharedServiceSelection !=
+                              ''LeaderOnly'' || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
+                              in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
+                              == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -34268,8 +34268,9 @@ spec:
                               type: string
                           type: object
                         sharedServiceSelection:
+                          default: LeaderOnly
                           description: SharedServiceSelection indicates the service
-                            policy of the role
+                            policy of the role. Defaults to LeaderOnly.
                           enum:
                           - All
                           - LeaderOnly
@@ -49329,13 +49330,6 @@ spec:
                   - message: standalonePattern and leaderWorkerPattern are mutually
                       exclusive
                     rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
-                  - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
-                      is only supported for RoleInstanceSet + leaderWorkerPattern
-                    rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
-                      || self.leaderWorkerPattern.sharedServiceSelection != ''LeaderOnly''
-                      || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
-                      in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
-                      == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -75599,8 +75593,9 @@ spec:
                                       type: string
                                   type: object
                                 sharedServiceSelection:
+                                  default: LeaderOnly
                                   description: SharedServiceSelection indicates the
-                                    service policy of the role
+                                    service policy of the role. Defaults to LeaderOnly.
                                   enum:
                                   - All
                                   - LeaderOnly
@@ -91231,13 +91226,6 @@ spec:
                           - message: standalonePattern and leaderWorkerPattern are
                               mutually exclusive
                             rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
-                          - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
-                              is only supported for RoleInstanceSet + leaderWorkerPattern
-                            rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
-                              || self.leaderWorkerPattern.sharedServiceSelection !=
-                              ''LeaderOnly'' || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
-                              in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
-                              == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -34269,9 +34269,8 @@ spec:
                           type: object
                         sharedServiceSelection:
                           description: |-
-                            SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
-                            which the controller applies when the field is unset (see
-                            LeaderWorkerPattern.GetSharedServiceSelection).
+                            SharedServiceSelection indicates the service policy of the role. When unset, a RoleInstanceSet
+                            role resolves to LeaderOnly and any other workload type resolves to All.
                           enum:
                           - All
                           - LeaderOnly
@@ -75602,9 +75601,8 @@ spec:
                                   type: object
                                 sharedServiceSelection:
                                   description: |-
-                                    SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
-                                    which the controller applies when the field is unset (see
-                                    LeaderWorkerPattern.GetSharedServiceSelection).
+                                    SharedServiceSelection indicates the service policy of the role. When unset, a RoleInstanceSet
+                                    role resolves to LeaderOnly and any other workload type resolves to All.
                                   enum:
                                   - All
                                   - LeaderOnly

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -34268,9 +34268,10 @@ spec:
                               type: string
                           type: object
                         sharedServiceSelection:
-                          default: LeaderOnly
-                          description: SharedServiceSelection indicates the service
-                            policy of the role. Defaults to LeaderOnly.
+                          description: |-
+                            SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
+                            which the controller applies when the field is unset (see
+                            LeaderWorkerPattern.GetSharedServiceSelection).
                           enum:
                           - All
                           - LeaderOnly
@@ -49330,6 +49331,13 @@ spec:
                   - message: standalonePattern and leaderWorkerPattern are mutually
                       exclusive
                     rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
+                  - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
+                      is only supported for RoleInstanceSet + leaderWorkerPattern
+                    rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
+                      || self.leaderWorkerPattern.sharedServiceSelection != ''LeaderOnly''
+                      || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
+                      in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
+                      == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -75593,9 +75601,10 @@ spec:
                                       type: string
                                   type: object
                                 sharedServiceSelection:
-                                  default: LeaderOnly
-                                  description: SharedServiceSelection indicates the
-                                    service policy of the role. Defaults to LeaderOnly.
+                                  description: |-
+                                    SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly,
+                                    which the controller applies when the field is unset (see
+                                    LeaderWorkerPattern.GetSharedServiceSelection).
                                   enum:
                                   - All
                                   - LeaderOnly
@@ -91226,6 +91235,13 @@ spec:
                           - message: standalonePattern and leaderWorkerPattern are
                               mutually exclusive
                             rule: '!(has(self.standalonePattern) && has(self.leaderWorkerPattern))'
+                          - message: leaderWorkerPattern.sharedServiceSelection=LeaderOnly
+                              is only supported for RoleInstanceSet + leaderWorkerPattern
+                            rule: '!has(self.leaderWorkerPattern) || !has(self.leaderWorkerPattern.sharedServiceSelection)
+                              || self.leaderWorkerPattern.sharedServiceSelection !=
+                              ''LeaderOnly'' || !has(self.annotations) || !(''rbg.workloads.x-k8s.io/role-workload-type''
+                              in self.annotations) || self.annotations[''rbg.workloads.x-k8s.io/role-workload-type'']
+                              == ''workloads.x-k8s.io/v1alpha2/RoleInstanceSet'''
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:

--- a/keps/260-leaderonly-service/README.md
+++ b/keps/260-leaderonly-service/README.md
@@ -116,22 +116,22 @@ This problem occurs with runtimes such as `sglang`. In a cross-node engine, work
 The problem here is different from the per-replica headless Service problem. This KEP aims to keep the role shared headless Service while controlling which Pods are targeted by it.
 
 
-- the shared Service name does not change, and the controller only needs to update Service selectors
-- Pod `ServiceName` and `subdomain` do not change and direct Pod DNS identity does not change
+- the shared Service name never changes, and the controller only needs to update the Service selector
+- the leader Pod's `ServiceName`, `subdomain`, and DNS identity never change
 
-This makes `LeaderOnly` a selector policy, not a service identity policy.
-
+The policy also decides which components of the role instance are bound to the shared Service, so
+worker Pods gain or lose their `hostname`/`subdomain` when it changes.
 
 ### Goals
 
-1. Introduce a clear API for controlling which Pods are selected by the shared headless Service of a role.
-2. Keep current behavior as the default and support a `LeaderOnly` mode for `RoleInstanceSet + leaderWorkerPattern`.
-3. Ensure that switching between `All` and `LeaderOnly` does not require Pod recreation or Service renaming.
+1. Introduce a clear API for controlling which Pods of a role participate in its shared headless Service.
+2. Default to `LeaderOnly`, which matches the common inference topology where only leader Pods serve requests, and support `All` for roles whose worker Pods must be reachable by DNS.
+3. Ensure that switching between `All` and `LeaderOnly` never renames or recreates the shared Service, and never changes the leader Pod's identity.
 
 ### Non-Goals
 
 1. Introducing per-replica headless Services or per-replica subdomain policy.
-2. Changing Pod network identity, `ServiceName`, or `subdomain`.
+2. Changing the shared Service name, or the leader Pod's `ServiceName`, `subdomain`, and FQDN.
 3. Supporting patterns that do not define a leader component.
 
 
@@ -139,16 +139,16 @@ This makes `LeaderOnly` a selector policy, not a service identity policy.
 
 Add an optional `SharedServiceSelection` field (of type `SharedServiceSelectionPolicy`) under `LeaderWorkerPattern`.
 
-- `All` keeps the current shared headless Service behavior. The Service continues to select every Pod in the role.
-- `LeaderOnly` keeps the same shared headless Service object and the same Service name, but narrows its selector so that only leader Pods are exposed
+- `All` keeps the shared headless Service targeting every Pod in the role, and binds every component of the role instance to it, so worker Pods are reachable at `<pod-name>.<service-name>.<namespace>.svc` as well.
+- `LeaderOnly` keeps the same shared headless Service object and the same Service name, but narrows its selector so that only leader Pods are exposed, and binds only the leader component to it.
 
 The feature is intended for `RoleInstanceSet + leaderWorkerPattern`, where the role has a clear leader component and 
 where only leader Pods should serve requests.
 
-Switching between `All` and `LeaderOnly` is an in-place Service update:
+Switching between `All` and `LeaderOnly` updates the shared Service in place:
 
-- no Pod restart nor `RoleInstanceSet` rollout
-- no Pod DNS identity change nor Service rename
+- no Service rename, no Service recreation, and no change to the leader Pod's DNS identity
+- worker Pods gain or lose their `hostname`/`subdomain`, which are immutable Pod fields, so the switch triggers a `RoleInstanceSet` rollout
 
 ### User Stories (Optional)
 
@@ -241,7 +241,7 @@ Discovery artifacts and environment variables remain stable because the shared S
 
 In particular:
 
-- `RBG_LEADER_ADDRESS` keeps the same address shape, and direct Pod DNS names remain unchanged
+- `RBG_LEADER_ADDRESS` keeps the same address shape, and the leader Pod's DNS name remains unchanged
 - config generation that derives addresses from the shared Service name does not need a new naming mode
 
 The only behavior changes are that worker Pods are not targeted by the shared Service endpoints under `LeaderOnly`, and that worker Pods are only addressable at `<pod-name>.<shared-service-name>` under `All`.

--- a/keps/260-leaderonly-service/README.md
+++ b/keps/260-leaderonly-service/README.md
@@ -119,8 +119,7 @@ The problem here is different from the per-replica headless Service problem. Thi
 - the shared Service name never changes, and the controller only needs to update the Service selector
 - the leader Pod's `ServiceName`, `subdomain`, and DNS identity never change
 
-The policy also decides which components of the role instance are bound to the shared Service, so
-worker Pods gain or lose their `hostname`/`subdomain` when it changes.
+The policy also decides which components of the role instance are bound to the shared Service, so worker Pods gain or lose their `hostname`/`subdomain` when it changes.
 
 ### Goals
 
@@ -142,8 +141,7 @@ Add an optional `SharedServiceSelection` field (of type `SharedServiceSelectionP
 - `All` keeps the shared headless Service targeting every Pod in the role, and binds every component of the role instance to it, so worker Pods are reachable at `<pod-name>.<service-name>.<namespace>.svc` as well.
 - `LeaderOnly` keeps the same shared headless Service object and the same Service name, but narrows its selector so that only leader Pods are exposed, and binds only the leader component to it.
 
-The feature is intended for `RoleInstanceSet + leaderWorkerPattern`, where the role has a clear leader component and 
-where only leader Pods should serve requests.
+The feature is intended for `RoleInstanceSet + leaderWorkerPattern`, where the role has a clear leader component and where only leader Pods should serve requests.
 
 Switching between `All` and `LeaderOnly` updates the shared Service in place:
 
@@ -154,19 +152,15 @@ Switching between `All` and `LeaderOnly` updates the shared Service in place:
 
 #### Story 1
 
-As an inference engineer using `sglang` in a multi-node pattern, I want the shared role Service to expose only leader Pods so that
-followers that do not run a fully functional serving endpoint do not receive external traffic.
+As an inference engineer using `sglang` in a multi-node pattern, I want the shared role Service to expose only leader Pods so that followers that do not run a fully functional serving endpoint do not receive external traffic.
 
 #### Story 2
 
-As an operator building a gateway, I want one stable shared Service per role, but I only want the real serving Pods to appear in that Service's endpoints. 
-This lets the gateway keep using Service-level discovery without routing requests to worker Pods that should only participate in internal execution.
+As an operator building a gateway, I want one stable shared Service per role, but I only want the real serving Pods to appear in that Service's endpoints. This lets the gateway keep using Service-level discovery without routing requests to worker Pods that should only participate in internal execution.
 
 
 #### Story 3
-As a platform engineer, although we do support a pod-level model gateway (e.g. `sglang` model gateway), we still need a fallback in case the gateway is absent.
-However, I cannot control user behavior, and once they use the `sglang` engine or `vllm` in headless mode to serve a model across nodes, I need to
-configure the service manually instead of automatically.
+As a platform engineer, although we do support a pod-level model gateway (e.g. `sglang` model gateway), we still need a fallback in case the gateway is absent. However, I cannot control user behavior, and once they use the `sglang` engine or `vllm` in headless mode to serve a model across nodes, I need to configure the service manually instead of automatically.
 
 ## Design Details
 
@@ -194,16 +188,9 @@ const (
 
 Default:
 
-- If the field is unset (`nil`) on a `RoleInstanceSet` role, the controller treats it as
-  `LeaderOnly` (`RoleSpec.GetSharedServiceSelection`).
-- On any other workload type the controller resolves to `All` regardless of the stored value. Those
-  roles have no component-name label on their Pods, so a narrowed selector would match no Pod at
-  all. The CEL rule below already rejects an explicit `LeaderOnly` there at admission, but the
-  controller does not depend on that: a cluster whose CRDs lag the controller is still safe.
-- The default is applied by the controller rather than by a CRD `default`, so that the stored
-  field stays unset. A CRD default would be written into every `leaderWorkerPattern` role before
-  validation runs, and the validation rule below would then reject every role that uses another
-  workload type, even one that never set the field.
+- If the field is unset (`nil`) on a `RoleInstanceSet` role, the controller treats it as `LeaderOnly` (`RoleSpec.GetSharedServiceSelection`).
+- On any other workload type the controller resolves to `All` regardless of the stored value. Those roles have no component-name label on their Pods, so a narrowed selector would match no Pod at all. The CEL rule below already rejects an explicit `LeaderOnly` there at admission, but the controller does not depend on that: a cluster whose CRDs lag the controller is still safe.
+- The default is applied by the controller rather than by a CRD `default`, so that the stored field stays unset. A CRD default would be written into every `leaderWorkerPattern` role before validation runs, and the validation rule below would then reject every role that uses another workload type, even one that never set the field.
 
 ### Validation
 
@@ -221,9 +208,7 @@ x-kubernetes-validations:
     message: "leaderWorkerPattern.sharedServiceSelection=LeaderOnly is only supported for RoleInstanceSet + leaderWorkerPattern"
 ```
 
-Unsupported combinations are therefore rejected at admission time instead of silently having no
-effect. An unset field stays valid on every workload type, which is what keeps the controller-side
-default compatible with this rule.
+Unsupported combinations are therefore rejected at admission time instead of silently having no effect. An unset field stays valid on every workload type, which is what keeps the controller-side default compatible with this rule.
 
 ### Behavior
 
@@ -257,42 +242,21 @@ These transitions do not require:
 - Service renaming or recreation
 - any change to the leader Pod's DNS identity
 
-They do require a `RoleInstanceSet` rollout: the worker component gains or loses its
-`serviceName`, which changes the worker Pods' `hostname`/`subdomain`. Those Pod fields are
-immutable, so worker Pods cannot be updated in place and the role instances are replaced
-according to the role's rollout strategy (`maxUnavailable`/`maxSurge`).
+They do require a `RoleInstanceSet` rollout: the worker component gains or loses its `serviceName`, which changes the worker Pods' `hostname`/`subdomain`. Those Pod fields are immutable, so worker Pods cannot be updated in place and the role instances are replaced according to the role's rollout strategy (`maxUnavailable`/`maxSurge`).
 
 ### Upgrade Considerations
 
-Upgrading the controller changes behavior for existing `RoleInstanceSet + leaderWorkerPattern`
-roles. The impact depends on what the role already stores, so the three cases differ:
+Upgrading the controller changes behavior for existing `RoleInstanceSet + leaderWorkerPattern` roles. The impact depends on what the role already stores, so the three cases differ:
 
-**Field unset** — this is the breaking case for endpoints. The field shipped in v0.7.0 with an
-unset field behaving as `All`, and every `leaderWorkerPattern` example in this repository leaves it
-unset. The controller now resolves these roles to `LeaderOnly` and patches the shared Service
-selector in place, so worker Pod IPs leave the Service's A record and its EndpointSlice. No Pod is
-recreated: worker Pods never had a `hostname`/`subdomain` under the old behavior either, because
-only the leader component carried a `serviceName`, so the worker component's `serviceName` stays
-absent and the component revision is unchanged.
+**Field unset** — this is the breaking case for endpoints. The field shipped in v0.7.0 with an unset field behaving as `All`, and every `leaderWorkerPattern` example in this repository leaves it unset. The controller now resolves these roles to `LeaderOnly` and patches the shared Service selector in place, so worker Pod IPs leave the Service's A record and its EndpointSlice. No Pod is recreated: worker Pods never had a `hostname`/`subdomain` under the old behavior either, because only the leader component carried a `serviceName`, so the worker component's `serviceName` stays absent and the component revision is unchanged.
 
-**Field explicitly `All`** — endpoints are unaffected, but **every worker Pod is replaced**. Under
-v0.7.0 an explicit `All` never reached the RoleInstance template; the worker component had no
-`serviceName`. It now gets one, which changes the component's extension spec revision, so the
-in-place update path refuses the change and the worker Pods are recreated according to the role's
-rollout strategy. This happens on the first reconcile after the controller image is rolled, with no
-spec change from the user. That rollout is also what delivers the fix — worker Pods come back with
-`hostname`/`subdomain` and become addressable at `<pod-name>.<shared-service-name>`, which is what
-`All` was always supposed to mean.
+**Field explicitly `All`** — endpoints are unaffected, but **every worker Pod is replaced**. Under v0.7.0 an explicit `All` never reached the RoleInstance template; the worker component had no `serviceName`. It now gets one, which changes the component's extension spec revision, so the in-place update path refuses the change and the worker Pods are recreated according to the role's rollout strategy. This happens on the first reconcile after the controller image is rolled, with no spec change from the user. That rollout is also what delivers the fix — worker Pods come back with `hostname`/`subdomain` and become addressable at `<pod-name>.<shared-service-name>`, which is what `All` was always supposed to mean.
 
 **Field explicitly `LeaderOnly`** — no change. Selector and Pods are already in the target state.
 
 In every case the shared Service keeps its name, its UID, and the leader Pod's DNS identity.
 
-Workloads that resolve worker Pod IPs through the role's shared Service must set
-`sharedServiceSelection: All` to keep working. Note that doing so — whether before or after the
-upgrade — triggers the worker Pod rollout described above, because it gives worker Pods a
-`subdomain` they did not have. Plan the upgrade during a window that tolerates a worker rollout for
-those roles.
+Workloads that resolve worker Pod IPs through the role's shared Service must set `sharedServiceSelection: All` to keep working. Note that doing so — whether before or after the upgrade — triggers the worker Pod rollout described above, because it gives worker Pods a `subdomain` they did not have. Plan the upgrade during a window that tolerates a worker rollout for those roles.
 
 
 
@@ -338,17 +302,11 @@ The only behavior changes are that worker Pods are not targeted by the shared Se
 
 ###### Does enabling the feature change any default behavior?
 
-Yes, and it is a breaking change for already-running roles. A `RoleInstanceSet` role that leaves
-the field unset resolves to `LeaderOnly`, so the shared Service of a leader-worker role stops
-exposing worker Pods as endpoints. Pods are not affected: the leader keeps its identity and worker
-Pods never had one, so no rollout is triggered. See [Upgrade Considerations](#upgrade-considerations)
-for what existing workloads need to do.
+Yes, and it is a breaking change for already-running roles. A `RoleInstanceSet` role that leaves the field unset resolves to `LeaderOnly`, so the shared Service of a leader-worker role stops exposing worker Pods as endpoints. Pods are not affected: the leader keeps its identity and worker Pods never had one, so no rollout is triggered. See [Upgrade Considerations](#upgrade-considerations) for what existing workloads need to do.
 
 ###### Can the feature be disabled once it has been enabled?
 
-Yes. Users can set the policy to `All`, which restores worker Pods as endpoints and additionally
-gives them a DNS identity. Because that changes worker Pod identity, it triggers a rollout of the
-role instances.
+Yes. Users can set the policy to `All`, which restores worker Pods as endpoints and additionally gives them a DNS identity. Because that changes worker Pod identity, it triggers a rollout of the role instances.
 
 ###### Are there any tests for feature enablement/disablement?
 

--- a/keps/260-leaderonly-service/README.md
+++ b/keps/260-leaderonly-service/README.md
@@ -99,10 +99,10 @@ This KEP proposes a new optional field `SharedServiceSelection` (of type `Shared
 
 The new field has two values:
 
-- `All` — keeps the current behavior (default)
-- `LeaderOnly` — narrows the Service selector to only target leader Pods
+- `All` — the Service selector targets every Pod of the role, and every component of the role instance is bound to the Service, so each Pod is addressable at `<pod-name>.<service-name>.<namespace>.svc`
+- `LeaderOnly` — the Service selector only targets leader Pods, and only the leader component is bound to the Service
 
-When unset or set to `All`, the shared headless Service continues to select all Pods. When set to `LeaderOnly`, the Service selector is updated in place so that only leader Pods are exposed through the shared Service.
+The field defaults to `LeaderOnly`, which matches the common inference topology where only leader Pods serve requests.
 
 
 ## Motivation
@@ -174,8 +174,9 @@ configure the service manually instead of automatically.
 
 ```go
 type LeaderWorkerPattern struct {
-    // SharedServiceSelection indicates the service policy of the role
+    // SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly.
     // +optional
+    // +kubebuilder:default=LeaderOnly
     // +kubebuilder:validation:Enum=All;LeaderOnly
     SharedServiceSelection *SharedServiceSelectionPolicy `json:"sharedServiceSelection,omitempty"`
 }
@@ -193,40 +194,22 @@ const (
 
 Default:
 
-- If the field is unset (`nil`), the behavior defaults to `All`.
-
-### Validation
-
-A CEL validation rule on `RoleSpec` ensures that `LeaderOnly` is only valid for `RoleInstanceSet + leaderWorkerPattern`:
-
-```yaml
-x-kubernetes-validations:
-  - rule: >-
-      !has(self.leaderWorkerPattern) ||
-      !has(self.leaderWorkerPattern.sharedServiceSelection) ||
-      self.leaderWorkerPattern.sharedServiceSelection != 'LeaderOnly' ||
-      !has(self.annotations) ||
-      !('rbg.workloads.x-k8s.io/role-workload-type' in self.annotations) ||
-      self.annotations['rbg.workloads.x-k8s.io/role-workload-type'] == 'workloads.x-k8s.io/v1alpha2/RoleInstanceSet'
-    message: "leaderWorkerPattern.sharedServiceSelection=LeaderOnly is only supported for RoleInstanceSet + leaderWorkerPattern"
-```
-
-This rejects unsupported combinations at admission time rather than silently falling back to `All`.
+- If the field is unset (`nil`), the API server defaults it to `LeaderOnly`.
 
 ### Behavior
 
 #### `All`
 
-This is the current behavior and remains the default.
-
 - one shared headless Service is created for the role and the Service selector includes leader and worker Pods
+- every component of the role instance is bound to the shared Service, so each Pod gets `hostname` = Pod name and `subdomain` = shared Service name and is addressable at `<pod-name>.<service-name>.<namespace>.svc`
 
 #### `LeaderOnly`
 
-This policy keeps the shared Service model but narrows the endpoint set.
+This is the default. It keeps the shared Service model but narrows the endpoint set.
 
 - the shared Service selector includes only leader Pods, and worker Pods are no longer exposed through the shared Service
-- Pod `ServiceName`, `subdomain`, and FQDN remain unchanged
+- only the leader component is bound to the shared Service; worker Pods have no `hostname`/`subdomain` and are not addressable through it
+- the leader Pod's `ServiceName`, `subdomain`, and FQDN are the same under both policies
 
 ### Supported Pattern
 
@@ -234,16 +217,21 @@ The supported scope of this KEP is:
 
 - `RoleInstanceSet + leaderWorkerPattern`
 
-Unsupported combinations should reject `LeaderOnly` instead of silently falling back to `All`.
+The policy only drives the shared headless Service that RBG manages for the role. `LeaderWorkerSet` roles are governed by the Service that `LeaderWorkerSet` creates itself, so the policy has no effect on them.
 
 ### Rollout and Transition Behavior
 
-`All -> LeaderOnly` and `LeaderOnly -> All` should be handled by updating the shared Service selector in place.
+`All -> LeaderOnly` and `LeaderOnly -> All` update the shared Service selector in place.
 
 These transitions do not require:
 
-- Pod recreation or `RoleInstanceSet` rollout
-- Service renaming or DNS identity updates
+- Service renaming or recreation
+- any change to the leader Pod's DNS identity
+
+They do require a `RoleInstanceSet` rollout: the worker component gains or loses its
+`serviceName`, which changes the worker Pods' `hostname`/`subdomain`. Those Pod fields are
+immutable, so worker Pods cannot be updated in place and the role instances are replaced
+according to the role's rollout strategy (`maxUnavailable`/`maxSurge`).
 
 
 
@@ -256,26 +244,27 @@ In particular:
 - `RBG_LEADER_ADDRESS` keeps the same address shape, and direct Pod DNS names remain unchanged
 - config generation that derives addresses from the shared Service name does not need a new naming mode
 
-The only behavior change is that worker Pods are no longer targeted by the shared Service endpoints when `LeaderOnly` is enabled.
+The only behavior changes are that worker Pods are not targeted by the shared Service endpoints under `LeaderOnly`, and that worker Pods are only addressable at `<pod-name>.<shared-service-name>` under `All`.
 
 ### Test Plan
 
 ##### Unit tests
 
+- Effective policy resolution: an unset field falls back to `LeaderOnly`, explicit values are honored
 - Shared Service selector generation for `All` and `LeaderOnly`
-- In-place Service selector update: `nil` → `LeaderOnly` and `LeaderOnly` → `nil`
-- CRD enum validation rejects unsupported combinations via CEL rule
+- Component `serviceName` propagation: `All` binds leader and worker, `LeaderOnly` binds the leader only
+- In-place Service selector update: `All` → `LeaderOnly` and `LeaderOnly` → `All`
 
 ##### Integration tests
 
-- `All` creates one shared headless Service per role and includes leader and worker Pods
-- `LeaderOnly` creates one shared headless Service per role and includes only leader Pods
-- `All <-> LeaderOnly` updates the shared Service in place
+- An unset field is defaulted to `LeaderOnly` by the API server, including on `LeaderWorkerSet` roles, which must not be rejected
+- `All` binds every component and every Pod carries `hostname`/`subdomain` under the shared Service
+- `LeaderOnly` binds the leader only and worker Pods carry no `subdomain`
 
 ##### e2e tests
 
 - In leader-worker mode, `LeaderOnly` prevents worker Pods from appearing in the shared Service EndpointSlice
-- Switching between `LeaderOnly` and `All` preserves Service UID (in-place update) and does not recreate Pods
+- Switching from `LeaderOnly` to `All` preserves the Service UID (in-place update) and replaces worker Pods with Pods that carry `hostname`/`subdomain` under the shared Service
 
 
 ## Production Readiness Review Questionnaire
@@ -284,11 +273,15 @@ The only behavior change is that worker Pods are no longer targeted by the share
 
 ###### Does enabling the feature change any default behavior?
 
-No. The default remains `All`.
+Yes. The default is `LeaderOnly`, so the shared Service of a leader-worker role stops exposing
+worker Pods as endpoints. Pods are not affected: the leader keeps its identity and worker Pods
+never had one, so no rollout is triggered.
 
 ###### Can the feature be disabled once it has been enabled?
 
-Yes. Users can switch the policy back to `All`.
+Yes. Users can set the policy to `All`, which restores worker Pods as endpoints and additionally
+gives them a DNS identity. Because that changes worker Pod identity, it triggers a rollout of the
+role instances.
 
 ###### Are there any tests for feature enablement/disablement?
 

--- a/keps/260-leaderonly-service/README.md
+++ b/keps/260-leaderonly-service/README.md
@@ -102,7 +102,7 @@ The new field has two values:
 - `All` — the Service selector targets every Pod of the role, and every component of the role instance is bound to the Service, so each Pod is addressable at `<pod-name>.<service-name>.<namespace>.svc`
 - `LeaderOnly` — the Service selector only targets leader Pods, and only the leader component is bound to the Service
 
-The field defaults to `LeaderOnly`, which matches the common inference topology where only leader Pods serve requests.
+On a `RoleInstanceSet` role the field defaults to `LeaderOnly`, which matches the common inference topology where only leader Pods serve requests. This changes the previous behavior of an unset field, so see [Upgrade Considerations](#upgrade-considerations).
 
 
 ## Motivation
@@ -174,9 +174,9 @@ configure the service manually instead of automatically.
 
 ```go
 type LeaderWorkerPattern struct {
-    // SharedServiceSelection indicates the service policy of the role. Defaults to LeaderOnly.
+    // SharedServiceSelection indicates the service policy of the role. When unset, the controller
+    // treats a RoleInstanceSet role as LeaderOnly and any other workload type as All.
     // +optional
-    // +kubebuilder:default=LeaderOnly
     // +kubebuilder:validation:Enum=All;LeaderOnly
     SharedServiceSelection *SharedServiceSelectionPolicy `json:"sharedServiceSelection,omitempty"`
 }
@@ -194,7 +194,36 @@ const (
 
 Default:
 
-- If the field is unset (`nil`), the API server defaults it to `LeaderOnly`.
+- If the field is unset (`nil`) on a `RoleInstanceSet` role, the controller treats it as
+  `LeaderOnly` (`RoleSpec.GetSharedServiceSelection`).
+- On any other workload type the controller resolves to `All` regardless of the stored value. Those
+  roles have no component-name label on their Pods, so a narrowed selector would match no Pod at
+  all. The CEL rule below already rejects an explicit `LeaderOnly` there at admission, but the
+  controller does not depend on that: a cluster whose CRDs lag the controller is still safe.
+- The default is applied by the controller rather than by a CRD `default`, so that the stored
+  field stays unset. A CRD default would be written into every `leaderWorkerPattern` role before
+  validation runs, and the validation rule below would then reject every role that uses another
+  workload type, even one that never set the field.
+
+### Validation
+
+A CEL rule on `RoleSpec` keeps `LeaderOnly` restricted to the combination that supports it:
+
+```yaml
+x-kubernetes-validations:
+  - rule: >-
+      !has(self.leaderWorkerPattern) ||
+      !has(self.leaderWorkerPattern.sharedServiceSelection) ||
+      self.leaderWorkerPattern.sharedServiceSelection != 'LeaderOnly' ||
+      !has(self.annotations) ||
+      !('rbg.workloads.x-k8s.io/role-workload-type' in self.annotations) ||
+      self.annotations['rbg.workloads.x-k8s.io/role-workload-type'] == 'workloads.x-k8s.io/v1alpha2/RoleInstanceSet'
+    message: "leaderWorkerPattern.sharedServiceSelection=LeaderOnly is only supported for RoleInstanceSet + leaderWorkerPattern"
+```
+
+Unsupported combinations are therefore rejected at admission time instead of silently having no
+effect. An unset field stays valid on every workload type, which is what keeps the controller-side
+default compatible with this rule.
 
 ### Behavior
 
@@ -217,7 +246,7 @@ The supported scope of this KEP is:
 
 - `RoleInstanceSet + leaderWorkerPattern`
 
-The policy only drives the shared headless Service that RBG manages for the role. `LeaderWorkerSet` roles are governed by the Service that `LeaderWorkerSet` creates itself, so the policy has no effect on them.
+The policy only drives the shared headless Service that RBG manages for the role. `LeaderWorkerSet` roles are governed by the Service that `LeaderWorkerSet` creates itself, so `LeaderOnly` has no meaning there and is rejected at admission. Outside the supported scope the controller resolves the policy to `All` whatever the stored value is, which is the behavior those roles already had, so admission rejection is a second line of defence rather than the only one.
 
 ### Rollout and Transition Behavior
 
@@ -232,6 +261,38 @@ They do require a `RoleInstanceSet` rollout: the worker component gains or loses
 `serviceName`, which changes the worker Pods' `hostname`/`subdomain`. Those Pod fields are
 immutable, so worker Pods cannot be updated in place and the role instances are replaced
 according to the role's rollout strategy (`maxUnavailable`/`maxSurge`).
+
+### Upgrade Considerations
+
+Upgrading the controller changes behavior for existing `RoleInstanceSet + leaderWorkerPattern`
+roles. The impact depends on what the role already stores, so the three cases differ:
+
+**Field unset** — this is the breaking case for endpoints. The field shipped in v0.7.0 with an
+unset field behaving as `All`, and every `leaderWorkerPattern` example in this repository leaves it
+unset. The controller now resolves these roles to `LeaderOnly` and patches the shared Service
+selector in place, so worker Pod IPs leave the Service's A record and its EndpointSlice. No Pod is
+recreated: worker Pods never had a `hostname`/`subdomain` under the old behavior either, because
+only the leader component carried a `serviceName`, so the worker component's `serviceName` stays
+absent and the component revision is unchanged.
+
+**Field explicitly `All`** — endpoints are unaffected, but **every worker Pod is replaced**. Under
+v0.7.0 an explicit `All` never reached the RoleInstance template; the worker component had no
+`serviceName`. It now gets one, which changes the component's extension spec revision, so the
+in-place update path refuses the change and the worker Pods are recreated according to the role's
+rollout strategy. This happens on the first reconcile after the controller image is rolled, with no
+spec change from the user. That rollout is also what delivers the fix — worker Pods come back with
+`hostname`/`subdomain` and become addressable at `<pod-name>.<shared-service-name>`, which is what
+`All` was always supposed to mean.
+
+**Field explicitly `LeaderOnly`** — no change. Selector and Pods are already in the target state.
+
+In every case the shared Service keeps its name, its UID, and the leader Pod's DNS identity.
+
+Workloads that resolve worker Pod IPs through the role's shared Service must set
+`sharedServiceSelection: All` to keep working. Note that doing so — whether before or after the
+upgrade — triggers the worker Pod rollout described above, because it gives worker Pods a
+`subdomain` they did not have. Plan the upgrade during a window that tolerates a worker rollout for
+those roles.
 
 
 
@@ -250,21 +311,25 @@ The only behavior changes are that worker Pods are not targeted by the shared Se
 
 ##### Unit tests
 
-- Effective policy resolution: an unset field falls back to `LeaderOnly`, explicit values are honored
+- Effective policy resolution: on a `RoleInstanceSet` role an unset field falls back to `LeaderOnly` and explicit values are honored; on any other workload type the result is `All` whatever is stored
 - Shared Service selector generation for `All` and `LeaderOnly`
 - Component `serviceName` propagation: `All` binds leader and worker, `LeaderOnly` binds the leader only
 - In-place Service selector update: `All` → `LeaderOnly` and `LeaderOnly` → `All`
+- A `StatefulSet + leaderWorkerPattern` role keeps the unnarrowed selector
 
 ##### Integration tests
 
-- An unset field is defaulted to `LeaderOnly` by the API server, including on `LeaderWorkerSet` roles, which must not be rejected
+- An unset field is left `nil` in the stored object and resolved to `LeaderOnly` by the controller
+- An explicit `LeaderOnly` on a `LeaderWorkerSet` role is rejected by the CEL rule, while an unset field on such a role is accepted
 - `All` binds every component and every Pod carries `hostname`/`subdomain` under the shared Service
 - `LeaderOnly` binds the leader only and worker Pods carry no `subdomain`
+- `All` → `LeaderOnly` removes the worker component's `serviceName` from the `RoleInstanceSet` template and narrows the shared Service selector in place, keeping the same Service UID
 
 ##### e2e tests
 
 - In leader-worker mode, `LeaderOnly` prevents worker Pods from appearing in the shared Service EndpointSlice
 - Switching from `LeaderOnly` to `All` preserves the Service UID (in-place update) and replaces worker Pods with Pods that carry `hostname`/`subdomain` under the shared Service
+- Switching back from `All` to `LeaderOnly` again preserves the Service UID, drops worker Pods from the EndpointSlice, and replaces them with Pods that carry no `subdomain`
 
 
 ## Production Readiness Review Questionnaire
@@ -273,9 +338,11 @@ The only behavior changes are that worker Pods are not targeted by the shared Se
 
 ###### Does enabling the feature change any default behavior?
 
-Yes. The default is `LeaderOnly`, so the shared Service of a leader-worker role stops exposing
-worker Pods as endpoints. Pods are not affected: the leader keeps its identity and worker Pods
-never had one, so no rollout is triggered.
+Yes, and it is a breaking change for already-running roles. A `RoleInstanceSet` role that leaves
+the field unset resolves to `LeaderOnly`, so the shared Service of a leader-worker role stops
+exposing worker Pods as endpoints. Pods are not affected: the leader keeps its identity and worker
+Pods never had one, so no rollout is triggered. See [Upgrade Considerations](#upgrade-considerations)
+for what existing workloads need to do.
 
 ###### Can the feature be disabled once it has been enabled?
 

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -420,7 +420,7 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 	// Under the All policy the shared headless service exposes every component, so the worker
 	// component also needs a serviceName: that is what gives its pods a network identity
 	// (hostname/subdomain) and makes them resolvable through the service.
-	if lwp.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionAll {
+	if role.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionAll {
 		workerComponentConfig = workerComponentConfig.WithServiceName(svcName)
 	}
 

--- a/pkg/reconciler/roleinstanceset_reconciler.go
+++ b/pkg/reconciler/roleinstanceset_reconciler.go
@@ -410,6 +410,20 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 	}
 
 	workerSize := utils.NonZeroValue(*lwp.Size - 1)
+	workerComponentConfig := workloadsv1alpha2client.RoleInstanceComponent().
+		WithName(string(constants.WorkerComponentType)).
+		WithSize(workerSize).
+		WithTemplate(workerTemplateApplyCfg.WithLabels(map[string]string{
+			constants.ComponentNameLabelKey: string(constants.WorkerComponentType),
+			constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *lwp.Size),
+		}))
+	// Under the All policy the shared headless service exposes every component, so the worker
+	// component also needs a serviceName: that is what gives its pods a network identity
+	// (hostname/subdomain) and makes them resolvable through the service.
+	if lwp.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionAll {
+		workerComponentConfig = workerComponentConfig.WithServiceName(svcName)
+	}
+
 	roleInstanceTemplateConfig.
 		WithComponents(
 			workloadsv1alpha2client.RoleInstanceComponent().
@@ -420,13 +434,8 @@ func (r *RoleInstanceSetReconciler) constructRoleInstanceTemplateByLeaderWorkerP
 					constants.ComponentNameLabelKey: string(constants.LeaderComponentType),
 					constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *lwp.Size),
 				})),
-			workloadsv1alpha2client.RoleInstanceComponent().
-				WithName(string(constants.WorkerComponentType)).
-				WithSize(workerSize).
-				WithTemplate(workerTemplateApplyCfg.WithLabels(map[string]string{
-					constants.ComponentNameLabelKey: string(constants.WorkerComponentType),
-					constants.ComponentSizeLabelKey: fmt.Sprintf("%d", *lwp.Size),
-				})))
+			workerComponentConfig,
+		)
 	return nil
 }
 

--- a/pkg/reconciler/roleinstanceset_reconciler_test.go
+++ b/pkg/reconciler/roleinstanceset_reconciler_test.go
@@ -217,6 +217,74 @@ func TestRoleInstanceSetReconciler_LeaderWorkerPattern_WithTemplateRef(t *testin
 	}
 }
 
+// TestRoleInstanceSetReconciler_LeaderWorkerPattern_ComponentServiceName verifies which
+// components of the role instance are bound to the role's shared headless service: All binds
+// every component, LeaderOnly (the default) binds the leader only.
+func TestRoleInstanceSetReconciler_LeaderWorkerPattern_ComponentServiceName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = workloadsv1alpha2.AddToScheme(scheme)
+
+	tests := []struct {
+		name               string
+		policy             *workloadsv1alpha2.SharedServiceSelectionPolicy
+		expectWorkerShared bool
+	}{
+		{
+			name:               "All binds leader and worker",
+			policy:             ptr.To(workloadsv1alpha2.SharedServiceSelectionAll),
+			expectWorkerShared: true,
+		},
+		{
+			name:               "LeaderOnly binds the leader only",
+			policy:             ptr.To(workloadsv1alpha2.SharedServiceSelectionLeaderOnly),
+			expectWorkerShared: false,
+		},
+		{
+			name:               "unset policy falls back to the LeaderOnly default",
+			policy:             nil,
+			expectWorkerShared: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role := wrappersv2.BuildLeaderWorkerRole("test-role").Obj()
+			role.LeaderWorkerPattern.SharedServiceSelection = tt.policy
+
+			rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").
+				WithRoles([]workloadsv1alpha2.RoleSpec{role}).
+				Obj()
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := NewRoleInstanceSetReconciler(scheme, fakeClient)
+
+			ctx := context.Background()
+			assert.NoError(t, reconciler.Reconciler(ctx, rbg, &role, nil, expectedRevisionHash))
+
+			ris := &workloadsv1alpha2.RoleInstanceSet{}
+			assert.NoError(
+				t, fakeClient.Get(
+					ctx, types.NamespacedName{Name: rbg.GetWorkloadName(&role), Namespace: rbg.Namespace}, ris,
+				),
+			)
+
+			svcName := rbg.GetServiceName(&role)
+			serviceNames := make(map[string]string, len(ris.Spec.RoleInstanceTemplate.Components))
+			for _, component := range ris.Spec.RoleInstanceTemplate.Components {
+				serviceNames[component.Name] = component.ServiceName
+			}
+
+			assert.Equal(t, svcName, serviceNames[string(constants.LeaderComponentType)])
+			if tt.expectWorkerShared {
+				assert.Equal(t, svcName, serviceNames[string(constants.WorkerComponentType)])
+			} else {
+				assert.Empty(t, serviceNames[string(constants.WorkerComponentType)])
+			}
+		})
+	}
+}
+
 // TestRoleInstanceSetReconciler_LeaderWorkerPattern_TemplateIsolation verifies
 // that mutations during leader reconciliation do not leak into worker template.
 func TestRoleInstanceSetReconciler_LeaderWorkerPattern_TemplateIsolation(t *testing.T) {

--- a/pkg/reconciler/svc_reconciler.go
+++ b/pkg/reconciler/svc_reconciler.go
@@ -107,8 +107,7 @@ func (r *ServiceReconciler) constructServiceApplyConfiguration(
 		constants.GroupNameLabelKey: rbg.Name,
 		constants.RoleNameLabelKey:  role.Name,
 	}
-	if role.IsLeaderWorkerPattern() &&
-		role.LeaderWorkerPattern.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
+	if role.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
 		selectMap[constants.ComponentNameLabelKey] = string(constants.LeaderComponentType)
 	}
 	svcName, err := utils.GetCompatibleHeadlessServiceName(ctx, r.client, rbg, role)

--- a/pkg/reconciler/svc_reconciler.go
+++ b/pkg/reconciler/svc_reconciler.go
@@ -107,8 +107,8 @@ func (r *ServiceReconciler) constructServiceApplyConfiguration(
 		constants.GroupNameLabelKey: rbg.Name,
 		constants.RoleNameLabelKey:  role.Name,
 	}
-	if role.IsLeaderWorkerPattern() && role.LeaderWorkerPattern.SharedServiceSelection != nil &&
-		*role.LeaderWorkerPattern.SharedServiceSelection == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
+	if role.IsLeaderWorkerPattern() &&
+		role.LeaderWorkerPattern.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
 		selectMap[constants.ComponentNameLabelKey] = string(constants.LeaderComponentType)
 	}
 	svcName, err := utils.GetCompatibleHeadlessServiceName(ctx, r.client, rbg, role)

--- a/pkg/reconciler/svc_reconciler_test.go
+++ b/pkg/reconciler/svc_reconciler_test.go
@@ -117,8 +117,7 @@ func TestServiceReconciler_reconcileHeadlessService(t *testing.T) {
 				constants.RoleNameLabelKey:  rbg.Spec.Roles[i].Name,
 			}
 			if rbg.Spec.Roles[i].IsLeaderWorkerPattern() &&
-				rbg.Spec.Roles[i].LeaderWorkerPattern.SharedServiceSelection != nil &&
-				*rbg.Spec.Roles[i].LeaderWorkerPattern.SharedServiceSelection == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
+				rbg.Spec.Roles[i].LeaderWorkerPattern.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
 				expectedSelector[constants.ComponentNameLabelKey] = "leader"
 			}
 			assert.Equal(t, expectedSelector, svc.Spec.Selector)
@@ -136,7 +135,9 @@ func TestServiceReconciler_reconcileHeadlessService_UpdatesSelectorInPlace(t *te
 	require.NoError(t, corev1.AddToScheme(s))
 
 	role := wrappersv2.BuildLeaderWorkerRole("test-role").Obj()
-	role.LeaderWorkerPattern.SharedServiceSelection = nil
+	role.LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+		workloadsv1alpha2.SharedServiceSelectionAll,
+	)
 
 	rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").WithRoles(
 		[]workloadsv1alpha2.RoleSpec{role},
@@ -217,8 +218,10 @@ func TestServiceReconciler_reconcileHeadlessService_UpdatesSelectorInPlace_Rever
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: rbg.Namespace}, svc))
 	assert.Equal(t, "leader", svc.Spec.Selector[constants.ComponentNameLabelKey])
 
-	// Switch to nil (All) — component label should be removed from selector
-	roleRef.LeaderWorkerPattern.SharedServiceSelection = nil
+	// Switch to All — component label should be removed from selector
+	roleRef.LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+		workloadsv1alpha2.SharedServiceSelectionAll,
+	)
 	require.NoError(t, reconciler.reconcileHeadlessService(context.Background(), rbg, roleRef))
 
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: rbg.Namespace}, svc))

--- a/pkg/reconciler/svc_reconciler_test.go
+++ b/pkg/reconciler/svc_reconciler_test.go
@@ -116,8 +116,7 @@ func TestServiceReconciler_reconcileHeadlessService(t *testing.T) {
 				constants.GroupNameLabelKey: rbg.Name,
 				constants.RoleNameLabelKey:  rbg.Spec.Roles[i].Name,
 			}
-			if rbg.Spec.Roles[i].IsLeaderWorkerPattern() &&
-				rbg.Spec.Roles[i].LeaderWorkerPattern.GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
+			if rbg.Spec.Roles[i].GetSharedServiceSelection() == workloadsv1alpha2.SharedServiceSelectionLeaderOnly {
 				expectedSelector[constants.ComponentNameLabelKey] = "leader"
 			}
 			assert.Equal(t, expectedSelector, svc.Spec.Selector)
@@ -226,6 +225,50 @@ func TestServiceReconciler_reconcileHeadlessService_UpdatesSelectorInPlace_Rever
 
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: rbg.Namespace}, svc))
 	assert.NotContains(t, svc.Spec.Selector, constants.ComponentNameLabelKey)
+}
+
+// A StatefulSet role may also declare a leaderWorkerPattern, but its pods never receive the
+// component-name label, so the implicit LeaderOnly default must not narrow the selector there.
+func TestServiceReconciler_reconcileHeadlessService_StatefulSetLeaderWorkerKeepsAllSelector(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, workloadsv1alpha2.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+
+	role := wrappersv2.BuildLeaderWorkerRole("test-role").WithWorkload("apps/v1", "StatefulSet").Obj()
+	require.Nil(t, role.LeaderWorkerPattern.SharedServiceSelection)
+
+	rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").WithRoles(
+		[]workloadsv1alpha2.RoleSpec{role},
+	).Obj()
+
+	statefulset := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbg.GetWorkloadName(&rbg.Spec.Roles[0]),
+			Namespace: rbg.Namespace,
+			UID:       "test-sts",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(rbg, statefulset).Build()
+	reconciler := NewServiceReconciler(cl)
+
+	roleRef := &rbg.Spec.Roles[0]
+	require.NoError(t, reconciler.reconcileHeadlessService(context.Background(), rbg, roleRef))
+
+	svcName, err := utils.GetCompatibleHeadlessServiceName(context.Background(), cl, rbg, roleRef)
+	require.NoError(t, err)
+
+	svc := &corev1.Service{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: svcName, Namespace: rbg.Namespace}, svc))
+	assert.Equal(t, map[string]string{
+		constants.GroupNameLabelKey: rbg.Name,
+		constants.RoleNameLabelKey:  roleRef.Name,
+	}, svc.Spec.Selector)
 }
 
 func TestSemanticallyEqualService(t *testing.T) {

--- a/test/e2e/testcase/v1alpha2/component_ordering.go
+++ b/test/e2e/testcase/v1alpha2/component_ordering.go
@@ -33,6 +33,10 @@ import (
 
 const (
 	componentDependsOnAnnotationKey = "rolebasedgroup.workloads.x-k8s.io/component-depends-on"
+
+	leaderComponentName = "leader"
+	workerComponentName = "worker"
+	routerComponentName = "router"
 )
 
 // RunComponentOrderingTestCases registers e2e tests for component-depends-on (startAfter/deleteAfter).
@@ -107,7 +111,7 @@ func buildOrderedRBG(namespace string) *workloadsv1alpha2.RoleBasedGroup {
 					CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
 						Components: []workloadsv1alpha2.InstanceComponent{
 							{
-								Name: "leader",
+								Name: leaderComponentName,
 								Size: ptr.To(int32(1)),
 								Annotations: map[string]string{
 									componentDependsOnAnnotationKey: `{"deleteAfter": ["router"]}`,
@@ -115,7 +119,7 @@ func buildOrderedRBG(namespace string) *workloadsv1alpha2.RoleBasedGroup {
 								Template: leaderTemplate,
 							},
 							{
-								Name: "worker",
+								Name: workerComponentName,
 								Size: ptr.To(int32(2)),
 								Annotations: map[string]string{
 									componentDependsOnAnnotationKey: `{"deleteAfter": ["router"]}`,
@@ -123,7 +127,7 @@ func buildOrderedRBG(namespace string) *workloadsv1alpha2.RoleBasedGroup {
 								Template: workerTemplate,
 							},
 							{
-								Name: "router",
+								Name: routerComponentName,
 								Size: ptr.To(int32(1)),
 								Annotations: map[string]string{
 									componentDependsOnAnnotationKey: `{"startAfter": ["leader", "worker"]}`,
@@ -161,9 +165,9 @@ func verifyRouterCreatedAfterLeaderWorker(f *framework.Framework, rbg *workloads
 		componentName := pod.Labels[constants.ComponentNameLabelKey]
 		ts := pod.CreationTimestamp.UnixNano()
 		switch componentName {
-		case "router":
+		case routerComponentName:
 			routerCreation = ts
-		case "leader", "worker":
+		case leaderComponentName, workerComponentName:
 			if ts > maxLeaderWorkerCreation {
 				maxLeaderWorkerCreation = ts
 			}
@@ -198,7 +202,7 @@ func verifyComponentStatuses(f *framework.Framework, rbg *workloadsv1alpha2.Role
 			statusMap[cs.Name] = cs
 		}
 		// All three components must have readyReplicas == their expected size.
-		expectations := map[string]int32{"leader": 1, "worker": 2, "router": 1}
+		expectations := map[string]int32{leaderComponentName: 1, workerComponentName: 2, routerComponentName: 1}
 		for name, expectedSize := range expectations {
 			cs, ok := statusMap[name]
 			if !ok || cs.Size != expectedSize || cs.ReadyReplicas < cs.Size {

--- a/test/e2e/testcase/v1alpha2/shared_service_selection.go
+++ b/test/e2e/testcase/v1alpha2/shared_service_selection.go
@@ -38,7 +38,7 @@ import (
 
 func RunSharedServiceSelectionTestCases(f *framework.Framework) {
 	ginkgo.Describe("shared service selection", func() {
-		ginkgo.It("should select only leader pod and update the selector in place when disabled", func() {
+		ginkgo.It("should expose only the leader pod under LeaderOnly and every pod under All", func() {
 			role := wrappersv2.BuildLeaderWorkerRole("decode").Obj()
 			role.LeaderWorkerPattern.TemplateSource.Template = &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -90,13 +90,21 @@ func RunSharedServiceSelectionTestCases(f *framework.Framework) {
 				[]string{podsByComponent["leader"].Name},
 			)
 
-			ginkgo.By("Removing shared service selection and verifying the Service is updated in place")
+			ginkgo.By("Verifying only the leader pod has a network identity under the shared service")
+			leaderPod := podsByComponent["leader"]
+			gomega.Expect(leaderPod.Spec.Hostname).Should(gomega.Equal(leaderPod.Name))
+			gomega.Expect(leaderPod.Spec.Subdomain).Should(gomega.Equal(svcName))
+			gomega.Expect(podsByComponent["worker"].Spec.Subdomain).Should(gomega.BeEmpty())
+
+			ginkgo.By("Switching to All and verifying the Service is updated in place")
 			updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
-				rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection = nil
+				rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+					workloadsv1alpha2.SharedServiceSelectionAll,
+				)
 			})
 			f.ExpectRbgV2Equal(rbg)
 
-			defaultService := expectServiceSelector(
+			allService := expectServiceSelector(
 				f,
 				rbg.Namespace,
 				svcName,
@@ -105,7 +113,12 @@ func RunSharedServiceSelectionTestCases(f *framework.Framework) {
 					constants.RoleNameLabelKey:  role.Name,
 				},
 			)
-			gomega.Expect(defaultService.UID).Should(gomega.Equal(leaderOnlyService.UID))
+			gomega.Expect(allService.UID).Should(gomega.Equal(leaderOnlyService.UID))
+
+			// hostname and subdomain are immutable, so worker pods are replaced by a rollout
+			// before they can be addressed through the shared service.
+			ginkgo.By("Verifying every pod is recreated with a network identity under the shared service")
+			podsByComponent = expectLeaderWorkerPodsSharingService(f, rbg.Namespace, rbg.Name, role.Name, svcName)
 
 			expectEndpointSliceTargets(
 				f,
@@ -149,6 +162,27 @@ func expectServiceSelector(
 func expectLeaderWorkerPods(
 	f *framework.Framework, namespace, groupName, roleName string,
 ) map[string]corev1.Pod {
+	return expectLeaderWorkerPodsMatching(f, namespace, groupName, roleName, nil)
+}
+
+// expectLeaderWorkerPodsSharingService waits until every leader-worker pod of the role carries a
+// network identity under the shared headless service, so each pod is addressable at
+// <pod-name>.<svcName>.
+func expectLeaderWorkerPodsSharingService(
+	f *framework.Framework, namespace, groupName, roleName, svcName string,
+) map[string]corev1.Pod {
+	return expectLeaderWorkerPodsMatching(
+		f, namespace, groupName, roleName, func(pod *corev1.Pod) bool {
+			return pod.Spec.Hostname == pod.Name && pod.Spec.Subdomain == svcName
+		},
+	)
+}
+
+// expectLeaderWorkerPodsMatching waits for the leader and worker pod of the role to be running
+// with an assigned IP, and, when matches is set, to additionally satisfy that predicate.
+func expectLeaderWorkerPodsMatching(
+	f *framework.Framework, namespace, groupName, roleName string, matches func(pod *corev1.Pod) bool,
+) map[string]corev1.Pod {
 	logger := log.FromContext(f.Ctx).WithValues("groupName", groupName, "roleName", roleName)
 
 	podsByComponent := map[string]corev1.Pod{}
@@ -168,10 +202,22 @@ func expectLeaderWorkerPods(
 		}
 
 		next := map[string]corev1.Pod{}
-		for _, pod := range podList.Items {
+		for i := range podList.Items {
+			pod := podList.Items[i]
+			if pod.DeletionTimestamp != nil {
+				logger.V(1).Info("waiting for terminating pod to be replaced", "pod", pod.Name)
+				return false
+			}
 			component := pod.Labels[constants.ComponentNameLabelKey]
 			if component == "" || pod.Status.PodIP == "" {
 				logger.V(1).Info("waiting for labeled leader-worker pods", "pod", pod.Name, "component", component, "podIP", pod.Status.PodIP)
+				return false
+			}
+			if matches != nil && !matches(&pod) {
+				logger.V(1).Info(
+					"waiting for pod to match expectation",
+					"pod", pod.Name, "hostname", pod.Spec.Hostname, "subdomain", pod.Spec.Subdomain,
+				)
 				return false
 			}
 			next[component] = pod

--- a/test/e2e/testcase/v1alpha2/shared_service_selection.go
+++ b/test/e2e/testcase/v1alpha2/shared_service_selection.go
@@ -38,7 +38,7 @@ import (
 
 func RunSharedServiceSelectionTestCases(f *framework.Framework) {
 	ginkgo.Describe("shared service selection", func() {
-		ginkgo.It("should expose only the leader pod under LeaderOnly and every pod under All", func() {
+		ginkgo.It("should follow the policy round trip between LeaderOnly and All", func() {
 			role := wrappersv2.BuildLeaderWorkerRole("decode").Obj()
 			role.LeaderWorkerPattern.TemplateSource.Template = &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -130,6 +130,41 @@ func RunSharedServiceSelectionTestCases(f *framework.Framework) {
 					podsByComponent["worker"].Name,
 				},
 			)
+
+			ginkgo.By("Switching back to LeaderOnly and verifying the Service is updated in place")
+			updateRbgV2(f, rbg, func(rbg *workloadsv1alpha2.RoleBasedGroup) {
+				rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+					workloadsv1alpha2.SharedServiceSelectionLeaderOnly,
+				)
+			})
+			f.ExpectRbgV2Equal(rbg)
+
+			revertedService := expectServiceSelector(
+				f,
+				rbg.Namespace,
+				svcName,
+				map[string]string{
+					constants.GroupNameLabelKey:     rbg.Name,
+					constants.RoleNameLabelKey:      role.Name,
+					constants.ComponentNameLabelKey: "leader",
+				},
+			)
+			gomega.Expect(revertedService.UID).Should(gomega.Equal(leaderOnlyService.UID))
+
+			// The worker component loses its serviceName, so its pods are replaced by a rollout
+			// and come back without a subdomain.
+			ginkgo.By("Verifying worker pods are recreated without a network identity")
+			podsByComponent = expectLeaderWorkerPodsLeaderIdentityOnly(
+				f, rbg.Namespace, rbg.Name, role.Name, svcName,
+			)
+
+			expectEndpointSliceTargets(
+				f,
+				rbg.Namespace,
+				svcName,
+				podIPsByName(podsByComponent),
+				[]string{podsByComponent["leader"].Name},
+			)
 		})
 	})
 }
@@ -174,6 +209,22 @@ func expectLeaderWorkerPodsSharingService(
 	return expectLeaderWorkerPodsMatching(
 		f, namespace, groupName, roleName, func(pod *corev1.Pod) bool {
 			return pod.Spec.Hostname == pod.Name && pod.Spec.Subdomain == svcName
+		},
+	)
+}
+
+// expectLeaderWorkerPodsLeaderIdentityOnly waits until the leader pod carries a network identity
+// under the shared headless service and the worker pod carries none, which is the LeaderOnly
+// steady state once the rollout replacing the worker pods has settled.
+func expectLeaderWorkerPodsLeaderIdentityOnly(
+	f *framework.Framework, namespace, groupName, roleName, svcName string,
+) map[string]corev1.Pod {
+	return expectLeaderWorkerPodsMatching(
+		f, namespace, groupName, roleName, func(pod *corev1.Pod) bool {
+			if pod.Labels[constants.ComponentNameLabelKey] == "leader" {
+				return pod.Spec.Hostname == pod.Name && pod.Spec.Subdomain == svcName
+			}
+			return pod.Spec.Subdomain == ""
 		},
 	)
 }

--- a/test/envtest/testcase/rbg/shared_service_selection_test.go
+++ b/test/envtest/testcase/rbg/shared_service_selection_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -63,6 +64,21 @@ var _ = Describe("SharedServiceSelection", func() {
 			testutil.Ctx, types.NamespacedName{Name: name, Namespace: testNs}, created,
 		)).Should(Succeed())
 		return created
+	}
+
+	// updateRbg re-reads the RBG and applies mutate, retrying on conflict because the controller
+	// writes to the same object.
+	updateRbg := func(name string, mutate func(*workloadsv1alpha2.RoleBasedGroup)) {
+		ExpectWithOffset(1, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest := &workloadsv1alpha2.RoleBasedGroup{}
+			if err := testutil.K8sClient.Get(
+				testutil.Ctx, types.NamespacedName{Name: name, Namespace: testNs}, latest,
+			); err != nil {
+				return err
+			}
+			mutate(latest)
+			return testutil.K8sClient.Update(testutil.Ctx, latest)
+		})).Should(Succeed())
 	}
 
 	// componentServiceNames waits for the RoleInstanceSet of the role and returns its
@@ -182,6 +198,63 @@ var _ = Describe("SharedServiceSelection", func() {
 				Expect(pod.Spec.Hostname).Should(Equal(pod.Name), "component %s", component)
 				Expect(pod.Spec.Subdomain).Should(Equal(svcName), "component %s", component)
 			}
+		})
+	})
+
+	// Switching All -> LeaderOnly drops WithServiceName from the worker apply configuration.
+	// ServiceName is a plain string with omitempty, so there is no explicit-empty value to send:
+	// the field only disappears because server-side apply retires a field the rbg field manager
+	// previously owned. That is worth pinning down rather than inferring from the code.
+	Context("When the policy changes from All to LeaderOnly", func() {
+		It("Should clear the worker component serviceName and narrow the shared service in place", func() {
+			role := wrappersv2.BuildLeaderWorkerRole("role-1").Obj()
+			role.LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+				workloadsv1alpha2.SharedServiceSelectionAll,
+			)
+
+			rbg := createRbg("rbg-all-to-leaderonly", role)
+			roleRef := &rbg.Spec.Roles[0]
+			svcName := rbg.GetServiceName(roleRef)
+
+			By("verifying both components start out bound to the shared service")
+			Eventually(func() string {
+				return componentServiceNames(rbg, roleRef)[string(constants.WorkerComponentType)]
+			}, sssTimeout, sssInterval).Should(Equal(svcName))
+
+			svc := &corev1.Service{}
+			Expect(testutil.K8sClient.Get(
+				testutil.Ctx, types.NamespacedName{Name: svcName, Namespace: testNs}, svc,
+			)).Should(Succeed())
+			originalSvcUID := svc.UID
+
+			By("switching the policy to LeaderOnly")
+			updateRbg(rbg.Name, func(latest *workloadsv1alpha2.RoleBasedGroup) {
+				latest.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+					workloadsv1alpha2.SharedServiceSelectionLeaderOnly,
+				)
+			})
+
+			By("verifying the worker component's serviceName is removed")
+			Eventually(func() string {
+				return componentServiceNames(rbg, roleRef)[string(constants.WorkerComponentType)]
+			}, sssTimeout, sssInterval).Should(BeEmpty())
+
+			By("verifying the leader component stays bound to the shared service")
+			Expect(componentServiceNames(rbg, roleRef)[string(constants.LeaderComponentType)]).
+				Should(Equal(svcName))
+
+			By("verifying the shared service selector narrows to leader pods")
+			Eventually(func() map[string]string {
+				return serviceSelector(rbg, roleRef)
+			}, sssTimeout, sssInterval).Should(
+				HaveKeyWithValue(constants.ComponentNameLabelKey, string(constants.LeaderComponentType)),
+			)
+
+			By("verifying the shared service was updated in place")
+			Expect(testutil.K8sClient.Get(
+				testutil.Ctx, types.NamespacedName{Name: svcName, Namespace: testNs}, svc,
+			)).Should(Succeed())
+			Expect(svc.UID).Should(Equal(originalSvcUID))
 		})
 	})
 

--- a/test/envtest/testcase/rbg/shared_service_selection_test.go
+++ b/test/envtest/testcase/rbg/shared_service_selection_test.go
@@ -125,16 +125,15 @@ var _ = Describe("SharedServiceSelection", func() {
 	}
 
 	Context("When the policy is not set", func() {
-		It("Should default to LeaderOnly and only give the leader component a serviceName", func() {
+		It("Should fall back to LeaderOnly and only give the leader component a serviceName", func() {
 			role := wrappersv2.BuildLeaderWorkerRole("role-1").Obj()
 			role.LeaderWorkerPattern.SharedServiceSelection = nil
 
 			rbg := createRbg("rbg-default", role)
 
-			By("verifying the API server defaulted the policy to LeaderOnly")
-			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).ShouldNot(BeNil())
-			Expect(*rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).
-				Should(Equal(workloadsv1alpha2.SharedServiceSelectionLeaderOnly))
+			// The default lives in the controller, not in the CRD, so the stored field stays unset.
+			By("verifying the API server does not populate the field")
+			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).Should(BeNil())
 
 			By("verifying only the leader component is bound to the shared service")
 			serviceNames := componentServiceNames(rbg, &rbg.Spec.Roles[0])
@@ -188,19 +187,31 @@ var _ = Describe("SharedServiceSelection", func() {
 
 	Context("When the role runs on a LeaderWorkerSet workload", func() {
 		// The policy only drives the shared headless service that RBG manages itself, which
-		// LeaderWorkerSet roles do not have. Admission must therefore accept the defaulted
-		// LeaderOnly value on those roles instead of rejecting them.
-		It("Should accept the defaulted policy", func() {
+		// LeaderWorkerSet roles do not have, so LeaderOnly is rejected at admission there. Leaving
+		// the field unset must stay valid: that is why the LeaderOnly default is applied by the
+		// controller instead of by a CRD default, which would populate the field on every role.
+		It("Should accept an unset policy and reject an explicit LeaderOnly", func() {
 			role := wrappersv2.BuildLeaderWorkerRole("role-1").
 				WithWorkload("leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet").
 				Obj()
 			role.LeaderWorkerPattern.SharedServiceSelection = nil
 
 			rbg := createRbg("rbg-lws", role)
+			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).Should(BeNil())
 
-			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).ShouldNot(BeNil())
-			Expect(*rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).
-				Should(Equal(workloadsv1alpha2.SharedServiceSelectionLeaderOnly))
+			By("verifying an explicit LeaderOnly is rejected on this workload type")
+			rejected := wrappersv2.BuildLeaderWorkerRole("role-1").
+				WithWorkload("leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet").
+				Obj()
+			rejected.LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+				workloadsv1alpha2.SharedServiceSelectionLeaderOnly,
+			)
+			rejectedRbg := wrappersv2.BuildBasicRoleBasedGroup("rbg-lws-leaderonly", testNs).
+				WithRoles([]workloadsv1alpha2.RoleSpec{rejected}).
+				Obj()
+			err := testutil.K8sClient.Create(testutil.Ctx, rejectedRbg)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("only supported for RoleInstanceSet"))
 		})
 	})
 })

--- a/test/envtest/testcase/rbg/shared_service_selection_test.go
+++ b/test/envtest/testcase/rbg/shared_service_selection_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbg
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/rbgs/api/workloads/constants"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	"sigs.k8s.io/rbgs/test/envtest/testutil"
+	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
+)
+
+var _ = Describe("SharedServiceSelection", func() {
+	const (
+		sssTimeout  = time.Second * 60
+		sssInterval = time.Millisecond * 500
+	)
+
+	var testNs string
+
+	BeforeEach(func() {
+		testNs = fmt.Sprintf("test-sss-%d", time.Now().UnixNano())
+		testutil.CreateNamespace(testNs)
+	})
+
+	AfterEach(func() {
+		testutil.DeleteNamespace(testNs)
+	})
+
+	// createRbg creates an RBG holding a single leaderWorkerPattern role and returns the
+	// object as persisted by the API server, so that defaulted fields are visible.
+	createRbg := func(name string, role workloadsv1alpha2.RoleSpec) *workloadsv1alpha2.RoleBasedGroup {
+		rbg := wrappersv2.BuildBasicRoleBasedGroup(name, testNs).
+			WithRoles([]workloadsv1alpha2.RoleSpec{role}).
+			Obj()
+		ExpectWithOffset(1, testutil.K8sClient.Create(testutil.Ctx, rbg)).Should(Succeed())
+
+		created := &workloadsv1alpha2.RoleBasedGroup{}
+		ExpectWithOffset(1, testutil.K8sClient.Get(
+			testutil.Ctx, types.NamespacedName{Name: name, Namespace: testNs}, created,
+		)).Should(Succeed())
+		return created
+	}
+
+	// componentServiceNames waits for the RoleInstanceSet of the role and returns its
+	// component name -> serviceName mapping.
+	componentServiceNames := func(
+		rbg *workloadsv1alpha2.RoleBasedGroup, role *workloadsv1alpha2.RoleSpec,
+	) map[string]string {
+		ris := &workloadsv1alpha2.RoleInstanceSet{}
+		EventuallyWithOffset(1, func() error {
+			return testutil.K8sClient.Get(testutil.Ctx, types.NamespacedName{
+				Name: rbg.GetWorkloadName(role), Namespace: testNs,
+			}, ris)
+		}, sssTimeout, sssInterval).Should(Succeed())
+
+		serviceNames := map[string]string{}
+		for _, component := range ris.Spec.RoleInstanceTemplate.Components {
+			serviceNames[component.Name] = component.ServiceName
+		}
+		return serviceNames
+	}
+
+	serviceSelector := func(
+		rbg *workloadsv1alpha2.RoleBasedGroup, role *workloadsv1alpha2.RoleSpec,
+	) map[string]string {
+		svc := &corev1.Service{}
+		EventuallyWithOffset(1, func() error {
+			return testutil.K8sClient.Get(testutil.Ctx, types.NamespacedName{
+				Name: rbg.GetServiceName(role), Namespace: testNs,
+			}, svc)
+		}, sssTimeout, sssInterval).Should(Succeed())
+		return svc.Spec.Selector
+	}
+
+	// podsByComponent waits until every pod of the role is created and indexes them by
+	// component name.
+	podsByComponent := func(rbgName, roleName string, count int) map[string]corev1.Pod {
+		pods := map[string]corev1.Pod{}
+		EventuallyWithOffset(1, func() int {
+			podList := &corev1.PodList{}
+			if err := testutil.K8sClient.List(testutil.Ctx, podList,
+				client.InNamespace(testNs),
+				client.MatchingLabels{
+					constants.GroupNameLabelKey: rbgName,
+					constants.RoleNameLabelKey:  roleName,
+				},
+			); err != nil {
+				return 0
+			}
+			pods = map[string]corev1.Pod{}
+			for i := range podList.Items {
+				pod := podList.Items[i]
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+				pods[pod.Labels[constants.ComponentNameLabelKey]] = pod
+			}
+			return len(pods)
+		}, sssTimeout, sssInterval).Should(Equal(count))
+		return pods
+	}
+
+	Context("When the policy is not set", func() {
+		It("Should default to LeaderOnly and only give the leader component a serviceName", func() {
+			role := wrappersv2.BuildLeaderWorkerRole("role-1").Obj()
+			role.LeaderWorkerPattern.SharedServiceSelection = nil
+
+			rbg := createRbg("rbg-default", role)
+
+			By("verifying the API server defaulted the policy to LeaderOnly")
+			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).ShouldNot(BeNil())
+			Expect(*rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).
+				Should(Equal(workloadsv1alpha2.SharedServiceSelectionLeaderOnly))
+
+			By("verifying only the leader component is bound to the shared service")
+			serviceNames := componentServiceNames(rbg, &rbg.Spec.Roles[0])
+			Expect(serviceNames[string(constants.LeaderComponentType)]).
+				Should(Equal(rbg.GetServiceName(&rbg.Spec.Roles[0])))
+			Expect(serviceNames[string(constants.WorkerComponentType)]).Should(BeEmpty())
+
+			By("verifying the shared service only selects leader pods")
+			Expect(serviceSelector(rbg, &rbg.Spec.Roles[0])).
+				Should(HaveKeyWithValue(constants.ComponentNameLabelKey, string(constants.LeaderComponentType)))
+
+			By("verifying only the leader pod has a network identity")
+			pods := podsByComponent(rbg.Name, rbg.Spec.Roles[0].Name, 2)
+			leader := pods[string(constants.LeaderComponentType)]
+			Expect(leader.Spec.Hostname).Should(Equal(leader.Name))
+			Expect(leader.Spec.Subdomain).Should(Equal(rbg.GetServiceName(&rbg.Spec.Roles[0])))
+			Expect(pods[string(constants.WorkerComponentType)].Spec.Subdomain).Should(BeEmpty())
+		})
+	})
+
+	Context("When the policy is All", func() {
+		It("Should give every component a serviceName and a pod network identity", func() {
+			role := wrappersv2.BuildLeaderWorkerRole("role-1").Obj()
+			role.LeaderWorkerPattern.SharedServiceSelection = ptr.To(
+				workloadsv1alpha2.SharedServiceSelectionAll,
+			)
+
+			rbg := createRbg("rbg-all", role)
+			svcName := rbg.GetServiceName(&rbg.Spec.Roles[0])
+
+			By("verifying both components are bound to the shared service")
+			serviceNames := componentServiceNames(rbg, &rbg.Spec.Roles[0])
+			Expect(serviceNames[string(constants.LeaderComponentType)]).Should(Equal(svcName))
+			Expect(serviceNames[string(constants.WorkerComponentType)]).Should(Equal(svcName))
+
+			By("verifying the shared service selects every pod of the role")
+			Expect(serviceSelector(rbg, &rbg.Spec.Roles[0])).
+				ShouldNot(HaveKey(constants.ComponentNameLabelKey))
+
+			By("verifying leader and worker pods both have a network identity")
+			pods := podsByComponent(rbg.Name, rbg.Spec.Roles[0].Name, 2)
+			for _, component := range []string{
+				string(constants.LeaderComponentType), string(constants.WorkerComponentType),
+			} {
+				pod := pods[component]
+				Expect(pod.Spec.Hostname).Should(Equal(pod.Name), "component %s", component)
+				Expect(pod.Spec.Subdomain).Should(Equal(svcName), "component %s", component)
+			}
+		})
+	})
+
+	Context("When the role runs on a LeaderWorkerSet workload", func() {
+		// The policy only drives the shared headless service that RBG manages itself, which
+		// LeaderWorkerSet roles do not have. Admission must therefore accept the defaulted
+		// LeaderOnly value on those roles instead of rejecting them.
+		It("Should accept the defaulted policy", func() {
+			role := wrappersv2.BuildLeaderWorkerRole("role-1").
+				WithWorkload("leaderworkerset.x-k8s.io/v1", "LeaderWorkerSet").
+				Obj()
+			role.LeaderWorkerPattern.SharedServiceSelection = nil
+
+			rbg := createRbg("rbg-lws", role)
+
+			Expect(rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).ShouldNot(BeNil())
+			Expect(*rbg.Spec.Roles[0].LeaderWorkerPattern.SharedServiceSelection).
+				Should(Equal(workloadsv1alpha2.SharedServiceSelectionLeaderOnly))
+		})
+	})
+})


### PR DESCRIPTION
### Ⅰ. Motivation

`leaderWorkerPattern.sharedServiceSelection: All` is documented as "the shared headless Service targets every Pod of the role", but worker Pods never actually join that Service in any usable way: they are reachable by IP through the Service's A record, yet they get **no per-Pod DNS name**, because `constructRoleInstanceTemplateByLeaderWorkerPattern` only sets `serviceName` on the **leader** component. `serviceName` is what `setComponentPodIdentity` turns into `pod.spec.hostname` / `pod.spec.subdomain`, so workers end up with neither.

Reproduced on a live cluster with a role that explicitly sets `All`:

```text
NAME                          STATUS    HOSTNAME                      SUBDOMAIN
vllm-pd-cmb-hami-decode-0-0   Running   vllm-pd-cmb-hami-decode-0-0   s-vllm-pd-cmb-hami-decode
vllm-pd-cmb-hami-decode-0-1   Running   <none>                        <none>      <-- worker
```

Secondly, the field had **no default**, while the controller's de-facto behaviour for an unset field was "Service selects all Pods, only the leader has a DNS identity" — a third state that matches neither documented value.

### Ⅱ. Modifications

**Controller** (`pkg/reconciler/`)

- `roleinstanceset_reconciler.go`: under `All`, **every** component is bound to the shared Service via `serviceName`. It is only written when non-empty, so `LeaderOnly` keeps the worker field absent rather than `""` (which would change the ControllerRevision hash).
- `svc_reconciler.go`: the selector now reads the effective policy through the helper below.

**Effective-policy helper** (`api/workloads/v1alpha2/helper.go`)

- Added `(*RoleSpec).GetSharedServiceSelection()`. For an unset field: `RoleInstanceSet` role → `LeaderOnly`; any other workload type → `All`.
- Not a CRD `+kubebuilder:default`: CRD defaulting runs *before* CEL validation, so a stored `LeaderOnly` would be rejected by the `RoleSpec` rule on every role using another workload type — including roles that never set the field. Applying it in the controller keeps the stored field `nil` and leaves the CEL rule intact.
- Scoped by workload type rather than defaulting unconditionally, so the controller and the CEL rule agree. `apps/v1/StatefulSet + leaderWorkerPattern` is rejected by no validation today and `StatefulSetReconciler` ignores the pattern, but it does call `reconcileHeadlessService`. Its Pods never receive `component-name`, so an unconditional `LeaderOnly` would narrow that selector to a label no Pod carries → **zero** endpoints.

**API** — field comment updated only. No struct field changed; the `RoleSpec` CEL rule is unchanged.

**Docs** — KEP updated: semantics, the controller-side default and its scope, the restored `### Validation` section, and a new **Upgrade Considerations** section.

**Generated** — CRDs/manifests regenerated (description text only); `make generate` is clean.
