### PR TITLE
fix: add semantic revision equality check to prevent spurious rollouts

### DIFF
--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -268,6 +268,9 @@ func (r *RoleBasedGroupReconciler) handleRevisions(ctx context.Context, rbg *wor
 		// across client-go versions (e.g., "creationTimestamp": null vs omitted).
 		if utils.SetMatchesRevision(rbg, expectedRevision, currentRevision, r.revisionEqualityCache) {
 			logger.V(4).Info("Revision bytes differ but are semantically equal, skipping creation")
+			// Keep using the persisted revision so downstream role hashes stay
+			// stable across serializer-only changes.
+			expectedRevision = currentRevision
 		} else {
 			logger.Info("Current revision need to be updated")
 			if err := r.client.Create(ctx, expectedRevision); err != nil {

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -97,6 +98,9 @@ type RoleBasedGroupReconciler struct {
 	// still enabled. When false, Deployment/StatefulSet/LeaderWorkerSet are skipped
 	// in cleanup paths (deleteOrphanRoles) to avoid forbidden errors when RBAC is removed.
 	enableDeprecatedWorkloadTypes bool
+	// revisionEqualityCache caches semantic revision equality results to avoid
+	// expensive ApplyRevision + getRBGPatch reconstruction on every reconcile.
+	revisionEqualityCache *lru.Cache
 }
 
 func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.SchedulerPluginType, bindings *instancesync.NodeBindingStore) (*RoleBasedGroupReconciler, error) {
@@ -106,13 +110,14 @@ func NewRoleBasedGroupReconciler(mgr ctrl.Manager, schedulerName scheduler.Sched
 		return nil, err
 	}
 	return &RoleBasedGroupReconciler{
-		client:             c,
-		apiReader:          mgr.GetAPIReader(),
-		scheme:             mgr.GetScheme(),
-		recorder:           mgr.GetEventRecorderFor("RoleBasedGroup"),
-		workloadReconciler: make(map[string]reconciler.WorkloadReconciler),
-		podGroupManager:    podGroupManager,
-		NodeBindings:       bindings,
+		client:                c,
+		apiReader:             mgr.GetAPIReader(),
+		scheme:                mgr.GetScheme(),
+		recorder:              mgr.GetEventRecorderFor("RoleBasedGroup"),
+		workloadReconciler:    make(map[string]reconciler.WorkloadReconciler),
+		podGroupManager:       podGroupManager,
+		NodeBindings:          bindings,
+		revisionEqualityCache: lru.New(utils.MaxRevisionEqualityCacheEntries),
 	}, nil
 }
 
@@ -258,14 +263,21 @@ func (r *RoleBasedGroupReconciler) handleRevisions(ctx context.Context, rbg *wor
 	}
 
 	if !utils.EqualRevision(currentRevision, expectedRevision) {
-		logger.Info("Current revision need to be updated")
-		if err := r.client.Create(ctx, expectedRevision); err != nil {
-			logger.Error(err, fmt.Sprintf("Failed to create revision %v", expectedRevision))
-			r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCreateRevision, "Failed create revision for RoleBasedGroup")
-			return nil, err
+		// If raw bytes differ but the revision is semantically equivalent, avoid
+		// triggering a spurious revision creation. This handles serialization drift
+		// across client-go versions (e.g., "creationTimestamp": null vs omitted).
+		if utils.SetMatchesRevision(rbg, expectedRevision, currentRevision, r.revisionEqualityCache) {
+			logger.V(4).Info("Revision bytes differ but are semantically equal, skipping creation")
 		} else {
-			logger.Info(fmt.Sprintf("Create revision [%s] successfully", expectedRevision.Name))
-			r.recorder.Event(rbg, corev1.EventTypeNormal, SucceedCreateRevision, "Successful create revision for RoleBasedGroup")
+			logger.Info("Current revision need to be updated")
+			if err := r.client.Create(ctx, expectedRevision); err != nil {
+				logger.Error(err, fmt.Sprintf("Failed to create revision %v", expectedRevision))
+				r.recorder.Event(rbg, corev1.EventTypeWarning, FailedCreateRevision, "Failed create revision for RoleBasedGroup")
+				return nil, err
+			} else {
+				logger.Info(fmt.Sprintf("Create revision [%s] successfully", expectedRevision.Name))
+				r.recorder.Event(rbg, corev1.EventTypeNormal, SucceedCreateRevision, "Successful create revision for RoleBasedGroup")
+			}
 		}
 	}
 

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package workloads
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -35,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +51,7 @@ import (
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/scale"
 	"sigs.k8s.io/rbgs/pkg/utils"
+	testutils "sigs.k8s.io/rbgs/test/utils"
 	"sigs.k8s.io/rbgs/test/wrappers"
 	wrappersv2 "sigs.k8s.io/rbgs/test/wrappers/v1alpha2"
 )
@@ -2101,5 +2105,76 @@ func TestCalculateScalingForAllCoordination_MultipleCoordinations(t *testing.T) 
 				}
 			}
 		})
+	}
+}
+
+func Test_HandleRevisions_SemanticallyEqualRevisionKeepsPersistedRoleHash(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(testScheme)
+	_ = workloadsv1alpha2.AddToScheme(testScheme)
+
+	rbg := wrappersv2.BuildBasicRoleBasedGroup("test-rbg", "default").Obj()
+	rbg.Generation = 1
+
+	ctx := ctrl.LoggerInto(context.TODO(), zap.New().WithValues("env", "unit-test"))
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(rbg).Build()
+
+	// A revision persisted by an older client-go: same spec, but its patch spells
+	// out "creationTimestamp": null instead of omitting it.
+	persistedRevision, err := utils.NewRevision(ctx, fakeClient, rbg, nil)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	legacyPatch, err := testutils.WithLegacyCreationTimestamp(persistedRevision.Data.Raw)
+	if err != nil {
+		t.Fatalf("WithLegacyCreationTimestamp() error = %v", err)
+	}
+	if bytes.Equal(legacyPatch, persistedRevision.Data.Raw) {
+		t.Fatalf("drift injection must actually change the patch bytes")
+	}
+	persistedRevision.Data.Raw = legacyPatch
+	if err := fakeClient.Create(ctx, persistedRevision); err != nil {
+		t.Fatalf("failed to seed persisted revision: %v", err)
+	}
+
+	freshRevision, err := utils.NewRevision(ctx, fakeClient, rbg, persistedRevision)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v", err)
+	}
+	persistedHash, err := utils.GetRolesRevisionHash(persistedRevision)
+	if err != nil {
+		t.Fatalf("GetRolesRevisionHash(persisted) error = %v", err)
+	}
+	freshHash, err := utils.GetRolesRevisionHash(freshRevision)
+	if err != nil {
+		t.Fatalf("GetRolesRevisionHash(fresh) error = %v", err)
+	}
+	if reflect.DeepEqual(persistedHash, freshHash) {
+		t.Fatalf("fixture is not exercising the regression: legacy and fresh role hashes are identical")
+	}
+
+	r := &RoleBasedGroupReconciler{
+		client:                fakeClient,
+		apiReader:             fakeClient,
+		scheme:                testScheme,
+		recorder:              record.NewFakeRecorder(10),
+		revisionEqualityCache: lru.New(utils.MaxRevisionEqualityCacheEntries),
+	}
+
+	gotHash, err := r.handleRevisions(ctx, rbg)
+	if err != nil {
+		t.Fatalf("handleRevisions() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(gotHash, persistedHash) {
+		t.Errorf("handleRevisions() hash = %v, want persisted revision hash %v", gotHash, persistedHash)
+	}
+
+	revisionList := &appsv1.ControllerRevisionList{}
+	if err := fakeClient.List(ctx, revisionList, client.InNamespace(rbg.Namespace)); err != nil {
+		t.Fatalf("failed to list revisions: %v", err)
+	}
+	if len(revisionList.Items) != 1 {
+		t.Errorf("expected no new ControllerRevision, got %d revisions", len(revisionList.Items))
 	}
 }

