### PR TITLE
fix(e2e): gate the upgrade baseline on pods, not the Ready condition

### DIFF
--- a/test/e2e/upgrade/specs.go
+++ b/test/e2e/upgrade/specs.go
@@ -923,23 +923,28 @@ func waitAllRBGsReady(f *framework.Framework, except ...string) {
 }
 
 // waitAllPodsRunning waits until every role of every RoleBasedGroup in the namespace has
-// its full complement of pods and every one of them is Running, except for the named
-// RBGs.
+// its full expected pod count and every one of those pods is Running, except for the
+// named RBGs.
 //
-// The Ready gate above cannot establish either half. An RBG's Ready condition is only as
-// good as the workload status it is derived from, and for a LeaderWorkerSet role that is
-// LWS's own group accounting: LeaderWorkerSetReconciler.CheckWorkloadReady is
-// `ReadyReplicas == Replicas`, which is also true before LWS has populated its status at
-// all, and both the role status and the condition have been observed reporting the single
-// group ready while one of its worker pods was still Pending.
+// The Ready gate above cannot establish this, because an RBG's Ready condition inherits
+// whatever the workload underneath it calls ready. For a LeaderWorkerSet role that is
+// LWS's group accounting, and LWS v0.7.0 counts a group ready when the leader pod is
+// Running and Ready and the worker StatefulSet merely has its pods *created*: its
+// StatefulsetReady compares Spec.Replicas against Status.Replicas, not against
+// Status.ReadyReplicas. A Pending worker beside a Running leader therefore makes the
+// whole RBG report Ready, which is how up-v1a1-lw-0-1 reached the baseline still Pending
+// and started a minute later.
 //
-// So without this, two things can reach the baseline on a slow cluster: a pod that is
-// still Pending, and a role whose pods have not all been created yet. `before` is what
-// every later phase compares against, so the first becomes a Pending -> Running
-// difference in phase 3 and the second becomes a pod that appears out of nowhere -- both
-// attributed to an upgrade that had nothing to do with either. Waiting here is what makes
-// the baseline mean "a converged world"; teaching the detectors to tolerate those two
-// instead would give up seeing an upgrade that really did restart or add a pod.
+// That matters because `before` is what every later phase compares against: a Pending pod
+// captured into it becomes a Pending -> Running difference in phase 3, attributed to an
+// upgrade that had nothing to do with it. Teaching checkStillReady to tolerate that would
+// instead give up seeing an upgrade that really did restart a pod.
+//
+// The pod count is the same guard one level lower, and no workload has been observed
+// opening the Ready gate with pods missing outright -- the condition also requires
+// `*role.Replicas == status.Replicas`. It is here because it does not depend on any
+// workload's definition of ready, so it still holds whatever a later version decides that
+// word means.
 //
 // Terminating objects are skipped for the same reason waitAllRBGsReady skips them: the
 // prune probe of the first phase 1 spec can still be here, and it will never have pods

--- a/test/e2e/upgrade/specs.go
+++ b/test/e2e/upgrade/specs.go
@@ -19,6 +19,7 @@ package upgrade
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -173,6 +174,12 @@ func RunUpgradeSpecs(f *framework.Framework) {
 			// starting -- and a baseline of a half-started world proves nothing.
 			ginkgo.By("waiting for every RoleBasedGroup in the namespace to be ready")
 			waitAllRBGsReady(f, fxPending)
+
+			// And the gate above is not enough on its own, because an RBG's Ready
+			// condition is only as good as the workload status it is derived from. This
+			// waits on the pods themselves: all of them present, all of them Running.
+			ginkgo.By("waiting for every pod the snapshot will record to be Running")
+			waitAllPodsRunning(f, fxPending)
 
 			// The never-ready fixture is still required to have got as far as a Pending
 			// pod. Without that it would contribute nothing to compare, and "the upgrade
@@ -913,6 +920,104 @@ func waitAllRBGsReady(f *framework.Framework, except ...string) {
 			}
 		}, utils.Timeout, utils.Interval,
 	).Should(gomega.Succeed())
