### PR TITLE
Fix stateful RoleInstance identity handling

### DIFF
--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
@@ -33,9 +33,31 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/rbgs/api/workloads/constants"
 	workloadsv1alpha2 "sigs.k8s.io/rbgs/api/workloads/v1alpha2"
 	instanceinplace "sigs.k8s.io/rbgs/pkg/inplace/instance/inplaceupdate"
 )
+
+func TestInstanceSpecIsolated(t *testing.T) {
+	set := buildSet("trainer", 2, nil, nil)
+	set.Spec.RoleInstanceTemplate.RoleInstanceSpec.Components = []workloadsv1alpha2.RoleInstanceComponent{
+		{Name: "worker"},
+	}
+
+	first := newVersionedInstance(set, set, testUpdateRev, testUpdateRev, 0, nil)
+	second := newVersionedInstance(set, set, testUpdateRev, testUpdateRev, 1, nil)
+	indexKey := constants.RoleInstanceIndexLabelKey
+
+	if got := first.Spec.Components[0].Template.Labels[indexKey]; got != "0" {
+		t.Fatalf("first component index = %q, want 0", got)
+	}
+	if got := second.Spec.Components[0].Template.Labels[indexKey]; got != "1" {
+		t.Fatalf("second component index = %q, want 1", got)
+	}
+	if _, ok := set.Spec.RoleInstanceTemplate.RoleInstanceSpec.Components[0].Template.Labels[indexKey]; ok {
+		t.Fatal("RoleInstance template was mutated")
+	}
+}
 
 func TestTruncateHistoryKeepsLiveInstanceRevision(t *testing.T) {
 	limit := int32(0)

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_control_test.go
@@ -59,6 +59,21 @@ func TestInstanceSpecIsolated(t *testing.T) {
 	}
 }
 