--- a/pkg/reconciler/roleinstance/instance_reconciler.go
+++ b/pkg/reconciler/roleinstance/instance_reconciler.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,6 +44,7 @@ import (
 	revisioncontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/revision"
 	synccontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/sync"
 	instanceutil "sigs.k8s.io/rbgs/pkg/reconciler/roleinstance/utils"
+	pkgutils "sigs.k8s.io/rbgs/pkg/utils"
 	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 	"sigs.k8s.io/rbgs/pkg/utils/fieldindex"
 )
@@ -51,13 +53,14 @@ func NewReconciler(mgr ctrl.Manager, bindings *synccontrol.NodeBindingStore) rec
 	recorder := mgr.GetEventRecorderFor("instance-controller")
 	c := utilclient.NewClientWithUserAgent(mgr, "roleinstance")
 	return &reconciler{
-		Client:            c,
-		scheme:            mgr.GetScheme(),
-		recorder:          recorder,
-		controllerHistory: historyutil.NewHistory(c),
-		statusUpdater:     newStatusUpdater(c),
-		revisionControl:   revisioncontrol.NewRevisionControl(),
-		syncControl:       synccontrol.New(c, mgr.GetAPIReader(), recorder, bindings),
+		Client:                c,
+		scheme:                mgr.GetScheme(),
+		recorder:              recorder,
+		controllerHistory:     historyutil.NewHistory(c),
+		statusUpdater:         newStatusUpdater(c),
+		revisionControl:       revisioncontrol.NewRevisionControl(),
+		syncControl:           synccontrol.New(c, mgr.GetAPIReader(), recorder, bindings),
+		revisionEqualityCache: lru.New(pkgutils.MaxRevisionEqualityCacheEntries),
 	}
 }
 
