### PR TITLE
feat(chart): gate upgrades on recorded source version

### DIFF
--- a/deploy/helm/rbgs/Chart.yaml
+++ b/deploy/helm/rbgs/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: rbgs
 description: A Helm chart for RoleBasedGroupSet and RoleBasedGroup Controller
+annotations:
+  workloads.x-k8s.io/minimum-upgrade-source-version: "0.8.0"
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/deploy/helm/rbgs/README.md
+++ b/deploy/helm/rbgs/README.md
@@ -12,6 +12,8 @@ CRD upgrade Job into your Kubernetes cluster.
   (certificates are bootstrapped by the controller itself, no cert-manager required).
 - **CRD Upgrader Job** (optional, enabled by default): a `pre-install,pre-upgrade` Helm hook Job
   (with its own ServiceAccount and RBAC) that applies/upgrades the RBG CRDs before the controller starts.
+- **Chart version marker**: a persistent post-install/post-upgrade ConfigMap that records the latest
+  successfully installed chart version for a later upgrade compatibility check.
 
 ## Prerequisites
 
@@ -145,10 +147,43 @@ kubectl delete -f config/crd/bases/
 
 ## Upgrading
 
-`helm upgrade` is supported. Nothing checks the cluster's existing objects against
-`controller.deprecatedWorkloadTypes.enabled`, so keeping it at its default `true` on an installation
-that already has objects using a deprecated workload type is the operator's responsibility — see
-[Deprecated workload types](#deprecated-workload-types).
+Every chart declares its minimum supported source chart version in the
+`workloads.x-k8s.io/minimum-upgrade-source-version` Chart annotation. Before **every**
+`helm upgrade`, the chart reads the prior release's `<release>-chart-version` ConfigMap and rejects a
+source below that minimum; see [Minimum upgrade source version](#minimum-upgrade-source-version). Nothing checks the cluster's
+existing objects against `controller.deprecatedWorkloadTypes.enabled`, so keeping it at its default
+`true` on an installation that already has objects using a deprecated workload type is the
+operator's responsibility — see [Deprecated workload types](#deprecated-workload-types).
+
+### Minimum upgrade source version
+
+Every chart declares its minimum compatible source version through this `Chart.yaml` annotation:
+
+```yaml
+annotations:
+  workloads.x-k8s.io/minimum-upgrade-source-version: "0.8.0"
+```
+
+On a successful install or upgrade, a `post-install,post-upgrade` ConfigMap hook persists the target
+chart version as `<release>-chart-version`:
+
+```yaml
+data:
+  chartVersion: "0.8.0"
+```
+
+Before **every** upgrade, Helm renders the chart, uses `lookup` to read that ConfigMap, and compares
+`data.chartVersion` with the chart's declared minimum as SemVer. A missing marker, a missing version,
+or a source below the minimum calls `fail`. This happens before Helm applies any resource or invokes
+the CRD upgrade hook, so a refusal changes neither the controller nor the CRDs.
+
+A release installed before this version-marker mechanism has no ConfigMap and is intentionally
+rejected. For the current chart, that includes every source older than v0.8.0, whose flat values are
+not compatible with the regrouped layout described below.
+
+The Helm identity that performs an upgrade needs `get` on ConfigMaps in the release namespace.
+Offline `helm template --is-upgrade` cannot read the marker and therefore cannot validate an upgrade;
+use `helm upgrade`, server-side dry-run, or a Helm-based GitOps controller with cluster API access.
 
 ### Breaking change: values regrouped in chart v0.8.0
 

--- a/deploy/helm/rbgs/templates/chart-version.yaml
+++ b/deploy/helm/rbgs/templates/chart-version.yaml
@@ -1,0 +1,36 @@
+{{- /*
+  Every upgrade first compares the latest successfully recorded chart version with this
+  chart's minimum supported source version. The marker is updated only by the post hook,
+  so a failed upgrade retains the last known-good source version.
+*/ -}}
+{{- $minimumSourceVersion := index .Chart.Annotations "workloads.x-k8s.io/minimum-upgrade-source-version" }}
+{{- $markerName := printf "%s-chart-version" .Release.Name }}
+{{- if .Release.IsUpgrade }}
+{{- $marker := lookup "v1" "ConfigMap" .Release.Namespace $markerName }}
+{{- if not $marker }}
+{{- fail (printf "cannot verify the version this release is upgrading from: ConfigMap %s/%s is missing. This chart requires a recorded source version of at least v%s." .Release.Namespace $markerName $minimumSourceVersion) }}
+{{- end }}
+{{- $markerData := $marker.data | default dict }}
+{{- $sourceVersion := get $markerData "chartVersion" | default "" }}
+{{- if not $sourceVersion }}
+{{- fail (printf "cannot verify the version this release is upgrading from: ConfigMap %s/%s has no data.chartVersion. This chart requires a recorded source version of at least v%s." .Release.Namespace $markerName $minimumSourceVersion) }}
+{{- end }}
+{{- if not (semverCompare (printf ">=%s" $minimumSourceVersion) $sourceVersion) }}
+{{- fail (printf "upgrading directly from chart v%s is not supported; this chart requires v%s or later." $sourceVersion $minimumSourceVersion) }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $markerName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    # A fixed-name hook must remove the previous marker before it can write the new one.
+    # It is otherwise retained as the source-version record for the next upgrade.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  chartVersion: {{ .Chart.Version | quote }}

--- a/doc/install.md
+++ b/doc/install.md
@@ -42,13 +42,23 @@ make helm-deploy
 #### CRD Upgrader Configuration
 
 | Parameter | Description | Default |
-|-----------|-------------|------|
+| --------- | ----------- | ------- |
 | `crdUpgrade.enabled` | Enable CRD Upgrader Job | `true` |
 | `crdUpgrade.image.repository` | CRD Upgrader image repository | `rolebasedgroup/rbgs-upgrade-crd` |
 | `crdUpgrade.image.tag` | CRD Upgrader image tag | Same as `controller.image.tag` |
 | `crdUpgrade.ttlSecondsAfterFinished` | Job TTL after completion | `259200` (3 days) |
 | `crdUpgrade.tolerations` | Pod tolerations | `[{operator: Exists}]` |
 | `crdUpgrade.nodeSelector` | Pod node selector | `{}` |
+
+#### Chart Version Marker
+
+Each chart declares a minimum compatible source version in its `Chart.yaml` annotation. Before every
+`helm upgrade`, it reads `<release>-chart-version` with Helm's `lookup` function and compares the
+recorded `data.chartVersion` with that minimum before applying any resources or upgrading CRDs. A
+successful install or upgrade writes the target chart version with a `post-install,post-upgrade`
+ConfigMap hook. A missing marker, missing version, or source below the declared minimum fails the
+upgrade during rendering. The Helm identity needs `get` on ConfigMaps in the release namespace;
+offline `helm template --is-upgrade` cannot perform this check. See [Minimum upgrade source version](../deploy/helm/rbgs/README.md#minimum-upgrade-source-version).
 
 #### Manual CRD Installation (Alternative)
 

--- a/test/chart/chart_version_test.go
+++ b/test/chart/chart_version_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The RBG Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chart
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const chartVersionMarkerKey = "ConfigMap/rbgs-chart-version"
+
+// renderUpgradeFailure renders the chart with Helm's upgrade release context and
+// returns the expected template error.
+func renderUpgradeFailure(t *testing.T, extraArgs ...string) string {
+	t.Helper()
+	if _, err := exec.LookPath("helm"); err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("helm is required in CI: %v", err)
+		}
+		t.Skip("helm not installed; skipping chart render test")
+	}
+	args := append([]string{"template", "rbgs", chartDir(t), "--is-upgrade"}, extraArgs...)
+	out, err := exec.Command("helm", args...).CombinedOutput()
+	if err == nil {
+		t.Fatal("helm template unexpectedly accepted an upgrade without a version marker")
+	}
+	return string(out)
+}
+
+func chartVersion(t *testing.T) string {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join(chartDir(t), "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read Chart.yaml: %v", err)
+	}
+	var chart struct {
+		Version string `json:"version"`
+	}
+	if err := yaml.Unmarshal(contents, &chart); err != nil {
+		t.Fatalf("parse Chart.yaml: %v", err)
+	}
+	if chart.Version == "" {
+		t.Fatal("Chart.yaml has no version")
+	}
+	return chart.Version
+}
+
+func chartVersionMarker(t *testing.T, manifest string) corev1.ConfigMap {
+	t.Helper()
+	obj, ok := splitObjects(t, manifest)[chartVersionMarkerKey]
+	if !ok {
+		t.Fatalf("%s not rendered", chartVersionMarkerKey)
+	}
+	var marker corev1.ConfigMap
+	if err := yaml.Unmarshal([]byte(obj.raw), &marker); err != nil {
+		t.Fatalf("unmarshal version marker: %v", err)
+	}
+	return marker
+}
+
+// TestChartVersionMarkerRecordsSuccessfulReleaseVersion verifies the bridge artifact
+// that later chart versions use to determine the source version of an upgrade. It is a
+// post hook rather than a regular manifest so a failed upgrade keeps the last
+// successfully recorded version.
+func TestChartVersionMarkerRecordsSuccessfulReleaseVersion(t *testing.T) {
+	marker := chartVersionMarker(t, renderChart(t))
+
+	if got, want := marker.Name, "rbgs-chart-version"; got != want {
+		t.Errorf("marker name = %q, want %q", got, want)
+	}
+	if got, want := marker.Data["chartVersion"], chartVersion(t); got != want {
+		t.Errorf("marker chartVersion = %q, want chart version %q", got, want)
+	}
+	if got, want := marker.Annotations["helm.sh/hook"], "post-install,post-upgrade"; got != want {
+		t.Errorf("marker hook = %q, want %q", got, want)
+	}
+	if got, want := marker.Annotations["helm.sh/hook-delete-policy"], "before-hook-creation"; got != want {
+		t.Errorf("marker hook delete policy = %q, want %q", got, want)
+	}
+}
+
+// TestUpgradeWithoutVersionMarkerFails makes the strict source-version contract explicit:
+// every upgrade must read the ConfigMap that an earlier successful install or upgrade wrote.
+func TestUpgradeWithoutVersionMarkerFails(t *testing.T) {
+	output := renderUpgradeFailure(t)
+	if want := "ConfigMap default/rbgs-chart-version is missing"; !strings.Contains(output, want) {
+		t.Fatalf("upgrade failure does not name the missing marker %q:\n%s", want, output)
+	}
+}


### PR DESCRIPTION
## Summary

Add a chart-version marker to gate incompatible Helm upgrades before any resources are applied.

- Add a per-chart `minimum-upgrade-source-version` annotation.
- Persist the successfully installed chart version in a post-install/post-upgrade ConfigMap hook.
- During every upgrade, read the previous marker with Helm `lookup` and fail rendering when it is missing, malformed, or below the declared minimum version.
- Document the required ConfigMap read permission and offline rendering limitation.
- Add chart rendering tests for marker creation and strict rejection of upgrades without a marker.

## Cluster Verification

- A real `helm upgrade` from an existing v0.3.2 release was rejected during template rendering because the version ConfigMap was missing.
- The rejected upgrade did not create a new Helm revision or modify the controller, CRDs, ConfigMap, or Jobs.
- A fresh install completed successfully and created `<release>-chart-version` with `chartVersion: 0.8.0`.