### PR TITLE
fix: validate rolling strategy only when replicas gt 0

### DIFF
--- a/pkg/reconciler/sts_reconciler.go
+++ b/pkg/reconciler/sts_reconciler.go
@@ -640,7 +640,7 @@ func validateRolloutStrategy(
 	if err != nil {
 		return nil, err
 	}
-	if maxUnavailable == 0 && maxSurge == 0 {
+	if replicas > 0 && maxUnavailable == 0 && maxSurge == 0 {
 		return nil, fmt.Errorf(
 			"RollingUpdate is invalid: " +
 				"rolloutStrategy.rollingUpdate.maxUnavailable may not be 0 when maxSurge is 0",

--- a/pkg/reconciler/sts_reconciler_test.go
+++ b/pkg/reconciler/sts_reconciler_test.go
@@ -38,6 +38,48 @@ import (
 	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
 )
 
+func TestValidateRolloutStrategyAllowsZeroReplicas(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxUnavailable intstr.IntOrString
+	}{
+		{name: "percentage", maxUnavailable: intstr.FromString("30%")},
+		{name: "integer", maxUnavailable: intstr.FromInt32(0)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategy := &workloadsv1alpha2.RolloutStrategy{
+				Type: workloadsv1alpha2.RollingUpdateStrategyType,
+				RollingUpdate: &workloadsv1alpha2.RollingUpdate{
+					MaxUnavailable: ptr.To(tt.maxUnavailable),
+					MaxSurge:       ptr.To(intstr.FromInt32(0)),
+					Partition:      ptr.To(intstr.FromInt32(0)),
+				},
+			}
+
+			_, err := validateRolloutStrategy(strategy, 0)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateRolloutStrategyRejectsZeroBudgetWhenReplicasGreaterThanZero(t *testing.T) {
+	strategy := &workloadsv1alpha2.RolloutStrategy{
+		Type: workloadsv1alpha2.RollingUpdateStrategyType,
+		RollingUpdate: &workloadsv1alpha2.RollingUpdate{
+			MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+			MaxSurge:       ptr.To(intstr.FromInt32(0)),
+			Partition:      ptr.To(intstr.FromInt32(0)),
+		},
+	}
+
+	_, err := validateRolloutStrategy(strategy, 1)
+
+	assert.ErrorContains(t, err, "maxUnavailable may not be 0 when maxSurge is 0")
+}
+
 func TestStatefulSetReconciler_Reconciler(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

Bug fix. When the replica count is 0 and `maxUnavailable` is set to percent format, scaling the replicas from 1 to 0 gets stuck.

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

Validate maxSurge and maxUnavailable only when replicas gt 0.

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