@@ -69,6 +72,9 @@ type reconciler struct {
 	revisionControl   revisioncontrol.Interface
 	syncControl       synccontrol.Interface
 	recorder          record.EventRecorder
+	// revisionEqualityCache caches semantic revision equality results to avoid
+	// expensive ApplyRevision + buildPatch reconstruction on every reconcile.
+	revisionEqualityCache *lru.Cache
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, retErr error) {
@@ -273,12 +279,19 @@ func (r *reconciler) getActiveRevisions(instance *workloadsv1alpha2.RoleInstance
 		if err != nil {
 			return nil, nil, collisionCount, err
 		}
+	} else if revisionCount > 0 && r.revisionControl.SetMatchesRevision(instance, updateRevision, revisions[revisionCount-1], r.revisionEqualityCache) {
+		// if there is no equivalent revision we check semantic equality before creating a new one.
+		// This handles serialization drift across client-go versions (e.g.,
+		// "creationTimestamp": null vs omitted) that causes EqualRevision to
+		// wrongly return false.
+		updateRevision = revisions[revisionCount-1]
 	} else {
 		updateRevision, err = r.controllerHistory.CreateControllerRevision(instance, updateRevision, &collisionCount)
 		if err != nil {
 			return nil, nil, collisionCount, err
 		}
 	}
+
 	for i := range revisions {
 		if revisions[i].Name == instance.Status.CurrentRevision {
 			currentRevision = revisions[i]

--- a/pkg/reconciler/roleinstance/revision/instance_revision.go
+++ b/pkg/reconciler/roleinstance/revision/instance_revision.go
@@ -17,12 +17,15 @@ limitations under the License.
 package revision
 
 import (
+	"bytes"
 	"encoding/json"
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/client-go/clientset/versioned/scheme"
@@ -37,6 +40,7 @@ var (
 type Interface interface {
 	NewRevision(instance *workloadsv1alpha2.RoleInstance, revision int64, collisionCount *int32) (*apps.ControllerRevision, error)
 	ApplyRevision(instance *workloadsv1alpha2.RoleInstance, revision *apps.ControllerRevision) (*workloadsv1alpha2.RoleInstance, error)
+	SetMatchesRevision(instance *workloadsv1alpha2.RoleInstance, proposedRevision *apps.ControllerRevision, existingRevision *apps.ControllerRevision, cache *lru.Cache) bool
 }
 
 // NewRevisionControl create a normal revision control.
@@ -84,6 +88,55 @@ func (c *realControl) ApplyRevision(instance *workloadsv1alpha2.RoleInstance, re
 	}
 	coreControl := instancecore.New(instance)
 	return coreControl.ApplyRevisionPatch(patched)
+}
+
+// revisionEqualityCacheKey uniquely identifies a semantic equality result by
+// combining the RoleInstance UID, its generation, and the ResourceVersion
+// of the existing ControllerRevision being compared.
+type revisionEqualityCacheKey struct {
+	instanceUID             types.UID
+	instanceGeneration      int64
+	revisionResourceVersion string
+}
+
+// SetMatchesRevision returns true if the proposedRevision (generated from the
+// current instance spec) semantically matches the existingRevision, even when
+// their raw bytes differ due to serialization changes across client-go
+// versions. It works by applying the existing revision back to the instance,
+// re-generating a patch with the current serialization format, and comparing
+// the raw bytes. Results are cached in the provided LRU cache to avoid
+// expensive reconstruction on every reconcile.
+func (c *realControl) SetMatchesRevision(
+	instance *workloadsv1alpha2.RoleInstance,
+	proposedRevision *apps.ControllerRevision,
+	existingRevision *apps.ControllerRevision,
+	cache *lru.Cache,
+) bool {
+	if existingRevision == nil || proposedRevision == nil {
+		return false
+	}
+	cacheKey := revisionEqualityCacheKey{
+		instanceUID:             instance.UID,
+		instanceGeneration:      instance.Generation,
+		revisionResourceVersion: existingRevision.ResourceVersion,
+	}
+	if _, ok := cache.Get(cacheKey); ok {
+		return true
+	}
+	restoredInstance, err := c.ApplyRevision(instance, existingRevision)
+	if err != nil {
+		return false
+	}
+	coreControl := instancecore.New(restoredInstance)
+	reconstructedPatch, err := c.buildPatch(restoredInstance, coreControl)
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {
+		cache.Add(cacheKey, struct{}{})
+		return true
+	}
+	return false
 }
 
 func (c *realControl) buildPatch(instance *workloadsv1alpha2.RoleInstance, coreControl instancecore.Control) ([]byte, error) {

--- a/pkg/reconciler/roleinstance/revision/instance_revision.go
+++ b/pkg/reconciler/roleinstance/revision/instance_revision.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/lru"
 
@@ -112,7 +113,7 @@ func (c *realControl) SetMatchesRevision(
 	existingRevision *apps.ControllerRevision,
 	cache *lru.Cache,
 ) bool {
-	if existingRevision == nil || proposedRevision == nil {
+	if existingRevision == nil || proposedRevision == nil || cache == nil {
 		return false
 	}
 	cacheKey := revisionEqualityCacheKey{
@@ -125,11 +126,15 @@ func (c *realControl) SetMatchesRevision(
 	}
 	restoredInstance, err := c.ApplyRevision(instance, existingRevision)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: ApplyRevision failed, falling back to new revision creation",
+			"instance", klog.KRef(instance.Namespace, instance.Name), "err", err)
 		return false
 	}
 	coreControl := instancecore.New(restoredInstance)
 	reconstructedPatch, err := c.buildPatch(restoredInstance, coreControl)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: buildPatch failed, falling back to new revision creation",
+			"instance", klog.KRef(instance.Namespace, instance.Name), "err", err)
 		return false
 	}
 	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {

--- a/pkg/reconciler/roleinstance/revision/instance_revision_test.go
+++ b/pkg/reconciler/roleinstance/revision/instance_revision_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package revision
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	testutils "sigs.k8s.io/rbgs/test/utils"
 )
 
 const maxRevisionEqualityCacheEntries = 10000
@@ -57,38 +57,6 @@ func newRevisionTestInstance(image string) *workloadsv1alpha2.RoleInstance {
 	}
 }
 
-// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
-// carry an explicit "creationTimestamp": null, reproducing how older client-go
-// versions serialized revisions. It edits the parsed tree rather than the raw
-// text, so the result stays valid JSON regardless of the fixture's shape.
-func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
-	t.Helper()
-	var tree interface{}
-	require.NoError(t, json.Unmarshal(patch, &tree))
-
-	var inject func(node interface{})
-	inject = func(node interface{}) {
-		switch n := node.(type) {
-		case map[string]interface{}:
-			for key, child := range n {
-				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
-					meta["creationTimestamp"] = nil
-				}
-				inject(child)
-			}
-		case []interface{}:
-			for _, child := range n {
-				inject(child)
-			}
-		}
-	}
-	inject(tree)
-
-	legacy, err := json.Marshal(tree)
-	require.NoError(t, err)
-	return legacy
-}
-
 func TestSetMatchesRevision(t *testing.T) {
 	control := NewRevisionControl()
 	instance := newRevisionTestInstance("nginx:1.0")
@@ -108,7 +76,8 @@ func TestSetMatchesRevision(t *testing.T) {
 
 	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
 		cache := lru.New(maxRevisionEqualityCacheEntries)
-		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		legacyPatch, err := testutils.WithLegacyCreationTimestamp(proposedRevision.Data.Raw)
+		require.NoError(t, err)
 		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
 
 		existingRevision := &apps.ControllerRevision{

--- a/pkg/reconciler/roleinstance/revision/instance_revision_test.go
+++ b/pkg/reconciler/roleinstance/revision/instance_revision_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/lru"
+	"k8s.io/utils/ptr"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+const maxRevisionEqualityCacheEntries = 10000
+
+func newRevisionTestInstance(image string) *workloadsv1alpha2.RoleInstance {
+	return &workloadsv1alpha2.RoleInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-instance",
+			Namespace:  "default",
+			UID:        "test-instance-uid",
+			Generation: 1,
+		},
+		Spec: workloadsv1alpha2.RoleInstanceSpec{
+			Components: []workloadsv1alpha2.RoleInstanceComponent{
+				{
+					Name: "worker",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "app", Image: image}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
+// carry an explicit "creationTimestamp": null, reproducing how older client-go
+// versions serialized revisions. It edits the parsed tree rather than the raw
+// text, so the result stays valid JSON regardless of the fixture's shape.
+func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
+	t.Helper()
+	var tree interface{}
+	require.NoError(t, json.Unmarshal(patch, &tree))
+
+	var inject func(node interface{})
+	inject = func(node interface{}) {
+		switch n := node.(type) {
+		case map[string]interface{}:
+			for key, child := range n {
+				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
+					meta["creationTimestamp"] = nil
+				}
+				inject(child)
+			}
+		case []interface{}:
+			for _, child := range n {
+				inject(child)
+			}
+		}
+	}
+	inject(tree)
+
+	legacy, err := json.Marshal(tree)
+	require.NoError(t, err)
+	return legacy
+}
+
+func TestSetMatchesRevision(t *testing.T) {
+	control := NewRevisionControl()
+	instance := newRevisionTestInstance("nginx:1.0")
+
+	proposedRevision, err := control.NewRevision(instance, 1, ptr.To(int32(0)))
+	assert.NoError(t, err)
+
+	t.Run("IdenticalBytes_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache),
+			"identical patch bytes should be semantically equal")
+	})
+
+	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
+
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: legacyPatch},
+		}
+		assert.True(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache),
+			"legacy creationTimestamp serialization should still match semantically")
+	})
+
+	t.Run("TrulyDifferentSpec_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		differentRevision, err := control.NewRevision(newRevisionTestInstance("nginx:999"), 1, ptr.To(int32(0)))
+		assert.NoError(t, err)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: differentRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache),
+			"revisions with truly different specs should not match")
+	})
+
+	t.Run("CacheHit_SecondCallReturnsTrue", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache))
+		assert.True(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache))
+		assert.Equal(t, 1, cache.Len())
+	})
+
+	t.Run("NilExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		assert.False(t, control.SetMatchesRevision(instance, proposedRevision, nil, cache))
+	})
+
+	t.Run("NilProposedRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(instance, nil, existingRevision, cache))
+	})
+
+	t.Run("NilCache_ReturnsFalseNoPanic", func(t *testing.T) {
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, nil))
+	})
+
+	t.Run("CorruptedExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: []byte("invalid-json")},
+		}
+		assert.False(t, control.SetMatchesRevision(instance, proposedRevision, existingRevision, cache),
+			"corrupted revision data should return false, not panic")
+		assert.Equal(t, 0, cache.Len())
+	})
+}

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	instanceinplace "sigs.k8s.io/rbgs/pkg/inplace/instance/inplaceupdate"
@@ -143,12 +144,13 @@ func NewDefaultStatefulInstanceSetControl(
 	controllerHistory history.Interface,
 	recorder record.EventRecorder) StatefulInstanceSetControlInterface {
 	return &defaultStatefulInstanceSetControl{
-		instanceControl,
-		statusUpdater,
-		controllerHistory,
-		recorder,
-		inplaceControl,
-		lifecycleControl,
+		instanceControl:       instanceControl,
+		statusUpdater:         statusUpdater,
+		controllerHistory:     controllerHistory,
+		recorder:              recorder,
+		inplaceControl:        inplaceControl,
+		lifecycleControl:      lifecycleControl,
+		revisionEqualityCache: lru.New(utils.MaxRevisionEqualityCacheEntries),
 	}
 }
 
@@ -162,6 +164,9 @@ type defaultStatefulInstanceSetControl struct {
 	recorder          record.EventRecorder
 	inplaceControl    instanceinplace.Interface
 	lifecycleControl  instancelifecycle.Interface
+	// revisionEqualityCache caches semantic revision equality results to avoid
+	// expensive ApplyRevision + getPatch reconstruction on every reconcile.
+	revisionEqualityCache *lru.Cache
 }
 
 // UpdateStatefulInstanceSet executes the core logic loop for a stateful set managing instances
