### PR TITLE
Add in-place scheduling injection logs

### DIFF
--- a/pkg/reconciler/roleinstance/sync/node_binding.go
+++ b/pkg/reconciler/roleinstance/sync/node_binding.go
@@ -332,6 +332,9 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 	// 6. Load binding
 	nodes := store.Load(key)
 	if len(nodes) == 0 {
+		klog.InfoS("in-place scheduling: no node binding found, skip hostname affinity injection",
+			"pod", klog.KObj(pod), "instance", klog.KObj(instance),
+			"mode", mode, "granularity", granularity, "key", key)
 		// No binding — if avoid is configured, fold it into every existing
 		// required term (AND semantics). If no required terms exist, add it
 		// as a standalone term.
@@ -362,6 +365,9 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		}
 		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
 			nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
+		klog.V(4).InfoS("in-place scheduling: injected preferred node affinity",
+			"pod", klog.KObj(pod), "instance", klog.KObj(instance),
+			"granularity", granularity, "key", key, "nodes", values)
 
 		// Fold avoid into every required term (AND semantics). If no
 		// required terms exist, a standalone avoid term is created.
@@ -387,6 +393,9 @@ func InjectInPlaceScheduling(pod *v1.Pod, instance *workloadsv1alpha2.RoleInstan
 		}
 		inPlaceExprs = append(inPlaceExprs, avoidExprs...)
 		foldIntoRequired(nodeAffinity, inPlaceExprs)
+		klog.V(4).InfoS("in-place scheduling: injected required node affinity",
+			"pod", klog.KObj(pod), "instance", klog.KObj(instance),
+			"granularity", granularity, "key", key, "nodes", values)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Log when in-place scheduling skips affinity injection because no node binding exists
- Log successful Preferred and Required node affinity injection with mode, granularity, key, and target nodes

## Why
In-place scheduling bindings are currently kept in memory. After a controller restart or leader failover, a recreated pod may have `role-inplace-scheduling: Required` but no binding available in the new controller process. In that case the controller intentionally skips affinity injection, and the resulting pod has an empty node affinity.

Without an explicit log, operators only see Kubernetes events showing the replacement pod was created and scheduled. That makes it hard to distinguish scheduler behavior from the controller having no recovered binding. The new logs make this path visible and also record which nodes are injected when a binding is present.

## Testing
- `GOCACHE=/private/tmp/rbg-go-cache GOMODCACHE=/private/tmp/rbg-go-modcache go test ./pkg/reconciler/roleinstance/sync -count=1`