### PR TITLE
ci: drop the removed benchmark dashboard image from the nightly build

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -61,15 +61,6 @@ jobs:
           echo "Target platforms: $PLATFORMS"
           make docker-buildx-push
 
-      - name: Build and push Benchmark Dashboard image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          IMG_REPO: ${{ secrets.DOCKERHUB_USERNAME }}
-        run: |
-          echo "Building and pushing Benchmark Dashboard image with tag: $TAG"
-          make docker-build-benchmark-dashboard
-          make docker-push-benchmark-dashboard
-
       - name: Summary
         run: |
           echo "## Docker Images Build and Push Summary" >> $GITHUB_STEP_SUMMARY
@@ -83,4 +74,3 @@ jobs:
           echo "### Images Pushed" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ secrets.DOCKERHUB_USERNAME }}/rbgs-controller:${{ steps.version.outputs.tag }}\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ secrets.DOCKERHUB_USERNAME }}/rbgs-upgrade-crd:${{ steps.version.outputs.tag }}\` (multi-arch)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ secrets.DOCKERHUB_USERNAME }}/rbgs-benchmark-dashboard:${{ steps.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Removing the CLI in #330 deleted the dashboard Dockerfile along with the docker-build-benchmark-dashboard and docker-push-benchmark-dashboard Makefile targets, but left the nightly workflow calling them. The step has failed with "No rule to make target" every night since, so no run has reported success.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [ ] Format your code `make fmt`.
- [ ] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