@@ -320,10 +325,17 @@ func (ssc *defaultStatefulInstanceSetControl) getInstanceSetRevisions(
 			}
 		}
 	} else {
-		// if there is no equivalent revision we create a new one
-		updateRevision, err = ssc.controllerHistory.CreateControllerRevision(set, updateRevision, &collisionCount)
-		if err != nil {
-			return nil, nil, collisionCount, err
+		// if there is no equivalent revision we check semantic equality before creating a new one.
+		// This handles serialization drift across client-go versions (e.g.,
+		// "creationTimestamp": null vs omitted) that causes EqualRevision to
+		// wrongly return false.
+		if revisionCount > 0 && SetMatchesRevision(set, updateRevision, revisions[revisionCount-1], ssc.revisionEqualityCache) {
+			updateRevision = revisions[revisionCount-1]
+		} else {
+			updateRevision, err = ssc.controllerHistory.CreateControllerRevision(set, updateRevision, &collisionCount)
+			if err != nil {
+				return nil, nil, collisionCount, err
+			}
 		}
 	}
 

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper.go
@@ -31,6 +31,7 @@ import (
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/lru"
 
@@ -155,7 +156,7 @@ func SetMatchesRevision(
 	existingRevision *apps.ControllerRevision,
 	cache *lru.Cache,
 ) bool {
-	if existingRevision == nil || proposedRevision == nil {
+	if existingRevision == nil || proposedRevision == nil || cache == nil {
 		return false
 	}
 	cacheKey := revisionEqualityCacheKey{
@@ -168,10 +169,14 @@ func SetMatchesRevision(
 	}
 	restoredSet, err := ApplyRevision(set, existingRevision)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: ApplyRevision failed, falling back to new revision creation",
+			"set", klog.KRef(set.Namespace, set.Name), "err", err)
 		return false
 	}
 	reconstructedPatch, err := getPatch(restoredSet)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: getPatch failed, falling back to new revision creation",
+			"set", klog.KRef(set.Namespace, set.Name), "err", err)
 		return false
 	}
 	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper.go
@@ -19,6 +19,7 @@ limitations under the License.
 package statefulmode
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -26,10 +27,12 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
@@ -128,6 +131,54 @@ func ApplyRevision(set *workloadsv1alpha2.RoleInstanceSet, revision *apps.Contro
 		return nil, err
 	}
 	return restoredSet, nil
+}
+
+// revisionEqualityCacheKey uniquely identifies a semantic equality result by
+// combining the RoleInstanceSet UID, its generation, and the ResourceVersion
+// of the existing ControllerRevision being compared.
+type revisionEqualityCacheKey struct {
+	setUID                  types.UID
+	setGeneration           int64
+	revisionResourceVersion string
+}
+
+// SetMatchesRevision returns true if the proposedRevision (generated from the
+// current set spec) semantically matches the existingRevision, even when their
+// raw bytes differ due to serialization changes across client-go versions.
+// It works by applying the existing revision back to the set, re-generating a
+// patch with the current serialization format, and comparing the raw bytes.
+// Results are cached in the provided LRU cache to avoid expensive
+// reconstruction on every reconcile.
+func SetMatchesRevision(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	proposedRevision *apps.ControllerRevision,
+	existingRevision *apps.ControllerRevision,
+	cache *lru.Cache,
+) bool {
+	if existingRevision == nil || proposedRevision == nil {
+		return false
+	}
+	cacheKey := revisionEqualityCacheKey{
+		setUID:                  set.UID,
+		setGeneration:           set.Generation,
+		revisionResourceVersion: existingRevision.ResourceVersion,
+	}
+	if _, ok := cache.Get(cacheKey); ok {
+		return true
+	}
+	restoredSet, err := ApplyRevision(set, existingRevision)
+	if err != nil {
+		return false
+	}
+	reconstructedPatch, err := getPatch(restoredSet)
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {
+		cache.Add(cacheKey, struct{}{})
+		return true
+	}
+	return false
 }
 
 // updateStatus updates the status fields of set based on the current and update revisions and instances

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package statefulmode
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	testutils "sigs.k8s.io/rbgs/test/utils"
 )
 
 const maxRevisionEqualityCacheEntries = 10000
@@ -68,38 +68,6 @@ func newRevisionTestSet(image string) *workloadsv1alpha2.RoleInstanceSet {
 	}
 }
 
-// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
-// carry an explicit "creationTimestamp": null, reproducing how older client-go
-// versions serialized revisions. It edits the parsed tree rather than the raw
-// text, so the result stays valid JSON regardless of the fixture's shape.
-func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
-	t.Helper()
-	var tree interface{}
-	require.NoError(t, json.Unmarshal(patch, &tree))
-
-	var inject func(node interface{})
-	inject = func(node interface{}) {
-		switch n := node.(type) {
-		case map[string]interface{}:
-			for key, child := range n {
-				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
-					meta["creationTimestamp"] = nil
-				}
-				inject(child)
-			}
-		case []interface{}:
-			for _, child := range n {
-				inject(child)
-			}
-		}
-	}
-	inject(tree)
-
-	legacy, err := json.Marshal(tree)
-	require.NoError(t, err)
-	return legacy
-}
-
 func TestSetMatchesRevision(t *testing.T) {
 	set := newRevisionTestSet("nginx:1.0")
 
@@ -118,7 +86,8 @@ func TestSetMatchesRevision(t *testing.T) {
 
 	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
 		cache := lru.New(maxRevisionEqualityCacheEntries)
-		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		legacyPatch, err := testutils.WithLegacyCreationTimestamp(proposedRevision.Data.Raw)
+		require.NoError(t, err)
 		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
 
 		existingRevision := &apps.ControllerRevision{

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulmode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/lru"
+	"k8s.io/utils/ptr"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+const maxRevisionEqualityCacheEntries = 10000
+
+// The package-level patchCodec resolves types against the client-go global
+// scheme, mirroring the registration cmd/rbgs/main.go performs at startup.
+func init() {
+	_ = workloadsv1alpha2.AddToScheme(clientgoscheme.Scheme)
+}
+
+func newRevisionTestSet(image string) *workloadsv1alpha2.RoleInstanceSet {
+	return &workloadsv1alpha2.RoleInstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-set",
+			Namespace:  "default",
+			UID:        "test-set-uid",
+			Generation: 1,
+		},
+		Spec: workloadsv1alpha2.RoleInstanceSetSpec{
+			RoleInstanceTemplate: workloadsv1alpha2.RoleInstanceTemplate{
+				RoleInstanceSpec: workloadsv1alpha2.RoleInstanceSpec{
+					Components: []workloadsv1alpha2.RoleInstanceComponent{
+						{
+							Name: "worker",
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{Name: "app", Image: image}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
+// carry an explicit "creationTimestamp": null, reproducing how older client-go
+// versions serialized revisions. It edits the parsed tree rather than the raw
+// text, so the result stays valid JSON regardless of the fixture's shape.
+func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
+	t.Helper()
+	var tree interface{}
+	require.NoError(t, json.Unmarshal(patch, &tree))
+
+	var inject func(node interface{})
+	inject = func(node interface{}) {
+		switch n := node.(type) {
+		case map[string]interface{}:
+			for key, child := range n {
+				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
+					meta["creationTimestamp"] = nil
+				}
+				inject(child)
+			}
+		case []interface{}:
+			for _, child := range n {
+				inject(child)
+			}
+		}
+	}
+	inject(tree)
+
+	legacy, err := json.Marshal(tree)
+	require.NoError(t, err)
+	return legacy
+}
+
+func TestSetMatchesRevision(t *testing.T) {
+	set := newRevisionTestSet("nginx:1.0")
+
+	proposedRevision, err := newRevision(set, 1, ptr.To(int32(0)))
+	assert.NoError(t, err)
+
+	t.Run("IdenticalBytes_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"identical patch bytes should be semantically equal")
+	})
+
+	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
+
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: legacyPatch},
+		}
+		assert.True(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"legacy creationTimestamp serialization should still match semantically")
+	})
+
+	t.Run("TrulyDifferentSpec_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		differentRevision, err := newRevision(newRevisionTestSet("nginx:999"), 1, ptr.To(int32(0)))
+		assert.NoError(t, err)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: differentRevision.Data.Raw},
+		}
+		assert.False(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"revisions with truly different specs should not match")
+	})
+
+	t.Run("CacheHit_SecondCallReturnsTrue", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache))
+		assert.True(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache))
+		assert.Equal(t, 1, cache.Len())
+	})
+
+	t.Run("NilExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		assert.False(t, SetMatchesRevision(set, proposedRevision, nil, cache))
+	})
+
+	t.Run("NilProposedRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, SetMatchesRevision(set, nil, existingRevision, cache))
+	})
+
+	t.Run("NilCache_ReturnsFalseNoPanic", func(t *testing.T) {
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, SetMatchesRevision(set, proposedRevision, existingRevision, nil))
+	})
+
+	t.Run("CorruptedExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: []byte("invalid-json")},
+		}
+		assert.False(t, SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"corrupted revision data should return false, not panic")
+		assert.Equal(t, 0, cache.Len())
+	})
+}

