### PR TITLE
fix: align template ref and update strategy validation

### DIFF
--- a/api/workloads/v1alpha2/rolebasedgroup_types.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_types.go
@@ -118,6 +118,7 @@ const (
 type RollingUpdate struct {
 	// Type indicates the type of the InstanceSetUpdateStrategy.
 	// Default is InPlaceIfPossible.
+	// +kubebuilder:validation:Enum={RecreatePod,InPlaceIfPossible,InPlaceOnly}
 	Type UpdateStrategyType `json:"type,omitempty"`
 
 	// Partition indicates the ordinal at which the role should be partitioned for updates.

--- a/api/workloads/v1alpha2/roleinstanceset_types.go
+++ b/api/workloads/v1alpha2/roleinstanceset_types.go
@@ -119,6 +119,7 @@ type RoleInstanceSetScaleStrategy struct {
 type RoleInstanceSetUpdateStrategy struct {
 	// Type indicates the type of the RoleInstanceSetUpdateStrategy.
 	// Default is InPlaceIfPossible.
+	// +kubebuilder:validation:Enum={RecreatePod,InPlaceIfPossible,InPlaceOnly}
 	Type UpdateStrategyType `json:"type,omitempty"`
 
 	// Partition is the desired number of RoleInstances in old revisions.

--- a/api/workloads/v1alpha2/roletemplate_validation.go
+++ b/api/workloads/v1alpha2/roletemplate_validation.go
@@ -135,13 +135,6 @@ func validateRoleTemplateFields(
 			)
 		}
 
-		// RawExtension cannot be inspected by CEL, so validate in controller.
-		if !hasTemplatePatch {
-			return fmt.Errorf(
-				"spec.roles[%d]: templateRef.patch is required when templateRef is set (if no overrides needed, set patch to empty object: {})",
-				index,
-			)
-		}
 		return nil
 	}
 

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroups.yaml
@@ -32991,6 +32991,10 @@ spec:
                               description: |-
                                 Type indicates the type of the InstanceSetUpdateStrategy.
                                 Default is InPlaceIfPossible.
+                              enum:
+                              - RecreatePod
+                              - InPlaceIfPossible
+                              - InPlaceOnly
                               type: string
                           type: object
                         type:

--- a/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_rolebasedgroupsets.yaml
@@ -33807,6 +33807,10 @@ spec:
                                       description: |-
                                         Type indicates the type of the InstanceSetUpdateStrategy.
                                         Default is InPlaceIfPossible.
+                                      enum:
+                                      - RecreatePod
+                                      - InPlaceIfPossible
+                                      - InPlaceOnly
                                       type: string
                                   type: object
                                 type:

--- a/config/crd/bases/workloads.x-k8s.io_roleinstancesets.yaml
+++ b/config/crd/bases/workloads.x-k8s.io_roleinstancesets.yaml
@@ -260,6 +260,10 @@ spec:
                     description: |-
                       Type indicates the type of the RoleInstanceSetUpdateStrategy.
                       Default is InPlaceIfPossible.
+                    enum:
+                    - RecreatePod
+                    - InPlaceIfPossible
+                    - InPlaceOnly
                     type: string
                 type: object
             required:

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -41854,6 +41854,10 @@ spec:
                               description: |-
                                 Type indicates the type of the InstanceSetUpdateStrategy.
                                 Default is InPlaceIfPossible.
+                              enum:
+                              - RecreatePod
+                              - InPlaceIfPossible
+                              - InPlaceOnly
                               type: string
                           type: object
                         type:
@@ -83523,6 +83527,10 @@ spec:
                                       description: |-
                                         Type indicates the type of the InstanceSetUpdateStrategy.
                                         Default is InPlaceIfPossible.
+                                      enum:
+                                      - RecreatePod
+                                      - InPlaceIfPossible
+                                      - InPlaceOnly
                                       type: string
                                   type: object
                                 type:
@@ -98397,6 +98405,10 @@ spec:
                     description: |-
                       Type indicates the type of the RoleInstanceSetUpdateStrategy.
                       Default is InPlaceIfPossible.
+                    enum:
+                    - RecreatePod
+                    - InPlaceIfPossible
+                    - InPlaceOnly
                     type: string
                 type: object
             required:

--- a/pkg/reconciler/roleinstanceset_reconciler_test.go
+++ b/pkg/reconciler/roleinstanceset_reconciler_test.go
@@ -438,12 +438,11 @@ func TestRoleInstanceSetReconciler_ValidateRoleTemplateReferences(t *testing.T) 
 			expectError:      false,
 		},
 		{
-			name:             "RoleInstanceSet with templateRef but no templatePatch should fail",
+			name:             "RoleInstanceSet with templateRef but no templatePatch should succeed",
 			workloadKind:     "RoleInstanceSet",
 			useTemplateRef:   true,
 			useTemplatePatch: false,
-			expectError:      true,
-			errorMsg:         "templateRef.patch is required when templateRef is set",
+			expectError:      false,
 		},
 		{
 			name:           "LeaderWorkerSet with templateRef should fail",

--- a/test/envtest/testcase/rbg/basic_test.go
+++ b/test/envtest/testcase/rbg/basic_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -185,6 +186,111 @@ var _ = Describe("RoleBasedGroup Controller", func() {
 			}
 
 			expectInvalidCreate(instance)
+		})
+
+		It("Should allow v1alpha2 templateRef without patch", func() {
+			rbgName := "template-ref-without-patch"
+			rbg := &workloadsv1alpha2.RoleBasedGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rbgName,
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha2.RoleBasedGroupSpec{
+					RoleTemplates: []workloadsv1alpha2.RoleTemplate{
+						{
+							Name:     "base",
+							Template: nginxPodTemplate(),
+						},
+					},
+					Roles: []workloadsv1alpha2.RoleSpec{
+						{
+							Name:     "worker",
+							Replicas: ptr.To(int32(0)),
+							Pattern: workloadsv1alpha2.Pattern{
+								LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{
+									Size: ptr.To(int32(1)),
+									TemplateSource: workloadsv1alpha2.TemplateSource{
+										TemplateRef: &workloadsv1alpha2.TemplateRef{Name: "base"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(testutil.K8sClient.Create(testutil.Ctx, rbg)).Should(Succeed())
+
+			created := &workloadsv1alpha2.RoleBasedGroup{}
+			Eventually(func() error {
+				if err := testutil.K8sClient.Get(testutil.Ctx, types.NamespacedName{Name: rbgName, Namespace: testNs}, created); err != nil {
+					return err
+				}
+				if !apimeta.IsStatusConditionTrue(created.Status.Conditions, string(workloadsv1alpha2.RoleBasedGroupReady)) {
+					return fmt.Errorf("RoleBasedGroup %s/%s Ready condition is not true: %v", testNs, rbgName, created.Status.Conditions)
+				}
+				return nil
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should reject v1alpha2 role rolloutStrategy with invalid update type", func() {
+			rbg := &workloadsv1alpha2.RoleBasedGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-rbg-update-type",
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha2.RoleBasedGroupSpec{
+					Roles: []workloadsv1alpha2.RoleSpec{
+						{
+							Name:     "worker",
+							Replicas: ptr.To(int32(1)),
+							RolloutStrategy: &workloadsv1alpha2.RolloutStrategy{
+								Type: workloadsv1alpha2.RollingUpdateStrategyType,
+								RollingUpdate: &workloadsv1alpha2.RollingUpdate{
+									Type: workloadsv1alpha2.UpdateStrategyType("DefinitelyNotARealStrategy"),
+								},
+							},
+							Pattern: workloadsv1alpha2.Pattern{
+								StandalonePattern: &workloadsv1alpha2.StandalonePattern{
+									TemplateSource: workloadsv1alpha2.TemplateSource{
+										Template: ptr.To(nginxPodTemplate()),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			expectInvalidCreate(rbg)
+		})
+
+		It("Should reject RoleInstanceSet with invalid update strategy type", func() {
+			ris := &workloadsv1alpha2.RoleInstanceSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-ris-update-type",
+					Namespace: testNs,
+				},
+				Spec: workloadsv1alpha2.RoleInstanceSetSpec{
+					Replicas: ptr.To(int32(0)),
+					RoleInstanceTemplate: workloadsv1alpha2.RoleInstanceTemplate{
+						RoleInstanceSpec: workloadsv1alpha2.RoleInstanceSpec{
+							Components: []workloadsv1alpha2.RoleInstanceComponent{
+								{
+									Name:     "worker",
+									Size:     ptr.To(int32(1)),
+									Template: nginxPodTemplate(),
+								},
+							},
+						},
+					},
+					UpdateStrategy: workloadsv1alpha2.RoleInstanceSetUpdateStrategy{
+						Type: workloadsv1alpha2.UpdateStrategyType("DefinitelyNotARealStrategy"),
+					},
+				},
+			}
+
+			expectInvalidCreate(ris)
 		})
 	})
 })


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### I. Motivation
Two validation paths were inconsistent with the v1alpha2 API shape:

- `templateRef.patch` is optional in the API type and template resolution already supports nil or empty patches, but controller validation rejected `templateRef` without a patch.
- v1alpha2 update strategy type fields accepted arbitrary strings because their CRD schemas had no enum constraint.

### II. Modifications
- Allow `templateRef` without `patch` in controller-side role template reference validation.
- Add kubebuilder enum validation for:
  - `spec.roles[].rolloutStrategy.rollingUpdate.type`
  - `RoleInstanceSet.spec.updateStrategy.type`
- Regenerate CRDs and the bundled kubectl manifest.
- Update controller validation tests and add envtest coverage for API acceptance/rejection behavior.

### III. Does this pull request fix one issue?
NONE

### IV. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Updated `TestRoleInstanceSetReconciler_ValidateRoleTemplateReferences` to expect `templateRef` without `patch` to pass.
- Added envtest coverage that v1alpha2 RBG with `roleTemplates` and `templateRef` but no `patch` becomes Ready.
- Added envtest coverage that invalid RBG rolling update type is rejected by API validation.
- Added envtest coverage that invalid RIS update strategy type is rejected by API validation.

### V. Describe how to verify it
- `make fmt`
- `git diff --check`
- `go test ./api/workloads/v1alpha2 ./pkg/reconciler -count=1`
- `go test ./test/envtest/testcase/rbg -run '^$' -count=1`
- Attempted `make test-envtest`, but the local run could not fetch envtest assets from GitHub and then failed before running specs because `kube-apiserver` was unavailable in PATH.

### VI. Special notes for reviews
This intentionally only uses CRD enum validation for update strategy type rejection, without adding extra webhook/controller defense-in-depth validation.

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
