### PR TITLE
ci: surface /release-test results in the PR merge box

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -11,6 +11,10 @@ env:
   VOLCANO_VERSION: v1.12.0
   LWS_VERSION: v0.7.0
   SCHEDULER_PLUGINS_VERSION: v0.32.7
+  # Commit status contexts mirrored onto the PR head commit. Shared by the pending step
+  # and the reporting job so the two cannot drift apart.
+  STATUS_CONTEXT_HELM: Release Test / e2e-test-helm
+  STATUS_CONTEXT_MANIFEST: Release Test / e2e-test-manifest
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -23,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      statuses: write
     outputs:
       pr_head_sha: ${{ steps.get-pr.outputs.head_sha }}
       pr_ref: ${{ steps.get-pr.outputs.ref }}
@@ -50,6 +55,24 @@ jobs:
             });
             core.setOutput('head_sha', pr.data.head.sha);
             core.setOutput('ref', pr.data.head.ref);
+
+      - name: Report pending status on PR head
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.get-pr.outputs.head_sha }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const name of [process.env.STATUS_CONTEXT_HELM, process.env.STATUS_CONTEXT_MANIFEST]) {
+              await github.rest.repos.createCommitStatus({
+                ...context.repo,
+                sha: process.env.HEAD_SHA,
+                state: 'pending',
+                context: name,
+                target_url: runUrl,
+                description: 'Running',
+              });
+            }
 
   # E2E test using Helm installation with default chart images (no build)
   e2e-test-helm:
@@ -326,3 +349,37 @@ jobs:
         if: always()
         run: |
           kind delete cluster --name rbgs-manifest-e2e || true
+
+  # An issue_comment run is attached to the last commit on the default branch, so its own
+  # checks never surface in the PR merge box. Mirror the results onto the PR head commit.
+  report-status:
+    needs: [check-command, e2e-test-helm, e2e-test-manifest]
+    if: always() && needs.check-command.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Report job results on PR head
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ needs.check-command.outputs.pr_head_sha }}
+          HELM_RESULT: ${{ needs.e2e-test-helm.result }}
+          MANIFEST_RESULT: ${{ needs.e2e-test-manifest.result }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const states = { success: 'success', cancelled: 'error', skipped: 'error' };
+            const results = [
+              [process.env.STATUS_CONTEXT_HELM, process.env.HELM_RESULT],
+              [process.env.STATUS_CONTEXT_MANIFEST, process.env.MANIFEST_RESULT],
+            ];
+            for (const [name, result] of results) {
+              await github.rest.repos.createCommitStatus({
+                ...context.repo,
+                sha: process.env.HEAD_SHA,
+                state: states[result] ?? 'failure',
+                context: name,
+                target_url: runUrl,
+                description: result,
+              });
+            }

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -4,6 +4,12 @@ on:
   issue_comment:
     types: [created]
 
+# A later /release-test on the same PR supersedes earlier ones; without this the older run
+# can finish last and overwrite the newer run's commit statuses.
+concurrency:
+  group: release-test-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: 1.24.1
   KIND_VERSION: v0.31.0
@@ -21,9 +27,12 @@ permissions: read-all
 
 jobs:
   check-command:
+    # statuses: write below lets this job write to the PR merge box, so only trusted
+    # commenters may run the command.
     if: |
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/release-test')
+      contains(github.event.comment.body, '/release-test') &&
+      contains(fromJSON('["OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -5,9 +5,11 @@ on:
     types: [created]
 
 # A later /release-test on the same PR supersedes earlier ones; without this the older run
-# can finish last and overwrite the newer run's commit statuses.
+# can finish last and overwrite the newer run's commit statuses. Concurrency is evaluated
+# before any job `if:`, so the key repeats the command gate — otherwise an unrelated comment
+# on the PR would open a run in this group and cancel an e2e run already in flight.
 concurrency:
-  group: release-test-${{ github.event.issue.number }}
+  group: release-test-${{ github.event.issue.number }}-${{ contains(github.event.comment.body, '/release-test') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) }}
   cancel-in-progress: true
 
 env:
@@ -32,7 +34,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/release-test') &&
-      contains(fromJSON('["OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -82,6 +84,32 @@ jobs:
                 description: 'Running',
               });
             }
+
+  # A silently ignored command looks like broken CI, so tell the commenter it was dropped.
+  reject-command:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/release-test') &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Signal the command was ignored
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: '`/release-test` is restricted to repository collaborators and org members. Ask a maintainer to run it for you.'
+            });
 
   # E2E test using Helm installation with default chart images (no build)
   e2e-test-helm:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,10 @@ Once you've done your work on developing RGB, you are now ready to submit a PR t
    - Ensure all CI tests pass.
    - For PRs that add or modify Go files, ensure the changed files contain the standard Apache 2.0 copyright header. You can check this locally with `make copyright-check`, or automatically add missing headers with `make copyright-fix`.
 
+4. Some PRs — release manifests, Helm chart or image version bumps — benefit from the release e2e suite, which is too slow to run on every push. A maintainer can start it by commenting `/release-test` on the PR. The two results show up on the PR head commit as the `Release Test / e2e-test-helm` and `Release Test / e2e-test-manifest` statuses.
+
+   These statuses are informational, not required checks: they do not block merging, and pushing a new commit leaves that commit without them, so the command has to be re-run if you want fresh results. The command is restricted to repository collaborators and organization members; if anyone else uses it the bot reacts 👎 and does nothing.
+
 ---
 
 ### Tracking Your PR


### PR DESCRIPTION
An issue_comment run is attached to the last commit on the default branch, so its checks are only visible on the Actions page. Mirror both e2e job results onto the PR head commit as commit statuses, with a pending status posted up front so the run shows immediately rather than 40 minutes later.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
