### PR TITLE
fix(e2e): caBundle verify race + apicompat update conflict flake

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -211,12 +211,25 @@ jobs:
           done
 
           echo "== caBundle injected into every webhook of the validating webhook config =="
-          if ! kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o json \
-              | jq -e '(.webhooks | length > 0) and all(.webhooks[]; (.clientConfig.caBundle // "") != "")' >/dev/null; then
-            echo "::error::caBundle not injected into every webhook of rbgs-validating-webhook-configuration"
-            kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o yaml || true
-            exit 1
-          fi
+          # The controller patches caBundle onto the ValidatingWebhookConfiguration
+          # asynchronously, after it has created/renewed the TLS secret above. The
+          # secret becoming present therefore does not guarantee caBundle is injected
+          # yet, so retry until the controller finishes patching (see issue #442).
+          for i in $(seq 1 24); do
+            if kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o json \
+                | jq -e '(.webhooks | length > 0) and all(.webhooks[]; (.clientConfig.caBundle // "") != "")' >/dev/null; then
+              echo "caBundle injected into every webhook of rbgs-validating-webhook-configuration"
+              break
+            fi
+            if [ "$i" -eq 24 ]; then
+              echo "::error::caBundle not injected into every webhook of rbgs-validating-webhook-configuration"
+              kubectl get validatingwebhookconfiguration rbgs-validating-webhook-configuration -o yaml || true
+              kubectl -n "$NS" logs -l control-plane=rbgs-controller --tail=100 || true
+              exit 1
+            fi
+            echo "waiting for caBundle injection... ($i/24)"
+            sleep 5
+          done
           echo "RBAC and webhook-cert bootstrap verified"
 
       - name: Pre-load e2e test images

--- a/test/e2e/apicompat/specs_test.go
+++ b/test/e2e/apicompat/specs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apicompat
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -198,9 +200,9 @@ func RunDeprecatedDisabledTestCases(f *framework.Framework) {
 			"a RoleInstanceSet RBG must be admitted")
 
 		fetched := &workloadsv1alpha2.RoleBasedGroup{}
-		gomega.Expect(f.Client.Get(ctx(), client.ObjectKeyFromObject(rbg), fetched)).Should(gomega.Succeed())
-		setRoleWorkload(&fetched.Spec.Roles[0], constants.DeploymentWorkloadType)
-		err := f.Client.Update(ctx(), fetched)
+		err := updateWithConflictRetry(ctx(), f.Client, client.ObjectKeyFromObject(rbg), fetched, func() {
+			setRoleWorkload(&fetched.Spec.Roles[0], constants.DeploymentWorkloadType)
+		})
 		gomega.Expect(containsRejection(err)).Should(gomega.BeTrue(),
 			"update introducing a Deployment workload should be rejected, got: %v", err)
 	})
@@ -225,9 +227,9 @@ func RunDeprecatedDisabledTestCases(f *framework.Framework) {
 			"a RoleInstanceSet RBGSet must be admitted")
 
 		fetched := &workloadsv1alpha2.RoleBasedGroupSet{}
-		gomega.Expect(f.Client.Get(ctx(), client.ObjectKeyFromObject(rbgset), fetched)).Should(gomega.Succeed())
-		setRoleWorkload(&fetched.Spec.GroupTemplate.Spec.Roles[0], constants.StatefulSetWorkloadType)
-		err := f.Client.Update(ctx(), fetched)
+		err := updateWithConflictRetry(ctx(), f.Client, client.ObjectKeyFromObject(rbgset), fetched, func() {
+			setRoleWorkload(&fetched.Spec.GroupTemplate.Spec.Roles[0], constants.StatefulSetWorkloadType)
+		})
 		gomega.Expect(containsRejection(err)).Should(gomega.BeTrue(),
 			"update introducing a StatefulSet workload should be rejected, got: %v", err)
 	})
@@ -261,4 +263,34 @@ func setRoleWorkload(role *workloadsv1alpha2.RoleSpec, workloadType string) {
 		role.Annotations = map[string]string{}
 	}
 	role.Annotations[constants.RoleWorkloadTypeAnnotationKey] = workloadType