+}
+
+// waitAllPodsRunning waits until every role of every RoleBasedGroup in the namespace has
+// its full complement of pods and every one of them is Running, except for the named
+// RBGs.
+//
+// The Ready gate above cannot establish either half. An RBG's Ready condition is only as
+// good as the workload status it is derived from, and for a LeaderWorkerSet role that is
+// LWS's own group accounting: LeaderWorkerSetReconciler.CheckWorkloadReady is
+// `ReadyReplicas == Replicas`, which is also true before LWS has populated its status at
+// all, and both the role status and the condition have been observed reporting the single
+// group ready while one of its worker pods was still Pending.
+//
+// So without this, two things can reach the baseline on a slow cluster: a pod that is
+// still Pending, and a role whose pods have not all been created yet. `before` is what
+// every later phase compares against, so the first becomes a Pending -> Running
+// difference in phase 3 and the second becomes a pod that appears out of nowhere -- both
+// attributed to an upgrade that had nothing to do with either. Waiting here is what makes
+// the baseline mean "a converged world"; teaching the detectors to tolerate those two
+// instead would give up seeing an upgrade that really did restart or add a pod.
+//
+// Terminating objects are skipped for the same reason waitAllRBGsReady skips them: the
+// prune probe of the first phase 1 spec can still be here, and it will never have pods
+// again.
+func waitAllPodsRunning(f *framework.Framework, except ...string) {
+	skip := make(map[string]bool, len(except))
+	for _, name := range except {
+		skip[name] = true
+	}
+
+	gomega.Eventually(
+		func(g gomega.Gomega) {
+			list := &workloadsv1alpha2.RoleBasedGroupList{}
+			g.Expect(f.Client.List(f.Ctx, list, client.InNamespace(f.Namespace))).To(gomega.Succeed())
+			g.Expect(list.Items).ToNot(gomega.BeEmpty())
+
+			var problems []string
+			for i := range list.Items {
+				rbg := &list.Items[i]
+				if skip[rbg.Name] || rbg.DeletionTimestamp != nil {
+					continue
+				}
+				for j := range rbg.Spec.Roles {
+					role := &rbg.Spec.Roles[j]
+					// The same helper captureRBG uses, so this waits on exactly the pods
+					// the snapshot will record.
+					pods := listPodFactsForRole(g, f, rbg, role.Name)
+					if want, err := expectedPodsForRole(role); err != nil {
+						problems = append(problems, fmt.Sprintf("%s/%s: %s", rbg.Name, role.Name, err))
+					} else if len(pods) != want {
+						problems = append(
+							problems,
+							fmt.Sprintf("%s/%s: has %d of %d pods", rbg.Name, role.Name, len(pods), want),
+						)
+					}
+					for pod, facts := range pods {
+						if facts.Phase != corev1.PodRunning {
+							problems = append(
+								problems,
+								fmt.Sprintf("%s/%s: pod %s is %s", rbg.Name, role.Name, pod, facts.Phase),
+							)
+						}
+					}
+				}
+			}
+			sort.Strings(problems)
+			g.Expect(problems).To(
+				gomega.BeEmpty(),
+				"the namespace has not converged, so the baseline would be a half-started world:\n  - %s",
+				strings.Join(problems, "\n  - "),
+			)
+		}, utils.Timeout, utils.Interval,
+	).Should(gomega.Succeed())
+}
+
+// expectedPodsForRole is how many pods a converged role has: one per replica, times the
+// pods each replica is made of.
+//
+// An unrecognised pattern is an error rather than a guess of one pod per replica, because
+// a guess would silently under-count a role a later version adds and quietly weaken the
+// gate above -- the failure mode this whole suite exists to avoid.
+func expectedPodsForRole(role *workloadsv1alpha2.RoleSpec) (int, error) {
+	replicas := ptr.Deref(role.Replicas, 1)
+
+	switch {
+	case role.IsStandalonePattern():
+		return int(replicas), nil
+	case role.IsLeaderWorkerPattern():
+		// Size counts the leader, so it is the number of pods per replica outright.
+		return int(replicas * ptr.Deref(role.GetLeaderWorkerSize(), 1)), nil
+	case role.GetCustomComponentsPattern() != nil:
+		perReplica := int32(0)
+		for _, component := range role.GetCustomComponentsPattern().Components {
+			perReplica += ptr.Deref(component.Size, 1)
+		}
+		return int(replicas * perReplica), nil
+	}
+	return 0, fmt.Errorf("no pattern this gate can count pods for")
 }
 
 // waitForPendingPod waits until the given RBG's only role has a pod that exists and is