--- a/pkg/reconciler/roleinstanceset/statelessmode/reconciler.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,6 +42,7 @@ import (
 	revisioncontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/revision"
 	synccontrol "sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/sync"
 	"sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/utils"
+	pkgutils "sigs.k8s.io/rbgs/pkg/utils"
 	utilclient "sigs.k8s.io/rbgs/pkg/utils/client"
 )
 
@@ -48,13 +50,14 @@ func NewReconciler(mgr ctrl.Manager) reconcile.Reconciler {
 	recorder := mgr.GetEventRecorderFor("instanceset-controller")
 	c := utilclient.NewClientWithUserAgent(mgr, "roleinstanceset")
 	return &ReconcileInstanceSet{
-		Client:            c,
-		scheme:            mgr.GetScheme(),
-		recorder:          recorder,
-		controllerHistory: historyutil.NewHistory(c),
-		statusUpdater:     newStatusUpdater(c),
-		revisionControl:   revisioncontrol.NewRevisionControl(),
-		syncControl:       synccontrol.New(c, recorder),
+		Client:                c,
+		scheme:                mgr.GetScheme(),
+		recorder:              recorder,
+		controllerHistory:     historyutil.NewHistory(c),
+		statusUpdater:         newStatusUpdater(c),
+		revisionControl:       revisioncontrol.NewRevisionControl(),
+		syncControl:           synccontrol.New(c, recorder),
+		revisionEqualityCache: lru.New(pkgutils.MaxRevisionEqualityCacheEntries),
 	}
 }
 
@@ -68,6 +71,9 @@ type ReconcileInstanceSet struct {
 	statusUpdater     StatusUpdater
 	revisionControl   revisioncontrol.Interface
 	syncControl       synccontrol.Interface
+	// revisionEqualityCache caches semantic revision equality results to avoid
+	// expensive ApplyRevision + getPatch reconstruction on every reconcile.
+	revisionEqualityCache *lru.Cache
 }
 
 // Reconcile reads that state of the cluster for a InstanceSet object and makes changes based on the state read
@@ -288,6 +294,12 @@ func (r *ReconcileInstanceSet) getActiveRevisions(set *workloadsv1alpha2.RoleIns
 		if err != nil {
 			return nil, nil, collisionCount, err
 		}
+	} else if revisionCount > 0 && r.revisionControl.SetMatchesRevision(set, updateRevision, revisions[revisionCount-1], r.revisionEqualityCache) {
+		// if there is no equivalent revision we check semantic equality before creating a new one.
+		// This handles serialization drift across client-go versions (e.g.,
+		// "creationTimestamp": null vs omitted) that causes EqualRevision to
+		// wrongly return false.
+		updateRevision = revisions[revisionCount-1]
 	} else {
 		// if there is no equivalent revision we create a new one
 		updateRevision, err = r.controllerHistory.CreateControllerRevision(set, updateRevision, &collisionCount)

--- a/pkg/reconciler/roleinstanceset/statelessmode/revision/revision.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/revision/revision.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/lru"
 
@@ -134,7 +135,7 @@ func (c *realControl) SetMatchesRevision(
 	existingRevision *apps.ControllerRevision,
 	cache *lru.Cache,
 ) bool {
-	if existingRevision == nil || proposedRevision == nil {
+	if existingRevision == nil || proposedRevision == nil || cache == nil {
 		return false
 	}
 	cacheKey := revisionEqualityCacheKey{
@@ -147,11 +148,15 @@ func (c *realControl) SetMatchesRevision(
 	}
 	restoredSet, err := c.ApplyRevision(set, existingRevision)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: ApplyRevision failed, falling back to new revision creation",
+			"set", klog.KRef(set.Namespace, set.Name), "err", err)
 		return false
 	}
 	coreControl := core.New(restoredSet)
 	reconstructedPatch, err := c.getPatch(restoredSet, coreControl)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: getPatch failed, falling back to new revision creation",
+			"set", klog.KRef(set.Namespace, set.Name), "err", err)
 		return false
 	}
 	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {

--- a/pkg/reconciler/roleinstanceset/statelessmode/revision/revision.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/revision/revision.go
@@ -17,13 +17,16 @@ limitations under the License.
 package revision
 
 import (
+	"bytes"
 	"encoding/json"
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/utils/lru"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/pkg/reconciler/roleinstanceset/statelessmode/core"
@@ -38,6 +41,7 @@ var (
 type Interface interface {
 	NewRevision(set *workloadsv1alpha2.RoleInstanceSet, revision int64, collisionCount *int32) (*apps.ControllerRevision, error)
 	ApplyRevision(set *workloadsv1alpha2.RoleInstanceSet, revision *apps.ControllerRevision) (*workloadsv1alpha2.RoleInstanceSet, error)
+	SetMatchesRevision(set *workloadsv1alpha2.RoleInstanceSet, proposedRevision *apps.ControllerRevision, existingRevision *apps.ControllerRevision, cache *lru.Cache) bool
 }
 
 // NewRevisionControl create a normal revision control.
@@ -106,4 +110,53 @@ func (c *realControl) ApplyRevision(set *workloadsv1alpha2.RoleInstanceSet, revi
 	}
 	coreControl := core.New(clone)
 	return coreControl.ApplyRevisionPatch(patched)
+}
+
+// revisionEqualityCacheKey uniquely identifies a semantic equality result by
+// combining the RoleInstanceSet UID, its generation, and the ResourceVersion
+// of the existing ControllerRevision being compared.
+type revisionEqualityCacheKey struct {
+	setUID                  types.UID
+	setGeneration           int64
+	revisionResourceVersion string
+}
+
+// SetMatchesRevision returns true if the proposedRevision (generated from the
+// current set spec) semantically matches the existingRevision, even when their
+// raw bytes differ due to serialization changes across client-go versions.
+// It works by applying the existing revision back to the set, re-generating a
+// patch with the current serialization format, and comparing the raw bytes.
+// Results are cached in the provided LRU cache to avoid expensive
+// reconstruction on every reconcile.
+func (c *realControl) SetMatchesRevision(
+	set *workloadsv1alpha2.RoleInstanceSet,
+	proposedRevision *apps.ControllerRevision,
+	existingRevision *apps.ControllerRevision,
+	cache *lru.Cache,
+) bool {
+	if existingRevision == nil || proposedRevision == nil {
+		return false
+	}
+	cacheKey := revisionEqualityCacheKey{
+		setUID:                  set.UID,
+		setGeneration:           set.Generation,
+		revisionResourceVersion: existingRevision.ResourceVersion,
+	}
+	if _, ok := cache.Get(cacheKey); ok {
+		return true
+	}
+	restoredSet, err := c.ApplyRevision(set, existingRevision)
+	if err != nil {
+		return false
+	}
+	coreControl := core.New(restoredSet)
+	reconstructedPatch, err := c.getPatch(restoredSet, coreControl)
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {
+		cache.Add(cacheKey, struct{}{})
+		return true
+	}
+	return false
 }

--- a/pkg/reconciler/roleinstanceset/statelessmode/revision/revision_test.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/revision/revision_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/lru"
+	"k8s.io/utils/ptr"
+
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+)
+
+const maxRevisionEqualityCacheEntries = 10000
+
+// patchCodec resolves types against the client-go global scheme, mirroring the
+// registration cmd/rbgs/main.go performs at startup.
+func init() {
+	_ = workloadsv1alpha2.AddToScheme(clientgoscheme.Scheme)
+}
+
+func newRevisionTestSet(image string) *workloadsv1alpha2.RoleInstanceSet {
+	return &workloadsv1alpha2.RoleInstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-set",
+			Namespace:  "default",
+			UID:        "test-set-uid",
+			Generation: 1,
+		},
+		Spec: workloadsv1alpha2.RoleInstanceSetSpec{
+			RoleInstanceTemplate: workloadsv1alpha2.RoleInstanceTemplate{
+				RoleInstanceSpec: workloadsv1alpha2.RoleInstanceSpec{
+					Components: []workloadsv1alpha2.RoleInstanceComponent{
+						{
+							Name: "worker",
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{Name: "app", Image: image}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
+// carry an explicit "creationTimestamp": null, reproducing how older client-go
+// versions serialized revisions. It edits the parsed tree rather than the raw
+// text, so the result stays valid JSON regardless of the fixture's shape.
+func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
+	t.Helper()
+	var tree interface{}
+	require.NoError(t, json.Unmarshal(patch, &tree))
+
+	var inject func(node interface{})
+	inject = func(node interface{}) {
+		switch n := node.(type) {
+		case map[string]interface{}:
+			for key, child := range n {
+				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
+					meta["creationTimestamp"] = nil
+				}
+				inject(child)
+			}
+		case []interface{}:
+			for _, child := range n {
+				inject(child)
+			}
+		}
+	}
+	inject(tree)
+
+	legacy, err := json.Marshal(tree)
+	require.NoError(t, err)
+	return legacy
+}
+
+func TestSetMatchesRevision(t *testing.T) {
+	control := NewRevisionControl()
+	set := newRevisionTestSet("nginx:1.0")
+
+	proposedRevision, err := control.NewRevision(set, 1, ptr.To(int32(0)))
+	assert.NoError(t, err)
+
+	t.Run("IdenticalBytes_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"identical patch bytes should be semantically equal")
+	})
+
+	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
+
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: legacyPatch},
+		}
+		assert.True(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"legacy creationTimestamp serialization should still match semantically")
+	})
+
+	t.Run("TrulyDifferentSpec_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		differentRevision, err := control.NewRevision(newRevisionTestSet("nginx:999"), 1, ptr.To(int32(0)))
+		assert.NoError(t, err)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: differentRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"revisions with truly different specs should not match")
+	})
+
+	t.Run("CacheHit_SecondCallReturnsTrue", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.True(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache))
+		assert.True(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache))
+		assert.Equal(t, 1, cache.Len())
+	})
+
+	t.Run("NilExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		assert.False(t, control.SetMatchesRevision(set, proposedRevision, nil, cache))
+	})
+
+	t.Run("NilProposedRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(set, nil, existingRevision, cache))
+	})
+
+	t.Run("NilCache_ReturnsFalseNoPanic", func(t *testing.T) {
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedRevision.Data.Raw},
+		}
+		assert.False(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, nil))
+	})
+
+	t.Run("CorruptedExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(maxRevisionEqualityCacheEntries)
+		existingRevision := &apps.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: []byte("invalid-json")},
+		}
+		assert.False(t, control.SetMatchesRevision(set, proposedRevision, existingRevision, cache),
+			"corrupted revision data should return false, not panic")
+		assert.Equal(t, 0, cache.Len())
+	})
+}

