### PR TITLE
chore: update manifests for v0.8.0 release

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: rolebasedgroup/rbgs-controller
-  newTag: v0.8.0-ba7b952e
+  newTag: v0.8.0-16705159

--- a/deploy/helm/rbgs/Chart.yaml
+++ b/deploy/helm/rbgs/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0-alpha.5
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.0-ba7b952e"
+appVersion: "0.8.0-16705159"

--- a/deploy/helm/rbgs/values.yaml
+++ b/deploy/helm/rbgs/values.yaml
@@ -10,7 +10,7 @@ controller:
   imagePullSecrets: []
   image:
     repository: rolebasedgroup/rbgs-controller
-    tag: "v0.8.0-ba7b952e"
+    tag: "v0.8.0-16705159"
     pullPolicy: IfNotPresent
   resources:
     limits:
@@ -89,7 +89,7 @@ crdUpgrade:
   # CRD Upgrader image configuration
   image:
     repository: rolebasedgroup/rbgs-upgrade-crd
-    tag: "v0.8.0-ba7b952e"
+    tag: "v0.8.0-16705159"
     pullPolicy: IfNotPresent
   # Tolerations for CRD Upgrader Job pod
   tolerations:

--- a/deploy/kubectl/manifests.yaml
+++ b/deploy/kubectl/manifests.yaml
@@ -98823,7 +98823,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: rolebasedgroup/rbgs-controller:v0.8.0-ba7b952e
+        image: rolebasedgroup/rbgs-controller:v0.8.0-16705159
         imagePullPolicy: IfNotPresent
         name: rbgs
         resources:


### PR DESCRIPTION
Bump chart version to `0.8.0` and image tags to `v0.8.0-16705159` for the v0.8.0 release.

Changes:
- `config/manager/kustomization.yaml`: image tag → `v0.8.0-16705159`
- `deploy/helm/rbgs/Chart.yaml`: version `0.8.0-alpha.5` → `0.8.0`, appVersion → `v0.8.0-16705159`
- `deploy/helm/rbgs/values.yaml`: controller & crdUpgrade image tags → `v0.8.0-16705159`
- `deploy/kubectl/manifests.yaml`: controller image → `v0.8.0-16705159`

Replaces #441 (superseded by reset of `0.8.0` to current `main`).