+func TestPodLabelsOmitRINSName(t *testing.T) {
+	set := buildSet("trainer", 1, nil, nil)
+	set.Spec.RoleInstanceTemplate.RoleInstanceSpec.Components = []workloadsv1alpha2.RoleInstanceComponent{
+		{Name: "worker"},
+	}
+
+	instance := newVersionedInstance(set, set, testUpdateRev, testUpdateRev, 0, nil)
+	if got := instance.Labels[apps.StatefulSetPodNameLabel]; got != instance.Name {
+		t.Fatalf("instance identity = %q, want %q", got, instance.Name)
+	}
+	if _, ok := instance.Spec.Components[0].Template.Labels[apps.StatefulSetPodNameLabel]; ok {
+		t.Fatal("component pod template contains the RoleInstance name label")
+	}
+}
+
 func TestTruncateHistoryKeepsLiveInstanceRevision(t *testing.T) {
 	limit := int32(0)
 	set := &workloadsv1alpha2.RoleInstanceSet{

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
@@ -169,8 +169,8 @@ func newVersionedInstance(
 			Labels:      make(map[string]string),
 			Annotations: make(map[string]string),
 		},
-		// Copy the RoleInstanceSpec from RoleInstanceTemplate
-		Spec: setToUse.Spec.RoleInstanceTemplate.RoleInstanceSpec,
+		// Isolate each instance before injecting its ordinal into component templates.
+		Spec: *setToUse.Spec.RoleInstanceTemplate.RoleInstanceSpec.DeepCopy(),
 	}
 
 	// Set basic identity

--- a/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
+++ b/pkg/reconciler/roleinstanceset/statefulmode/stateful_instance_set_utils.go
@@ -105,20 +105,19 @@ func updateIdentity(set *workloadsv1alpha2.RoleInstanceSet, instance *workloadsv
 	for k, v := range identityLabels {
 		instance.Labels[k] = v
 	}
-	injectIdentityLabelsIntoComponents(instance, identityLabels)
+	injectInstanceIndex(instance, ordinal)
 }
 
-// injectIdentityLabelsIntoComponents writes the given identity labels into each
-// component's pod template metadata, so that pods created from the template
-// also carry the instance's ordinal identity labels.
-func injectIdentityLabelsIntoComponents(instance *workloadsv1alpha2.RoleInstance, identityLabels map[string]string) {
+// Component Pods inherit the RINS ordinal, but keep their own Pod name identity.
+func injectInstanceIndex(instance *workloadsv1alpha2.RoleInstance, ordinal int) {
+	index := strconv.Itoa(ordinal)
+
 	for i := range instance.Spec.Components {
 		if instance.Spec.Components[i].Template.Labels == nil {
 			instance.Spec.Components[i].Template.Labels = make(map[string]string)
 		}
-		for k, v := range identityLabels {
-			instance.Spec.Components[i].Template.Labels[k] = v
-		}
+
+		instance.Spec.Components[i].Template.Labels[constants.RoleInstanceIndexLabelKey] = index
 	}
 }
 
@@ -202,7 +201,7 @@ func newVersionedInstance(
 	for k, v := range identityLabels {
 		instance.Labels[k] = v
 	}
-	injectIdentityLabelsIntoComponents(instance, identityLabels)
+	injectInstanceIndex(instance, ordinal)
 
 	// Set owner reference
 	instance.OwnerReferences = []metav1.OwnerReference{


### PR DESCRIPTION
### Ⅰ. Motivation

Stateful RoleInstances currently shallow-copy the nested `RoleInstanceSpec`. Their component slices and Pod template metadata maps can therefore be shared.

When identity labels are injected for a later RoleInstance, labels on an earlier instance may be overwritten.

For example, the following Pod belongs to RoleInstance `prefill-0`, but contains identity labels from `prefill-1`:

```yaml
metadata:
  name: multi-role-custom-components-gang-prefill-0-worker-0
  labels:
    rbg.workloads.x-k8s.io/role-instance-name: multi-role-custom-components-gang-prefill-0
    rbg.workloads.x-k8s.io/role-instance-index: "1"
    statefulset.kubernetes.io/pod-name: multi-role-custom-components-gang-prefill-1
```

The expected RoleInstance index is `0`.

The shallow copy occurs when constructing a RoleInstance:

```go
Spec: setToUse.Spec.RoleInstanceTemplate.RoleInstanceSpec
```

The first commit fixes this by deep-copying the spec before injecting instance-specific metadata.

### Ⅱ. Modifications

This PR contains two separate commits.

#### 1. Fix shared RoleInstance specs

Deep-copy each `RoleInstanceSpec` before modifying component templates:

```go
Spec: *setToUse.Spec.RoleInstanceTemplate.RoleInstanceSpec.DeepCopy()
```

This prevents one RoleInstance from modifying another RoleInstance or the source RoleInstanceSet template.

#### 2. Discuss the Pod name label semantics

Component Pod templates currently inherit:

```text
statefulset.kubernetes.io/pod-name=<RoleInstance name>
```

For example:

```text
Pod name:    multi-role-custom-components-gang-prefill-0-worker-0
Label value: multi-role-custom-components-gang-prefill-0
```

According to the Kubernetes
[StatefulSet Pod name label semantics](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-name-label),
this label identifies the actual Pod name.

The second commit therefore proposes:

- Keep `statefulset.kubernetes.io/pod-name` on the RoleInstance.
- Stop propagating it to component Pod templates.
- Continue propagating `rbg.workloads.x-k8s.io/role-instance-index`.

### Ⅲ. Does this pull request fix one issue?

NONE

### Ⅳ. Added test cases

- `TestInstanceSpecIsolated`
  - Verifies that RoleInstances have independent component templates.
  - Verifies that the source RoleInstanceSet template is not mutated.

- `TestPodLabelsOmitRINSName`
  - Verifies that the RoleInstance keeps its identity label.
  - Verifies that component Pod templates do not inherit the
    StatefulSet Pod name label.

### Ⅴ. Verification

```shell
go test ./pkg/reconciler/roleinstanceset/statefulmode -count=1
```

### VI. Discussion

The DeepCopy change is a correctness fix.

The second commit changes existing component Pod labels and needs maintainer agreement. Which behavior should RBG use?

1. Remove `statefulset.kubernetes.io/pod-name` from component Pods.
2. Set it to the actual component Pod name during Pod creation.
3. Keep the current RoleInstance-name value for compatibility.

The commits are separated so the second change can be revised or dropped without affecting the DeepCopy fix.
