### PR TITLE
fix: validate RoleBasedGroup role dependencies at admission

### DIFF
--- a/api/workloads/v1alpha2/rolebasedgroup_admission.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_admission.go
@@ -57,6 +57,9 @@ func (v *RoleBasedGroupValidator) ValidateCreate(_ context.Context, obj runtime.
 	if err := ValidateRollingUpdate(rbg); err != nil {
 		allErrs = append(allErrs, err)
 	}
+	if err := ValidateRoleDependencies(rbg); err != nil {
+		allErrs = append(allErrs, err)
+	}
 	if !v.EnableDeprecatedWorkloadTypes {
 		if err := validateNoDeprecatedWorkloadTypes("spec.roles", rbg.Spec.Roles); err != nil {
 			allErrs = append(allErrs, err)
@@ -80,6 +83,9 @@ func (v *RoleBasedGroupValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 
 	var allErrs []error
 	if err := ValidateRollingUpdate(rbg); err != nil {
+		allErrs = append(allErrs, err)
+	}
+	if err := ValidateRoleDependencies(rbg); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if err := ValidateScalingAdapterReplicas(ctx, v.Client, oldRBG, rbg); err != nil {

--- a/api/workloads/v1alpha2/rolebasedgroup_validation.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_validation.go
@@ -19,6 +19,7 @@ package v1alpha2
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,6 +54,95 @@ func ValidateRollingUpdate(rbg *RoleBasedGroup) error {
 		}
 	}
 	return utilerrors.NewAggregate(allErrs)
+}
+
+// ValidateRoleDependencies validates that every role dependency references an
+// existing role and that the role dependency graph is acyclic.
+func ValidateRoleDependencies(rbg *RoleBasedGroup) error {
+	roleNames := make(map[string]struct{}, len(rbg.Spec.Roles))
+	for i := range rbg.Spec.Roles {
+		roleNames[rbg.Spec.Roles[i].Name] = struct{}{}
+	}
+
+	var allErrs []error
+	graph := make(map[string][]string, len(rbg.Spec.Roles))
+	for i := range rbg.Spec.Roles {
+		role := &rbg.Spec.Roles[i]
+		for j, dependency := range role.Dependencies {
+			if dependency == role.Name {
+				allErrs = append(allErrs, fmt.Errorf(
+					"spec.roles[%d].dependencies[%d]: role %q cannot depend on itself",
+					i, j, role.Name,
+				))
+				continue
+			}
+			if _, ok := roleNames[dependency]; !ok {
+				allErrs = append(allErrs, fmt.Errorf(
+					"spec.roles[%d].dependencies[%d]: role %q depends on unknown role %q",
+					i, j, role.Name, dependency,
+				))
+				continue
+			}
+			graph[role.Name] = append(graph[role.Name], dependency)
+		}
+		if _, ok := graph[role.Name]; !ok {
+			graph[role.Name] = nil
+		}
+	}
+	if err := validateNoRoleDependencyCycle(rbg.Spec.Roles, graph); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	return utilerrors.NewAggregate(allErrs)
+}
+
+func validateNoRoleDependencyCycle(roles []RoleSpec, graph map[string][]string) error {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+
+	state := make(map[string]int, len(roles))
+	var visit func(roleName string, path []string) error
+	visit = func(roleName string, path []string) error {
+		switch state[roleName] {
+		case visiting:
+			cycle := appendCycle(path, roleName)
+			return fmt.Errorf("spec.roles: dependency cycle detected: %s", strings.Join(cycle, " -> "))
+		case visited:
+			return nil
+		}
+
+		state[roleName] = visiting
+		path = append(path, roleName)
+		for _, dependency := range graph[roleName] {
+			if err := visit(dependency, path); err != nil {
+				return err
+			}
+		}
+		state[roleName] = visited
+		return nil
+	}
+
+	for i := range roles {
+		if state[roles[i].Name] == unvisited {
+			if err := visit(roles[i].Name, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func appendCycle(path []string, roleName string) []string {
+	for i := range path {
+		if path[i] == roleName {
+			cycle := append([]string{}, path[i:]...)
+			return append(cycle, roleName)
+		}
+	}
+	return append(append([]string{}, path...), roleName)
 }
 
 func validateRoleRollingUpdate(index int, ru *RollingUpdate, replicas int32) []error {

--- a/api/workloads/v1alpha2/rolebasedgroup_validation.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_validation.go
@@ -57,46 +57,47 @@ func ValidateRollingUpdate(rbg *RoleBasedGroup) error {
 }
 
 // ValidateRoleDependencies validates that every role dependency references an
-// existing role and that the role dependency graph is acyclic.
+// existing role, no role depends on itself, and the role dependency graph is acyclic.
 func ValidateRoleDependencies(rbg *RoleBasedGroup) error {
-	roleNames := make(map[string]struct{}, len(rbg.Spec.Roles))
-	for i := range rbg.Spec.Roles {
-		roleNames[rbg.Spec.Roles[i].Name] = struct{}{}
+	return validateRoleDependencies("spec.roles", rbg.Spec.Roles)
+}
+
+func validateRoleDependencies(fieldPath string, roles []RoleSpec) error {
+	roleNames := make(map[string]struct{}, len(roles))
+	for i := range roles {
+		roleNames[roles[i].Name] = struct{}{}
 	}
 
 	var allErrs []error
-	graph := make(map[string][]string, len(rbg.Spec.Roles))
-	for i := range rbg.Spec.Roles {
-		role := &rbg.Spec.Roles[i]
+	graph := make(map[string][]string, len(roles))
+	for i := range roles {
+		role := &roles[i]
 		for j, dependency := range role.Dependencies {
 			if dependency == role.Name {
 				allErrs = append(allErrs, fmt.Errorf(
-					"spec.roles[%d].dependencies[%d]: role %q cannot depend on itself",
-					i, j, role.Name,
+					"%s[%d].dependencies[%d]: role %q cannot depend on itself",
+					fieldPath, i, j, role.Name,
 				))
 				continue
 			}
 			if _, ok := roleNames[dependency]; !ok {
 				allErrs = append(allErrs, fmt.Errorf(
-					"spec.roles[%d].dependencies[%d]: role %q depends on unknown role %q",
-					i, j, role.Name, dependency,
+					"%s[%d].dependencies[%d]: role %q depends on unknown role %q",
+					fieldPath, i, j, role.Name, dependency,
 				))
 				continue
 			}
 			graph[role.Name] = append(graph[role.Name], dependency)
 		}
-		if _, ok := graph[role.Name]; !ok {
-			graph[role.Name] = nil
-		}
 	}
-	if err := validateNoRoleDependencyCycle(rbg.Spec.Roles, graph); err != nil {
+	if err := validateNoRoleDependencyCycle(fieldPath, roles, graph); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
 	return utilerrors.NewAggregate(allErrs)
 }
 
-func validateNoRoleDependencyCycle(roles []RoleSpec, graph map[string][]string) error {
+func validateNoRoleDependencyCycle(fieldPath string, roles []RoleSpec, graph map[string][]string) error {
 	const (
 		unvisited = iota
 		visiting
@@ -108,8 +109,10 @@ func validateNoRoleDependencyCycle(roles []RoleSpec, graph map[string][]string) 
 	visit = func(roleName string, path []string) error {
 		switch state[roleName] {
 		case visiting:
+			// Keep the reported cycle minimal when a later edge points back into
+			// the active DFS path, e.g. a -> b -> c -> b reports b -> c -> b.
 			cycle := appendCycle(path, roleName)
-			return fmt.Errorf("spec.roles: dependency cycle detected: %s", strings.Join(cycle, " -> "))
+			return fmt.Errorf("%s: dependency cycle detected: %s", fieldPath, strings.Join(cycle, " -> "))
 		case visited:
 			return nil
 		}

--- a/api/workloads/v1alpha2/rolebasedgroup_validation_test.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_validation_test.go
@@ -158,6 +158,105 @@ func TestValidateNoDeprecatedWorkloadTypes(t *testing.T) {
 	}
 }
 
+func TestValidateRoleDependencies(t *testing.T) {
+	tests := []struct {
+		name        string
+		roles       []RoleSpec
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid dependency",
+			roles: []RoleSpec{
+				{Name: "head"},
+				{Name: "worker", Dependencies: []string{"head"}},
+			},
+		},
+		{
+			name: "dependency references unknown role",
+			roles: []RoleSpec{
+				{Name: "worker", Dependencies: []string{"ghost"}},
+			},
+			wantErr:     true,
+			errContains: `role "worker" depends on unknown role "ghost"`,
+		},
+		{
+			name: "self dependency",
+			roles: []RoleSpec{
+				{Name: "worker", Dependencies: []string{"worker"}},
+			},
+			wantErr:     true,
+			errContains: `role "worker" cannot depend on itself`,
+		},
+		{
+			name: "cyclic dependency",
+			roles: []RoleSpec{
+				{Name: "head", Dependencies: []string{"worker"}},
+				{Name: "worker", Dependencies: []string{"head"}},
+			},
+			wantErr:     true,
+			errContains: "dependency cycle detected: head -> worker -> head",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rbg := &RoleBasedGroup{
+				Spec: RoleBasedGroupSpec{
+					Roles: tt.roles,
+				},
+			}
+
+			err := ValidateRoleDependencies(rbg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestRoleBasedGroupValidator_ValidateCreateRoleDependencies(t *testing.T) {
+	rbg := &RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rbg"},
+		Spec: RoleBasedGroupSpec{
+			Roles: []RoleSpec{
+				{Name: "worker", Replicas: ptr.To(int32(1)), Dependencies: []string{"ghost"}},
+			},
+		},
+	}
+	v := &RoleBasedGroupValidator{EnableDeprecatedWorkloadTypes: true}
+
+	_, err := v.ValidateCreate(context.Background(), rbg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `role "worker" depends on unknown role "ghost"`)
+}
+
+func TestRoleBasedGroupValidator_ValidateUpdateRoleDependencies(t *testing.T) {
+	oldRBG := &RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rbg"},
+		Spec: RoleBasedGroupSpec{
+			Roles: []RoleSpec{
+				{Name: "head", Replicas: ptr.To(int32(1))},
+				{Name: "worker", Replicas: ptr.To(int32(1))},
+			},
+		},
+	}
+	newRBG := oldRBG.DeepCopy()
+	newRBG.Spec.Roles[0].Dependencies = []string{"worker"}
+	newRBG.Spec.Roles[1].Dependencies = []string{"head"}
+	v := &RoleBasedGroupValidator{
+		Client:                        fake.NewClientBuilder().Build(),
+		EnableDeprecatedWorkloadTypes: true,
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldRBG, newRBG)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency cycle detected: head -> worker -> head")
+}
+
 func TestRoleBasedGroupValidator_ValidateCreate_DeprecatedWorkloadTypesDisabled(t *testing.T) {
 	tests := []struct {
 		name                          string

--- a/api/workloads/v1alpha2/rolebasedgroup_validation_test.go
+++ b/api/workloads/v1alpha2/rolebasedgroup_validation_test.go
@@ -197,6 +197,16 @@ func TestValidateRoleDependencies(t *testing.T) {
 			wantErr:     true,
 			errContains: "dependency cycle detected: head -> worker -> head",
 		},
+		{
+			name: "cyclic dependency starting mid path",
+			roles: []RoleSpec{
+				{Name: "head", Dependencies: []string{"worker"}},
+				{Name: "worker", Dependencies: []string{"sidecar"}},
+				{Name: "sidecar", Dependencies: []string{"worker"}},
+			},
+			wantErr:     true,
+			errContains: "dependency cycle detected: worker -> sidecar -> worker",
+		},
 	}
 
 	for _, tt := range tests {
@@ -255,6 +265,53 @@ func TestRoleBasedGroupValidator_ValidateUpdateRoleDependencies(t *testing.T) {
 	_, err := v.ValidateUpdate(context.Background(), oldRBG, newRBG)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "dependency cycle detected: head -> worker -> head")
+}
+
+func TestRoleBasedGroupSetValidator_ValidateCreateRoleDependencies(t *testing.T) {
+	rbgs := &RoleBasedGroupSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rbgs"},
+		Spec: RoleBasedGroupSetSpec{
+			Replicas: ptr.To(int32(1)),
+			GroupTemplate: RoleBasedGroupTemplateSpec{
+				Spec: RoleBasedGroupSpec{
+					Roles: []RoleSpec{
+						{Name: "worker", Replicas: ptr.To(int32(1)), Dependencies: []string{"ghost"}},
+					},
+				},
+			},
+		},
+	}
+	v := &RoleBasedGroupSetValidator{EnableDeprecatedWorkloadTypes: true}
+
+	_, err := v.ValidateCreate(context.Background(), rbgs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `spec.groupTemplate.spec.roles[0].dependencies[0]`)
+	assert.Contains(t, err.Error(), `role "worker" depends on unknown role "ghost"`)
+}
+
+func TestRoleBasedGroupSetValidator_ValidateUpdateRoleDependencies(t *testing.T) {
+	oldRBGS := &RoleBasedGroupSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rbgs"},
+		Spec: RoleBasedGroupSetSpec{
+			Replicas: ptr.To(int32(1)),
+			GroupTemplate: RoleBasedGroupTemplateSpec{
+				Spec: RoleBasedGroupSpec{
+					Roles: []RoleSpec{
+						{Name: "head", Replicas: ptr.To(int32(1))},
+						{Name: "worker", Replicas: ptr.To(int32(1))},
+					},
+				},
+			},
+		},
+	}
+	newRBGS := oldRBGS.DeepCopy()
+	newRBGS.Spec.GroupTemplate.Spec.Roles[0].Dependencies = []string{"worker"}
+	newRBGS.Spec.GroupTemplate.Spec.Roles[1].Dependencies = []string{"head"}
+	v := &RoleBasedGroupSetValidator{EnableDeprecatedWorkloadTypes: true}
+
+	_, err := v.ValidateUpdate(context.Background(), oldRBGS, newRBGS)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec.groupTemplate.spec.roles: dependency cycle detected: head -> worker -> head")
 }
 
 func TestRoleBasedGroupValidator_ValidateCreate_DeprecatedWorkloadTypesDisabled(t *testing.T) {

--- a/api/workloads/v1alpha2/rolebasedgroupset_admission.go
+++ b/api/workloads/v1alpha2/rolebasedgroupset_admission.go
@@ -48,6 +48,9 @@ func (v *RoleBasedGroupSetValidator) ValidateCreate(_ context.Context, obj runti
 	klog.V(4).InfoS("validating RoleBasedGroupSet on create", "name", rbgs.Name, "namespace", rbgs.Namespace)
 
 	var allErrs []error
+	if err := validateRoleDependencies("spec.groupTemplate.spec.roles", rbgs.Spec.GroupTemplate.Spec.Roles); err != nil {
+		allErrs = append(allErrs, err)
+	}
 	if !v.EnableDeprecatedWorkloadTypes {
 		if err := validateNoDeprecatedWorkloadTypes("spec.groupTemplate.spec.roles", rbgs.Spec.GroupTemplate.Spec.Roles); err != nil {
 			allErrs = append(allErrs, err)
@@ -66,6 +69,9 @@ func (v *RoleBasedGroupSetValidator) ValidateUpdate(_ context.Context, _ runtime
 	klog.V(4).InfoS("validating RoleBasedGroupSet on update", "name", rbgs.Name, "namespace", rbgs.Namespace)
 
 	var allErrs []error
+	if err := validateRoleDependencies("spec.groupTemplate.spec.roles", rbgs.Spec.GroupTemplate.Spec.Roles); err != nil {
+		allErrs = append(allErrs, err)
+	}
 	if !v.EnableDeprecatedWorkloadTypes {
 		if err := validateNoDeprecatedWorkloadTypes(
 			"spec.groupTemplate.spec.roles",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
Reject invalid RoleBasedGroup role dependency graphs during admission instead of accepting the object and surfacing dependency errors later during reconciliation.

RoleBasedGroupSet templates are validated as well because the set controller copies template roles into derived RoleBasedGroups; admitting an invalid template would otherwise move the failure from the original object to child reconciliation.

### Ⅱ. Modifications
- Add `ValidateRoleDependencies(rbg *RoleBasedGroup) error` for unknown dependency roles, self-dependencies, and dependency cycles.
- Reuse the dependency validation for RoleBasedGroupSet templates with the correct `spec.groupTemplate.spec.roles` field path.
- Call role dependency validation from RoleBasedGroup and RoleBasedGroupSet create/update admission paths.
- Add unit coverage for unknown role dependencies, self-dependencies, cyclic dependencies, RBG admission wiring, and RBGSet admission wiring.

### Ⅲ. Does this pull request fix one issue?
NONE

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- `TestValidateRoleDependencies`
- `TestRoleBasedGroupValidator_ValidateCreateRoleDependencies`
- `TestRoleBasedGroupValidator_ValidateUpdateRoleDependencies`
- `TestRoleBasedGroupSetValidator_ValidateCreateRoleDependencies`
- `TestRoleBasedGroupSetValidator_ValidateUpdateRoleDependencies`

### Ⅴ. Describe how to verify it
```bash
go test -count=1 ./api/workloads/v1alpha2
```

### VI. Special notes for reviews
This keeps the validation in the API package and does not make admission depend on the controller dependency manager.

`ValidateUpdate` validates the complete role dependency graph on every main-resource update. That means pre-existing invalid objects admitted before this webhook will need their dependency spec fixed before non-status updates can be accepted; status subresource updates are unaffected.

## Checklist

- [ ] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [ ] Update the documentation related to the change.