--- a/pkg/reconciler/roleinstanceset/statelessmode/revision/revision_test.go
+++ b/pkg/reconciler/roleinstanceset/statelessmode/revision/revision_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package revision
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	testutils "sigs.k8s.io/rbgs/test/utils"
 )
 
 const maxRevisionEqualityCacheEntries = 10000
@@ -68,38 +68,6 @@ func newRevisionTestSet(image string) *workloadsv1alpha2.RoleInstanceSet {
 	}
 }
 
-// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
-// carry an explicit "creationTimestamp": null, reproducing how older client-go
-// versions serialized revisions. It edits the parsed tree rather than the raw
-// text, so the result stays valid JSON regardless of the fixture's shape.
-func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
-	t.Helper()
-	var tree interface{}
-	require.NoError(t, json.Unmarshal(patch, &tree))
-
-	var inject func(node interface{})
-	inject = func(node interface{}) {
-		switch n := node.(type) {
-		case map[string]interface{}:
-			for key, child := range n {
-				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
-					meta["creationTimestamp"] = nil
-				}
-				inject(child)
-			}
-		case []interface{}:
-			for _, child := range n {
-				inject(child)
-			}
-		}
-	}
-	inject(tree)
-
-	legacy, err := json.Marshal(tree)
-	require.NoError(t, err)
-	return legacy
-}
-
 func TestSetMatchesRevision(t *testing.T) {
 	control := NewRevisionControl()
 	set := newRevisionTestSet("nginx:1.0")
@@ -119,7 +87,8 @@ func TestSetMatchesRevision(t *testing.T) {
 
 	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
 		cache := lru.New(maxRevisionEqualityCacheEntries)
-		legacyPatch := withLegacyCreationTimestamp(t, proposedRevision.Data.Raw)
+		legacyPatch, err := testutils.WithLegacyCreationTimestamp(proposedRevision.Data.Raw)
+		require.NoError(t, err)
 		assert.NotEqual(t, proposedRevision.Data.Raw, legacyPatch, "drift injection must actually change the bytes")
 
 		existingRevision := &apps.ControllerRevision{

--- a/pkg/utils/revision_utils.go
+++ b/pkg/utils/revision_utils.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -125,7 +126,7 @@ func SetMatchesRevision(
 	existingRevision *appsv1.ControllerRevision,
 	cache *lru.Cache,
 ) bool {
-	if existingRevision == nil || proposedRevision == nil {
+	if existingRevision == nil || proposedRevision == nil || cache == nil {
 		return false
 	}
 
@@ -140,11 +141,15 @@ func SetMatchesRevision(
 
 	latestRbg, err := ApplyRevision(rbg, existingRevision)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: ApplyRevision failed, falling back to new revision creation",
+			"rbg", klog.KRef(rbg.Namespace, rbg.Name), "err", err)
 		return false
 	}
 
 	reconstructedPatch, err := getRBGPatch(latestRbg)
 	if err != nil {
+		klog.V(4).InfoS("SetMatchesRevision: getRBGPatch failed, falling back to new revision creation",
+			"rbg", klog.KRef(rbg.Namespace, rbg.Name), "err", err)
 		return false
 	}
 

--- a/pkg/utils/revision_utils.go
+++ b/pkg/utils/revision_utils.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/rbgs/api/workloads/constants"
@@ -93,6 +95,64 @@ func EqualRevision(lhs, rhs *appsv1.ControllerRevision) bool {
 	}
 
 	return bytes.Equal(lhs.Data.Raw, rhs.Data.Raw) && apiequality.Semantic.DeepEqual(lhs.Data.Object, rhs.Data.Object)
+}
+
+// MaxRevisionEqualityCacheEntries is the LRU cache size for semantic revision equality results.
+const MaxRevisionEqualityCacheEntries = 10000
+
+// revisionEqualityCacheKey uniquely identifies a semantic equality result by
+// combining the RBG UID, the RBG generation (spec revision), and the
+// ResourceVersion of the existing ControllerRevision being compared.
+type revisionEqualityCacheKey struct {
+	rbgUID                  types.UID
+	rbgGeneration           int64
+	revisionResourceVersion string
+}
+
+// SetMatchesRevision returns true if the proposedRevision (generated from the
+// current RBG spec) semantically matches the existingRevision, even when their
+// raw bytes differ due to serialization changes across client-go versions
+// (e.g., "creationTimestamp": null vs omitted).
+//
+// It works by applying the existing revision back to the RBG, re-generating a
+// patch with the current serialization format, and comparing the raw bytes.
+// Results are cached in the provided LRU cache to avoid expensive
+// reconstruction on every reconcile.
+// This function adapts the approach in https://github.com/kubernetes/kubernetes/pull/135017.
+func SetMatchesRevision(
+	rbg *workloadsv1alpha2.RoleBasedGroup,
+	proposedRevision *appsv1.ControllerRevision,
+	existingRevision *appsv1.ControllerRevision,
+	cache *lru.Cache,
+) bool {
+	if existingRevision == nil || proposedRevision == nil {
+		return false
+	}
+
+	cacheKey := revisionEqualityCacheKey{
+		rbgUID:                  rbg.UID,
+		rbgGeneration:           rbg.Generation,
+		revisionResourceVersion: existingRevision.ResourceVersion,
+	}
+	if _, ok := cache.Get(cacheKey); ok {
+		return true
+	}
+
+	latestRbg, err := ApplyRevision(rbg, existingRevision)
+	if err != nil {
+		return false
+	}
+
+	reconstructedPatch, err := getRBGPatch(latestRbg)
+	if err != nil {
+		return false
+	}
+
+	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {
+		cache.Add(cacheKey, struct{}{})
+		return true
+	}
+	return false
 }
 
 // ApplyRevision deserializes the historical RBG Roles data stored in a ControllerRevision and applies it to the current RBG.

--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -913,6 +914,38 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 	}
 }
 
+// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
+// carry an explicit "creationTimestamp": null, reproducing how older client-go
+// versions serialized revisions. It edits the parsed tree rather than the raw
+// text, so the result stays valid JSON regardless of the fixture's shape.
+func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
+	t.Helper()
+	var tree interface{}
+	require.NoError(t, json.Unmarshal(patch, &tree))
+
+	var inject func(node interface{})
+	inject = func(node interface{}) {
+		switch n := node.(type) {
+		case map[string]interface{}:
+			for key, child := range n {
+				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
+					meta["creationTimestamp"] = nil
+				}
+				inject(child)
+			}
+		case []interface{}:
+			for _, child := range n {
+				inject(child)
+			}
+		}
+	}
+	inject(tree)
+
+	legacy, err := json.Marshal(tree)
+	require.NoError(t, err)
+	return legacy
+}
+
 func TestSetMatchesRevision(t *testing.T) {
 	rbg := getRBG()
 	rbg.UID = "test-rbg-uid"
@@ -936,20 +969,17 @@ func TestSetMatchesRevision(t *testing.T) {
 		assert.True(t, result, "identical patch bytes should be semantically equal")
 	})
 