+}
+
+// updateWithConflictRetry re-Gets obj, applies mutate, and Updates it, retrying on
+// optimistic-concurrency (409 conflict) errors. The controller writes status on
+// freshly created RBG/RBGSet objects, so a plain Get->Update races it and surfaces a
+// conflict instead of reaching the validating webhook. A conflict is transient and
+// unrelated to whether the update is admissible, so we re-Get and retry; the final
+// non-conflict Update error (typically the validator's rejection, or nil on success)
+// is returned for the caller to assert on.
+func updateWithConflictRetry(
+	ctx context.Context,
+	c client.Client,
+	key client.ObjectKey,
+	obj client.Object,
+	mutate func(),
+) error {
+	const maxAttempts = 10
+	var lastErr error
+	for i := 0; i < maxAttempts; i++ {
+		if err := c.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		mutate()
+		lastErr = c.Update(ctx, obj)
+		if lastErr == nil || !apierrors.IsConflict(lastErr) {
+			return lastErr
+		}
+	}
+	return fmt.Errorf("update %s kept hitting optimistic-concurrency conflicts after %d attempts: %w",
+		key, maxAttempts, lastErr)
 }


### PR DESCRIPTION
## Summary

Fixes the e2e CI flakiness exposed by the v0.8.0 release PR (#441). The run failed in **two** independent places; both are pre-existing races, not v0.8.0 regressions.

Closes #442.

### Flake 1 — `e2e-test` job: caBundle verify races the cert-manager patch

The **"Verify controller RBAC and webhook-cert bootstrap"** step in `.github/workflows/e2e-test.yml` failed with `caBundle not injected into every webhook of rbgs-validating-webhook-configuration`.

- The **webhook-cert secret** check retries in a loop (up to ~120s) and exits as soon as the secret is present.
- The **caBundle** check then ran **once, immediately**, with no retry.

But the controller patches `caBundle` onto `rbgs-validating-webhook-configuration` *asynchronously, after* creating the TLS secret. Timestamps from the failed run:

| Time (UTC) | Event |
|---|---|
| 14:18:32.957 | webhook-cert secret check passes (loop exits) |
| 14:18:33.052 | caBundle check runs → **fails** (not patched yet) |
| 14:18:33.162 | controller logs `patched caBundle on ValidatingWebhookConfiguration` |

The check ran ~95ms after the secret appeared; the controller finished patching ~110ms *after* the check. The controller logs confirm the patch succeeded moments later, so the bootstrap is fine — only the verification was too eager.

**Fix:** wrap the caBundle check in the same retry loop pattern used for the webhook-cert secret (up to 24 × 5s), and dump controller logs on final failure.

### Flake 2 — `e2e-test-deprecated-disabled` job: apicompat update tests hit optimistic-concurrency conflict

The spec `rejects a RoleBasedGroupSet update that introduces a deprecated workload type` failed:

```
[FAILED] update introducing a StatefulSet workload should be rejected, got:
  Operation cannot be fulfilled on rolebasedgroupsets... "dep-rbgset-update":
  the object has been modified; please apply your changes to the latest version and try again
```

The update specs (RBG and RBGSet) did a single `Get -> mutate -> Update`. The controller writes status on freshly created objects, so its status patch bumps the resourceVersion between the test's `Get` and `Update`, surfacing a 409 conflict instead of reaching the validating webhook. `containsRejection` correctly treats a conflict as "not a rejection", so the spec flakes (it passed on PR #441's run, failed on this branch's run).

**Fix:** add `updateWithConflictRetry`, which re-Gets and retries on conflict (up to 10 attempts) and returns the final non-conflict error for the existing rejection assertion; apply it to both update specs in `test/e2e/apicompat/specs_test.go`.

Both fixes must land together — neither flake is in the other's job, but each PR's CI runs the full e2e suite, so splitting them leaves each PR red on the other's flake.

## Test plan

- [x] `go test -c ./test/e2e/apicompat/` compiles; `go vet` clean; gofmt clean.
- [ ] `e2e-test` job: verify step passes even when the controller's caBundle patch lands after the TLS secret.
- [ ] `e2e-test-deprecated-disabled` job: update specs pass even when the controller writes status between Get and Update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)