### PR TITLE
fix: reject duplicate roleinstance component names

### DIFF
--- a/api/workloads/v1alpha1/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha1/rolebasedgroup_types.go
@@ -358,8 +358,10 @@ type RoleSpec struct {
 	// +optional
 	LeaderWorkerSet *LeaderWorkerTemplate `json:"leaderWorkerSet,omitempty"`
 
-	// Components describe the components that will be created.
+	// Components describe the components that will be created. Component names must be unique.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Components []InstanceComponent `json:"components,omitempty"`
 
 	// +optional

--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -402,7 +402,10 @@ type LeaderWorkerPattern struct {
 }
 
 type CustomComponentsPattern struct {
+	// Components describe the components that will be created. Component names must be unique.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Components []InstanceComponent `json:"components,omitempty"`
 
 	// RestartPolicy defines the restart policy when pod failures happen.

--- a/api/workloads/v1alpha2/roleinstance_types.go
+++ b/api/workloads/v1alpha2/roleinstance_types.go
@@ -23,7 +23,7 @@ import (
 
 // RoleInstanceSpec defines the desired state of RoleInstance
 type RoleInstanceSpec struct {
-	// Components is a list of components, each of which specifies a component and the number of replicas and template for RoleInstance that match the component.
+	// Components is a list of components, each of which specifies a component and the number of replicas and template for RoleInstance that match the component. Component names must be unique.
 	// +listType=map
 	// +listMapKey=name
 	Components []RoleInstanceComponent `json:"components" patchStrategy:"merge" patchMergeKey:"name"`

--- a/api/workloads/v1alpha2/roleinstance_types.go
+++ b/api/workloads/v1alpha2/roleinstance_types.go
@@ -24,6 +24,8 @@ import (
 // RoleInstanceSpec defines the desired state of RoleInstance
 type RoleInstanceSpec struct {
 	// Components is a list of components, each of which specifies a component and the number of replicas and template for RoleInstance that match the component.
+	// +listType=map
+	// +listMapKey=name
 	Components []RoleInstanceComponent `json:"components" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// RoleInstanceReadyPolicy specifies the policy for determining if the RoleInstance is ready.

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -7493,7 +7493,7 @@ spec:
                       type: object
                     components:
                       description: Components describe the components that will be
-                        created.
+                        created. Component names must be unique.
                       items:
                         properties:
                           name:
@@ -7519,6 +7519,9 @@ spec:
                         - template
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     dependencies:
                       description: Dependencies of the role
                       items:
@@ -23915,6 +23918,8 @@ spec:
                         custom components.
                       properties:
                         components:
+                          description: Components describe the components that will
+                            be created. Component names must be unique.
                           items:
                             properties:
                               annotations:
@@ -23954,6 +23959,9 @@ spec:
                             - template
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart policy when pod failures happen.

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -7622,7 +7622,7 @@ spec:
                           type: object
                         components:
                           description: Components describe the components that will
-                            be created.
+                            be created. Component names must be unique.
                           items:
                             properties:
                               name:
@@ -7648,6 +7648,9 @@ spec:
                             - template
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         dependencies:
                           description: Dependencies of the role
                           items:
@@ -24408,6 +24411,9 @@ spec:
                                 with custom components.
                               properties:
                                 components:
+                                  description: Components describe the components
+                                    that will be created. Component names must be
+                                    unique.
                                   items:
                                     properties:
                                       annotations:
@@ -24448,6 +24454,9 @@ spec:
                                     - template
                                     type: object
                                   type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 restartPolicy:
                                   description: |-
                                     RestartPolicy defines the restart policy when pod failures happen.

--- a/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
@@ -93,6 +93,9 @@ spec:
                   - template
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               readinessGates:
                 description: ReadinessGates is an optional list of PodReadinessGates
                   for the whole RoleInstance.

--- a/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_roleinstances.yaml
@@ -54,7 +54,7 @@ spec:
               components:
                 description: Components is a list of components, each of which specifies
                   a component and the number of replicas and template for RoleInstance
-                  that match the component.
+                  that match the component. Component names must be unique.
                 items:
                   properties:
                     annotations:

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -97899,6 +97899,9 @@ spec:
                   - template
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               readinessGates:
                 description: ReadinessGates is an optional list of PodReadinessGates
                   for the whole RoleInstance.

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -16356,7 +16356,7 @@ spec:
                       type: object
                     components:
                       description: Components describe the components that will be
-                        created.
+                        created. Component names must be unique.
                       items:
                         properties:
                           name:
@@ -16382,6 +16382,9 @@ spec:
                         - template
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     dependencies:
                       description: Dependencies of the role
                       items:
@@ -32778,6 +32781,8 @@ spec:
                         custom components.
                       properties:
                         components:
+                          description: Components describe the components that will
+                            be created. Component names must be unique.
                           items:
                             properties:
                               annotations:
@@ -32817,6 +32822,9 @@ spec:
                             - template
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         restartPolicy:
                           description: |-
                             RestartPolicy defines the restart policy when pod failures happen.
@@ -57330,7 +57338,7 @@ spec:
                           type: object
                         components:
                           description: Components describe the components that will
-                            be created.
+                            be created. Component names must be unique.
                           items:
                             properties:
                               name:
@@ -57356,6 +57364,9 @@ spec:
                             - template
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         dependencies:
                           description: Dependencies of the role
                           items:
@@ -74116,6 +74127,9 @@ spec:
                                 with custom components.
                               properties:
                                 components:
+                                  description: Components describe the components
+                                    that will be created. Component names must be
+                                    unique.
                                   items:
                                     properties:
                                       annotations:
@@ -74156,6 +74170,9 @@ spec:
                                     - template
                                     type: object
                                   type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 restartPolicy:
                                   description: |-
                                     RestartPolicy defines the restart policy when pod failures happen.
@@ -97860,7 +97877,7 @@ spec:
               components:
                 description: Components is a list of components, each of which specifies
                   a component and the number of replicas and template for RoleInstance
-                  that match the component.
+                  that match the component. Component names must be unique.
                 items:
                   properties:
                     annotations:

--- a/test/envtest/testcase/rbg/basic_test.go
+++ b/test/envtest/testcase/rbg/basic_test.go
@@ -23,10 +23,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	workloadsv1alpha1 "sigs.k8s.io/rbgs/api/workloads/v1alpha1"
+	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	"sigs.k8s.io/rbgs/test/envtest/testutil"
 )
 
@@ -98,5 +101,109 @@ var _ = Describe("RoleBasedGroup Controller", func() {
 			Expect(createdRBG.Spec.Roles).To(HaveLen(1))
 			Expect(createdRBG.Spec.Roles[0].Name).To(Equal("worker"))
 		})
+
+		It("Should reject v1alpha2 custom components with duplicate names", func() {
+			rbg := &workloadsv1alpha2.RoleBasedGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-v1alpha2-components",
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha2.RoleBasedGroupSpec{
+					Roles: []workloadsv1alpha2.RoleSpec{
+						{
+							Name:     "worker",
+							Replicas: ptr.To(int32(1)),
+							Pattern: workloadsv1alpha2.Pattern{
+								CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+									Components: []workloadsv1alpha2.InstanceComponent{
+										{
+											Name:     "worker",
+											Template: nginxPodTemplate(),
+										},
+										{
+											Name:     "worker",
+											Template: nginxPodTemplate(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			expectInvalidCreate(rbg)
+		})
+
+		It("Should reject v1alpha1 components with duplicate names", func() {
+			rbg := &workloadsv1alpha1.RoleBasedGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-v1alpha1-components",
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha1.RoleBasedGroupSpec{
+					Roles: []workloadsv1alpha1.RoleSpec{
+						{
+							Name:     "worker",
+							Replicas: ptr.To(int32(1)),
+							Components: []workloadsv1alpha1.InstanceComponent{
+								{
+									Name:     "worker",
+									Template: nginxPodTemplate(),
+								},
+								{
+									Name:     "worker",
+									Template: nginxPodTemplate(),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			expectInvalidCreate(rbg)
+		})
+
+		It("Should reject RoleInstance components with duplicate names", func() {
+			instance := &workloadsv1alpha2.RoleInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-roleinstance-components",
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha2.RoleInstanceSpec{
+					Components: []workloadsv1alpha2.RoleInstanceComponent{
+						{
+							Name:     "worker",
+							Template: nginxPodTemplate(),
+						},
+						{
+							Name:     "worker",
+							Template: nginxPodTemplate(),
+						},
+					},
+				},
+			}
+
+			expectInvalidCreate(instance)
+		})
 	})
 })
+
+func nginxPodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:latest",
+				},
+			},
+		},
+	}
+}
+
+func expectInvalidCreate(obj client.Object) {
+	err := testutil.K8sClient.Create(testutil.Ctx, obj)
+	Expect(err).To(HaveOccurred())
+	Expect(apierrors.IsInvalid(err)).To(BeTrue(), "got %v", err)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
Duplicate component names are currently accepted by API admission on the user-facing RoleBasedGroup paths and on direct RoleInstance creation. The controller later detects the duplicate names and reports `FailedScale=True` with `the name of component must be unique`.

Rejecting duplicate component names in the CRD schema returns the error earlier during admission for the objects users submit.

### Ⅱ. Modifications
- Mark v1alpha2 `RoleInstanceSpec.Components` as a Kubernetes map-list keyed by `name`.
- Mark v1alpha2 `CustomComponentsPattern.Components` and v1alpha1 `RoleSpec.Components` as Kubernetes map-lists keyed by `name`.
- Update the field comments to document that component names must be unique.
- Regenerate the RoleInstance, RoleBasedGroup, RoleBasedGroupSet CRDs and bundled kubectl manifest.
- Keep the existing controller-side duplicate-name check as defense in depth.

### Ⅲ. Does this pull request fix one issue?
NONE

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Envtest case for rejecting duplicate names in v1alpha2 `RoleBasedGroup.spec.roles[].customComponentsPattern.components[]`.
- Envtest case for rejecting duplicate names in v1alpha1 `RoleBasedGroup.spec.roles[].components[]`.
- Envtest case for rejecting duplicate names in v1alpha2 `RoleInstance.spec.components[]`.

### Ⅴ. Describe how to verify it
- `make manifests`
- `make fmt`
- `go test -mod=mod ./api/workloads/v1alpha1 ./api/workloads/v1alpha2 -count=1`
- `go test -mod=mod ./test/envtest/testcase/rbg -run '^$' -count=1`

I also attempted the focused envtest locally, but this machine is missing `/usr/local/kubebuilder/bin/etcd` and `setup-envtest use 1.31.0 --bin-dir ./bin -p path` timed out while downloading `envtest-releases.yaml` from `raw.githubusercontent.com`. The envtest cases are included for CI to run against the repository envtest setup.

### VI. Special notes for reviews
This relies on Kubernetes structural schema map-list semantics to reject duplicate component names during admission. The controller validation remains unchanged as a fallback for clusters that have not applied the updated CRD.

For upgrade cases, objects that already contain duplicate component names are already semantically invalid and can still be caught by the controller defense. Applying the new CRD may cause subsequent writes to those invalid objects to fail schema validation on clusters without validation ratcheting behavior, so the duplicate component names should be corrected before or when those objects are updated.

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