-	t.Run("DifferentBytes_SemanticallyEqual", func(t *testing.T) {
+	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
 		cache := lru.New(MaxRevisionEqualityCacheEntries)
-		// Re-marshal the patch through map to normalize it (simulates serialization drift)
-		var raw map[string]interface{}
-		err := json.Unmarshal(proposedPatch, &raw)
-		assert.NoError(t, err)
-		reMarshalled, err := json.MarshalIndent(raw, "", "  ")
-		assert.NoError(t, err)
+		legacyPatch := withLegacyCreationTimestamp(t, proposedPatch)
+		assert.NotEqual(t, proposedPatch, legacyPatch, "drift injection must actually change the bytes")
+
 		existingRevision := &appsv1.ControllerRevision{
 			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
-			Data:       runtime.RawExtension{Raw: reMarshalled},
+			Data:       runtime.RawExtension{Raw: legacyPatch},
 		}
 		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
-		assert.True(t, result, "semantically equal patches with different byte representations should match")
+		assert.True(t, result, "legacy creationTimestamp serialization should still match semantically")
 	})
 
 	t.Run("TrulyDifferentSpec_ReturnsFalse", func(t *testing.T) {

--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/rbgs/api/workloads/constants"
@@ -910,6 +911,111 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 			},
 		},
 	}
+}
+
+func TestSetMatchesRevision(t *testing.T) {
+	rbg := getRBG()
+	rbg.UID = "test-rbg-uid"
+	rbg.Generation = 1
+
+	// Generate the proposed revision patch from the current RBG spec
+	proposedPatch, err := getRBGPatch(rbg)
+	assert.NoError(t, err)
+	proposedRevision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{Name: "proposed-rev", ResourceVersion: "100"},
+		Data:       runtime.RawExtension{Raw: proposedPatch},
+	}
+
+	t.Run("IdenticalBytes_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedPatch},
+		}
+		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.True(t, result, "identical patch bytes should be semantically equal")
+	})
+
+	t.Run("DifferentBytes_SemanticallyEqual", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		// Re-marshal the patch through map to normalize it (simulates serialization drift)
+		var raw map[string]interface{}
+		err := json.Unmarshal(proposedPatch, &raw)
+		assert.NoError(t, err)
+		reMarshalled, err := json.MarshalIndent(raw, "", "  ")
+		assert.NoError(t, err)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: reMarshalled},
+		}
+		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.True(t, result, "semantically equal patches with different byte representations should match")
+	})
+
+	t.Run("TrulyDifferentSpec_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		differentRbg := getRBG()
+		differentRbg.UID = "test-rbg-uid"
+		differentRbg.Generation = 1
+		differentRbg.Spec.Roles[0].StandalonePattern.Template.Spec.Containers[0].Image = "nginx:999"
+		differentPatch, err := getRBGPatch(differentRbg)
+		assert.NoError(t, err)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: differentPatch},
+		}
+		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.False(t, result, "revisions with truly different specs should not match")
+	})
+
+	t.Run("CacheHit_SecondCallReturnsTrue", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedPatch},
+		}
+		result1 := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.True(t, result1)
+		result2 := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.True(t, result2)
+		assert.Equal(t, 1, cache.Len())
+	})
+
+	t.Run("NilExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		result := SetMatchesRevision(rbg, proposedRevision, nil, cache)
+		assert.False(t, result)
+	})
+
+	t.Run("NilProposedRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedPatch},
+		}
+		result := SetMatchesRevision(rbg, nil, existingRevision, cache)
+		assert.False(t, result)
+	})
+
+	t.Run("NilCache_ReturnsFalseNoPanic", func(t *testing.T) {
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: proposedPatch},
+		}
+		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, nil)
+		assert.False(t, result)
+	})
+
+	t.Run("CorruptedExistingRevision_ReturnsFalse", func(t *testing.T) {
+		cache := lru.New(MaxRevisionEqualityCacheEntries)
+		existingRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-rev", ResourceVersion: "200"},
+			Data:       runtime.RawExtension{Raw: []byte("invalid-json")},
+		}
+		result := SetMatchesRevision(rbg, proposedRevision, existingRevision, cache)
+		assert.False(t, result, "corrupted revision data should return false, not panic")
+		assert.Equal(t, 0, cache.Len())
+	})
 }
 
 func getRBGWithRoleTemplates() *workloadsv1alpha2.RoleBasedGroup {

--- a/pkg/utils/revision_utils_test.go
+++ b/pkg/utils/revision_utils_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
+	testutils "sigs.k8s.io/rbgs/test/utils"
 )
 
 func TestListRevisions(t *testing.T) {
@@ -914,38 +915,6 @@ func getRBG() *workloadsv1alpha2.RoleBasedGroup {
 	}
 }
 
