### PR TITLE
docs: correct RoleInstance lifecycle metadata reference

### DIFF
--- a/doc/reference/variables.md
+++ b/doc/reference/variables.md
@@ -28,6 +28,7 @@
 | `rbg.workloads.x-k8s.io/role-instance-index` | The index of RoleInstance in Role (for ordered scenarios). |
 | `rbg.workloads.x-k8s.io/role-instance-owner` | The owning RoleInstanceSet name; used as the RoleInstanceSet selector. |
 | `rbg.workloads.x-k8s.io/role-instance-delete` | Marks a RoleInstance for specified deletion. |
+| `rbg.workloads.x-k8s.io/role-instance-lifecycle-state` | The current lifecycle state of a RoleInstance. |
 
 ### Component Level Labels
 
@@ -70,7 +71,7 @@
 |-----|-------------|
 | `rbg.workloads.x-k8s.io/role-instance-pattern` | Identifies the RoleInstance organization pattern (Stateful/Stateless). |
 | `rbg.workloads.x-k8s.io/role-instance-gang-scheduling` | Enables gang-scheduling aware behavior at the RoleInstance level. |
-| `rbg.workloads.x-k8s.io/role-instance-lifecycle-state` | Identifies the lifecycle state of a RoleInstance. |
+| `rbg.workloads.x-k8s.io/role-instance-lifecycle-timestamp` | Identifies the timestamp of the most recent RoleInstance lifecycle state change. |
 | `rbg.workloads.x-k8s.io/inplace-update-state` | Identifies the in-place update state. |
 | `rbg.workloads.x-k8s.io/inplace-update-grace` | Identifies the in-place update grace period configuration. |
 


### PR DESCRIPTION
### Ⅰ. Motivation

The metadata reference documents `rbg.workloads.x-k8s.io/role-instance-lifecycle-state` as an annotation, while the controller reads and writes it as a label. The lifecycle timestamp annotation is not documented.

### Ⅱ. Modifications

- Move `role-instance-lifecycle-state` to the RoleInstance labels reference.
- Document `role-instance-lifecycle-timestamp` as an annotation and describe its RFC 3339 value.

### Ⅲ. Does this pull request fix one issue?

fixes #457

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No tests are needed because this change only corrects the metadata reference.

### Ⅴ. Describe how to verify it

- Confirm the documentation matches the lifecycle implementation: the state is in `metadata.labels` and the timestamp is in `metadata.annotations`.
- Ran `git diff --check`.

### VI. Special notes for reviews

NONE

## Checklist

- [ ] Format your code `make fmt` (not applicable: documentation-only change).
- [ ] Add unit tests or integration tests (not applicable: documentation-only change).
- [x] Update the documentation related to the change.