### PR DESCRIPTION
## Summary
   `Release Test` on main fails intermittently in the upgrade suite's phase 3:

    ```
    pods are no longer in the phase they were in before the upgrade:
      - up-v1a1/lw: pod up-v1a1-lw-0-1 went from Pending to Running
    ```

    The upgrade did not do this. The baseline did: `before` was captured while that pod was
    still `Pending`, and it started about a minute later. This waits on the pods themselves
    before taking the baseline.

## Root cause

    Phase 1 gated the baseline on status only, and an RBG's `Ready` condition inherits
    whatever the workload underneath it calls ready. The chain, bottom up:

    1. LWS v0.7.0 counts a group ready when the leader pod is Running and Ready **and** the
       worker StatefulSet is "ready" (`pkg/controllers/leaderworkerset_controller.go:418`).
    2. That `StatefulsetReady` compares `*sts.Spec.Replicas` against `sts.Status.Replicas` —
       pods *created* — not against `Status.ReadyReplicas`
       (`pkg/utils/statefulset/statefulset_utils.go:48-51`). A `Pending` worker pod counts.
    3. RBG passes that straight up: the role's `Replicas`/`ReadyReplicas` are
       `lws.Status.*` verbatim (`pkg/reconciler/lws_reconciler.go:133-145`).
    4. The `Ready` condition requires `*role.Replicas == rs.Replicas == rs.ReadyReplicas`
       (`internal/controller/workloads/rolebasedgroup_controller.go:736-748`) → `1 == 1 == 1`
       → `Ready=True`.

    CI installs LWS v0.7.0 (`release-test.yml:23`), the version read above. So a `Pending`
    worker beside a `Running` leader makes the whole RBG report Ready, and RBG has no way to
    tell the difference.

    [The failing run](https://github.com/sgl-project/rbg/actions/runs/33303713013) shows
    exactly that: `before` has `up-v1a1` at `ready=true`, `role lw ready=1`, and its worker at
    `phase=Pending rv=1705`. The live dump 80s later has it `Running rv=2290`, with the
    `resourceVersion` unmoved in between — the pod was starting for the first time, not being
    restarted by the upgrade.

    The only pod-level guard was "every role has at least one `Running` pod", asserted on
    `before`. A `Running` leader beside a `Pending` worker satisfies it.

## What changed

    `waitAllPodsRunning` runs after `waitAllRBGsReady`, before `before` is captured, and waits
    until every role has its full expected pod count and every one of those pods is `Running`.

    - Pods come from `listPodFactsForRole`, the same helper `captureRBG` uses, so the gate
      waits on exactly the pods the snapshot will record.
    - `expectedPodsForRole` computes `replicas × pods-per-replica`: `1` for
      `standalonePattern`, `leaderWorkerPattern.size` for leader-worker, `Σ components[].size`
      for `customComponentsPattern`. A pattern it cannot count is an error, not a guess of one
      pod per replica — a guess would silently under-count a pattern added later.
    - Terminating objects are skipped, as in `waitAllRBGsReady`: the prune probe of the first
      phase 1 spec can still be present and will never have pods again.

    Scope, stated honestly: the reproduced failure is the `Pending` pod, and that is what the
    phase check catches. **No workload has been observed opening the Ready gate with pods
    missing outright** — the condition also requires `*role.Replicas == status.Replicas`. The
    count is there because it does not depend on any workload's definition of ready, so it
    holds whatever a later version decides that word means.

    No detector was touched. `checkStillReady` still treats any phase change as a finding,
    including `Pending -> Running`, so an upgrade that really does restart or add a pod is
    still reported.