-// withLegacyCreationTimestamp rewrites every "metadata" object in the patch to
-// carry an explicit "creationTimestamp": null, reproducing how older client-go
-// versions serialized revisions. It edits the parsed tree rather than the raw
-// text, so the result stays valid JSON regardless of the fixture's shape.
-func withLegacyCreationTimestamp(t *testing.T, patch []byte) []byte {
-	t.Helper()
-	var tree interface{}
-	require.NoError(t, json.Unmarshal(patch, &tree))
-
-	var inject func(node interface{})
-	inject = func(node interface{}) {
-		switch n := node.(type) {
-		case map[string]interface{}:
-			for key, child := range n {
-				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
-					meta["creationTimestamp"] = nil
-				}
-				inject(child)
-			}
-		case []interface{}:
-			for _, child := range n {
-				inject(child)
-			}
-		}
-	}
-	inject(tree)
-
-	legacy, err := json.Marshal(tree)
-	require.NoError(t, err)
-	return legacy
-}
-
 func TestSetMatchesRevision(t *testing.T) {
 	rbg := getRBG()
 	rbg.UID = "test-rbg-uid"
@@ -971,7 +940,8 @@ func TestSetMatchesRevision(t *testing.T) {
 
 	t.Run("LegacyCreationTimestamp_SemanticallyEqual", func(t *testing.T) {
 		cache := lru.New(MaxRevisionEqualityCacheEntries)
-		legacyPatch := withLegacyCreationTimestamp(t, proposedPatch)
+		legacyPatch, err := testutils.WithLegacyCreationTimestamp(proposedPatch)
+		require.NoError(t, err)
 		assert.NotEqual(t, proposedPatch, legacyPatch, "drift injection must actually change the bytes")
 
 		existingRevision := &appsv1.ControllerRevision{

--- a/test/utils/revision.go
+++ b/test/utils/revision.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "encoding/json"
+
+// WithLegacyCreationTimestamp rewrites every "metadata" object in a
+// ControllerRevision patch to carry an explicit "creationTimestamp": null,
+// reproducing how older client-go versions serialized revisions. It edits the
+// parsed tree rather than the raw text, so the result stays valid JSON
+// regardless of the fixture's shape.
+func WithLegacyCreationTimestamp(patch []byte) ([]byte, error) {
+	var tree interface{}
+	if err := json.Unmarshal(patch, &tree); err != nil {
+		return nil, err
+	}
+
+	var inject func(node interface{})
+	inject = func(node interface{}) {
+		switch n := node.(type) {
+		case map[string]interface{}:
+			for key, child := range n {
+				if meta, ok := child.(map[string]interface{}); ok && key == "metadata" {
+					meta["creationTimestamp"] = nil
+				}
+				inject(child)
+			}
+		case []interface{}:
+			for _, child := range n {
+				inject(child)
+			}
+		}
+	}
+	inject(tree)
+
+	return json.Marshal(tree)
+}


### PR DESCRIPTION
### Ⅰ. Motivation

ControllerRevision serialization drift causes spurious rollouts across different client-go versions. The `creationTimestamp` field serializes as `"creationTimestamp": null` in some client-go versions but is omitted entirely in others, causing `EqualRevision`'s byte comparison to return `false` even when two revisions are semantically identical. This triggers unnecessary rolling updates on every reconcile.

This PR introduces a semantic equality check, adapting the approach from [kubernetes/kubernetes#135017](https://github.com/kubernetes/kubernetes/pull/135017): apply the existing revision back to the object, re-generate the patch with the current serialization format, and compare bytes. Results are cached in an LRU cache to avoid expensive reconstruction on every reconcile.

### Ⅱ. Modifications

**Added `SetMatchesRevision` function (one per controller layer):**

| Layer | File | Description |
|---|---|---|
| RBG controller | `pkg/utils/revision_utils.go` | Top-level `SetMatchesRevision` for RBG revisions |
| RoleInstance reconciler | `pkg/reconciler/roleinstance/revision/instance_revision.go` | `realControl.SetMatchesRevision` for RoleInstance revisions |
| Stateful InstanceSet | `pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_helper.go` | `SetMatchesRevision` for stateful InstanceSet revisions |
| Stateless InstanceSet | `pkg/reconciler/roleinstanceset/statelessmode/revision/revision.go` | `realControl.SetMatchesRevision` for stateless InstanceSet revisions |

Each implementation follows the same logic:
1. Nil guard (`existingRevision == nil || proposedRevision == nil || cache == nil`)
2. LRU cache lookup (key = `UID + Generation + ResourceVersion`)
3. `ApplyRevision` to restore the old revision → re-generate patch → byte-compare
4. `klog.V(4)` logging on error paths

**Integrated into 4 reconcile paths:**

- [rolebasedgroup_controller.go](file:///Users/wangdi/github/diw-zw/rbg/internal/controller/workloads/rolebasedgroup_controller.go) — `handleRevisions` new `else-if` branch
- [instance_reconciler.go](file:///Users/wangdi/github/diw-zw/rbg/pkg/reconciler/roleinstance/instance_reconciler.go) — `getActiveRevisions` new `else-if` branch
- [stateful_instance_set_control.go](file:///Users/wangdi/github/diw-zw/rbg/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control.go) — `getInstanceSetRevisions` new `else-if` branch
- [reconciler.go (stateless)](file:///Users/wangdi/github/diw-zw/rbg/pkg/reconciler/roleinstanceset/statelessmode/reconciler.go) — `getActiveRevisions` new `else-if` branch

Each controller struct gains a `revisionEqualityCache *lru.Cache` field, initialized in the constructor (capacity `MaxRevisionEqualityCacheEntries = 10000`).

### Ⅲ. Does this pull request fix one issue?

fixes #NNNN

### Ⅳ. List of the added test cases (unit test/integration test) if any, please explain if no tests are needed.

**Unit tests** (`pkg/utils/revision_utils_test.go`):

`TestSetMatchesRevision` — 8 subtests:
- `IdenticalBytes_SemanticallyEqual` — identical bytes match directly
- `DifferentBytes_SemanticallyEqual` — serialization drift (simulated via `json.MarshalIndent`) but semantically equal
- `TrulyDifferentSpec_ReturnsFalse` — genuinely different spec returns false
- `CacheHit_SecondCallReturnsTrue` — cache hit returns true on second call
- `NilExistingRevision_ReturnsFalse` — nil existing guard
- `NilProposedRevision_ReturnsFalse` — nil proposed guard
- `NilCache_ReturnsFalseNoPanic` — nil cache does not panic
- `CorruptedExistingRevision_ReturnsFalse` — corrupted JSON data returns false without panic

**E2e tests** (already present in `test/e2e/testcase/v1alpha{1,2}/revision.go`, not modified by this PR but cover the core paths):
- "overriding changes that fail the semantically equal check" — exercises the `return false` path
- "the workload spec will only be modified once" — exercises `return false` + single new revision creation
- "semantic comparison can reconcile modifications on the workload" — exercises the `return true` path (semantic equality + drift correction)

### Ⅴ. Describe how to verify it

```bash
# Unit tests
go test ./pkg/utils/... -v -run TestSetMatchesRevision -count=1

# E2e tests
go test ./test/e2e/... -v -ginkgo.focus="semantically equal"
```
