### PR TITLE
fix: count scheduled Pods in role replica units

### DIFF
--- a/api/workloads/v1alpha2/helper.go
+++ b/api/workloads/v1alpha2/helper.go
@@ -99,7 +99,8 @@ func ComputeSubGroupSize(role *RoleSpec) int32 {
 				total++
 				continue
 			}
-			total += *c.Size
+			// The RoleInstance controller creates no Pods for non-positive sizes.
+			total += max(*c.Size, 0)
 		}
 		return total
 	}

--- a/doc/features/coordinated-policy.md
+++ b/doc/features/coordinated-policy.md
@@ -120,14 +120,6 @@ Coordinated scaling ensures roles scale together during scale-out operations.
 | `OrderScheduled` | Proceed when pods are scheduled (faster, less safe) |
 | `OrderReady` | Proceed when pods are fully ready (slower, safer) |
 
-For a role that is still scaling out, `OrderScheduled` waits for the Pod count
-represented by its current replicas to be scheduled. For example, two current
-replicas with four Pods each require eight scheduled Pods before the next batch
-can proceed. Standalone replicas require one Pod each; leader-worker replicas use
-their `size`, and custom-component replicas use the sum of their component sizes.
-
-An empty custom-component list or components whose sizes are all zero produce no Pods. Such roles satisfy `OrderScheduled` without waiting for scheduling; the normal `maxSkew` batch limits still apply. `OrderReady` continues to use the reported ready replica count.
-
 ### Example: Simple Coordinated Scaling
 
 ```yaml

--- a/doc/features/coordinated-policy.md
+++ b/doc/features/coordinated-policy.md
@@ -120,6 +120,12 @@ Coordinated scaling ensures roles scale together during scale-out operations.
 | `OrderScheduled` | Proceed when pods are scheduled (faster, less safe) |
 | `OrderReady` | Proceed when pods are fully ready (slower, safer) |
 
+For a role that is still scaling out, `OrderScheduled` waits for the Pod count
+represented by its current replicas to be scheduled. For example, two current
+replicas with four Pods each require eight scheduled Pods before the next batch
+can proceed. Standalone replicas require one Pod each; leader-worker replicas use
+their `size`, and custom-component replicas use the sum of their component sizes.
+
 ### Example: Simple Coordinated Scaling
 
 ```yaml

--- a/doc/features/coordinated-policy.md
+++ b/doc/features/coordinated-policy.md
@@ -126,6 +126,8 @@ replicas with four Pods each require eight scheduled Pods before the next batch
 can proceed. Standalone replicas require one Pod each; leader-worker replicas use
 their `size`, and custom-component replicas use the sum of their component sizes.
 
+An empty custom-component list or components whose sizes are all zero produce no Pods. Such roles satisfy `OrderScheduled` without waiting for scheduling; the normal `maxSkew` batch limits still apply. `OrderReady` continues to use the reported ready replica count.
+
 ### Example: Simple Coordinated Scaling
 
 ```yaml

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -1375,12 +1375,21 @@ func (r *RoleBasedGroupReconciler) CalculateScalingForAllCoordination(
 	return result, nil
 }
 
-// getScheduledReplicas queries the number of scheduled pods (with nodeName) for a given role.
+// getScheduledReplicas converts scheduled Pods into the replica units used by RoleStatus.
 func (r *RoleBasedGroupReconciler) getScheduledReplicas(
 	ctx context.Context,
 	rbg *workloadsv1alpha2.RoleBasedGroup,
 	roleName string,
 ) (int32, error) {
+	role, err := rbg.GetRole(roleName)
+	if err != nil {
+		return 0, err
+	}
+	podsPerReplica := workloadsv1alpha2.ComputeSubGroupSize(role)
+	if podsPerReplica == 0 {
+		return 0, nil
+	}
+
 	podList := &corev1.PodList{}
 	labelSelector := client.MatchingLabels{
 		constants.GroupNameLabelKey: rbg.Name,
@@ -1398,7 +1407,10 @@ func (r *RoleBasedGroupReconciler) getScheduledReplicas(
 		}
 	}
 
-	return scheduled, nil
+	// CurrentReplicas counts instances for multi-Pod patterns. Keep the comparison
+	// in replica units so the next batch waits for currentReplicas * podsPerReplica
+	// scheduled Pods, rather than advancing after only currentReplicas Pods.
+	return scheduled / podsPerReplica, nil
 }
 
 // CalculateRollingUpdateForAllCoordination calculates rolling update strategies for all coordination policies.

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -1337,7 +1337,7 @@ func (r *RoleBasedGroupReconciler) CalculateScalingForAllCoordination(
 			}
 
 			// Query scheduled replicas from pods
-			scheduled, err := r.getScheduledReplicas(ctx, rbg, roleName)
+			scheduled, err := r.getScheduledReplicas(ctx, rbg, roleName, current)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query scheduled replicas for role %s: %w", roleName, err)
 			}
@@ -1380,14 +1380,17 @@ func (r *RoleBasedGroupReconciler) getScheduledReplicas(
 	ctx context.Context,
 	rbg *workloadsv1alpha2.RoleBasedGroup,
 	roleName string,
+	currentReplicas int32,
 ) (int32, error) {
 	role, err := rbg.GetRole(roleName)
 	if err != nil {
-		return 0, err
+		// A separate policy may still reference a role removed from the RBG.
+		return 0, nil
 	}
 	podsPerReplica := workloadsv1alpha2.ComputeSubGroupSize(role)
 	if podsPerReplica == 0 {
-		return 0, nil
+		// With no Pods to schedule, every current replica satisfies OrderScheduled.
+		return currentReplicas, nil
 	}
 
 	podList := &corev1.PodList{}

--- a/internal/controller/workloads/rolebasedgroup_controller.go
+++ b/internal/controller/workloads/rolebasedgroup_controller.go
@@ -1336,18 +1336,19 @@ func (r *RoleBasedGroupReconciler) CalculateScalingForAllCoordination(
 				}
 			}
 
-			// Query scheduled replicas from pods
-			scheduled, err := r.getScheduledReplicas(ctx, rbg, roleName, current)
+			// Count scheduled Pods and the Pods expected from the current replicas.
+			scheduled, expected, err := r.getPodSchedulingCounts(ctx, rbg, roleName, current)
 			if err != nil {
-				return nil, fmt.Errorf("failed to query scheduled replicas for role %s: %w", roleName, err)
+				return nil, fmt.Errorf("failed to query Pod scheduling counts for role %s: %w", roleName, err)
 			}
 
 			roleStates[roleName] = coordinationscaling.RoleScalingState{
-				RoleName:          roleName,
-				DesiredReplicas:   desired,
-				CurrentReplicas:   current,
-				ScheduledReplicas: scheduled,
-				ReadyReplicas:     ready,
+				RoleName:        roleName,
+				DesiredReplicas: desired,
+				CurrentReplicas: current,
+				ScheduledPods:   scheduled,
+				ExpectedPods:    expected,
+				ReadyReplicas:   ready,
 			}
 		}
 
@@ -1375,22 +1376,23 @@ func (r *RoleBasedGroupReconciler) CalculateScalingForAllCoordination(
 	return result, nil
 }
 
-// getScheduledReplicas converts scheduled Pods into the replica units used by RoleStatus.
-func (r *RoleBasedGroupReconciler) getScheduledReplicas(
+// getPodSchedulingCounts returns scheduled Pods and the expected Pod count for the
+// current replicas. The expectation includes Pods that have not been created yet.
+func (r *RoleBasedGroupReconciler) getPodSchedulingCounts(
 	ctx context.Context,
 	rbg *workloadsv1alpha2.RoleBasedGroup,
 	roleName string,
 	currentReplicas int32,
-) (int32, error) {
+) (scheduledPods, expectedPods int64, err error) {
 	role, err := rbg.GetRole(roleName)
 	if err != nil {
 		// A separate policy may still reference a role removed from the RBG.
-		return 0, nil
+		return 0, 0, nil
 	}
 	podsPerReplica := workloadsv1alpha2.ComputeSubGroupSize(role)
-	if podsPerReplica == 0 {
-		// With no Pods to schedule, every current replica satisfies OrderScheduled.
-		return currentReplicas, nil
+	expectedPods = int64(currentReplicas) * int64(podsPerReplica)
+	if expectedPods == 0 {
+		return 0, 0, nil
 	}
 
 	podList := &corev1.PodList{}
@@ -1398,22 +1400,19 @@ func (r *RoleBasedGroupReconciler) getScheduledReplicas(
 		constants.GroupNameLabelKey: rbg.Name,
 		constants.RoleNameLabelKey:  roleName,
 	}
-
 	if err := r.client.List(ctx, podList, client.InNamespace(rbg.Namespace), labelSelector); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	var scheduled int32
 	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		if pod.Spec.NodeName != "" {
-			scheduled++
+			scheduledPods++
 		}
 	}
-
-	// CurrentReplicas counts instances for multi-Pod patterns. Keep the comparison
-	// in replica units so the next batch waits for currentReplicas * podsPerReplica
-	// scheduled Pods, rather than advancing after only currentReplicas Pods.
-	return scheduled / podsPerReplica, nil
+	return scheduledPods, expectedPods, nil
 }
 
 // CalculateRollingUpdateForAllCoordination calculates rolling update strategies for all coordination policies.

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -2390,3 +2390,114 @@ func TestReconcileIncompatibleGangConfig(t *testing.T) {
 	assert.Zero(t, result.RequeueAfter)
 	assert.Contains(t, drainEvents(), "Warning FailedReconcilePodGroup podgroup apiserver hiccup")
 }
+
+// OrderScheduled must wait for every Pod in the current replica batch, including
+// when a role replica creates more than one Pod.
+func TestCalculateScalingForAllCoordination_OrderScheduled(t *testing.T) {
+	patterns := []struct {
+		name           string
+		pattern        workloadsv1alpha2.Pattern
+		podsPerReplica int
+	}{
+		{
+			name:           "standalone",
+			pattern:        workloadsv1alpha2.Pattern{StandalonePattern: &workloadsv1alpha2.StandalonePattern{}},
+			podsPerReplica: 1,
+		},
+		{
+			name:           "leader worker",
+			pattern:        workloadsv1alpha2.Pattern{LeaderWorkerPattern: &workloadsv1alpha2.LeaderWorkerPattern{Size: ptr.To(int32(4))}},
+			podsPerReplica: 4,
+		},
+		{
+			name: "custom components",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{
+					{Name: "leader", Size: ptr.To(int32(1))},
+					{Name: "worker", Size: ptr.To(int32(3))},
+				},
+			}},
+			podsPerReplica: 4,
+		},
+		{
+			name: "custom component with default size",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{
+					{Name: "leader"},
+					{Name: "worker", Size: ptr.To(int32(3))},
+				},
+			}},
+			podsPerReplica: 4,
+		},
+		{
+			name:    "empty custom components",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{}},
+		},
+		{
+			name: "zero sized custom component",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{{Name: "worker", Size: ptr.To(int32(0))}},
+			}},
+		},
+	}
+
+	const currentReplicas int32 = 2
+	const desiredReplicas int32 = 4
+	for _, pattern := range patterns {
+		t.Run(pattern.name, func(t *testing.T) {
+			role := workloadsv1alpha2.RoleSpec{Pattern: pattern.pattern}
+			role.Name = "prefill"
+			role.Replicas = ptr.To(desiredReplicas)
+			rbg := &workloadsv1alpha2.RoleBasedGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "scheduled-batch", Namespace: "default"},
+				Spec:       workloadsv1alpha2.RoleBasedGroupSpec{Roles: []workloadsv1alpha2.RoleSpec{role}},
+			}
+			policy := &workloadsv1alpha2.CoordinatedPolicy{
+				Spec: workloadsv1alpha2.CoordinatedPolicySpec{Policies: []workloadsv1alpha2.CoordinatedPolicyRule{{
+					Roles: []string{role.Name},
+					Strategy: workloadsv1alpha2.CoordinatedPolicyStrategy{Scaling: &workloadsv1alpha2.ScalingCoordinationStrategy{
+						MaxSkew:     ptr.To(intstr.FromString("50%")),
+						Progression: workloadsv1alpha2.OrderScheduledProgression,
+					}},
+				}}},
+			}
+			statuses := []workloadsv1alpha2.RoleStatus{{Name: role.Name, Replicas: currentReplicas}}
+			podCount := int(currentReplicas) * pattern.podsPerReplica
+			scheduledCounts := []int{0}
+			if podCount > 0 {
+				scheduledCounts = append(scheduledCounts, podCount-1, podCount)
+				if pattern.podsPerReplica > 1 {
+					scheduledCounts = append(scheduledCounts, pattern.podsPerReplica)
+				}
+			}
+			for _, scheduledPods := range scheduledCounts {
+				t.Run(fmt.Sprintf("%d of %d Pods scheduled", scheduledPods, podCount), func(t *testing.T) {
+					scheme := runtime.NewScheme()
+					require.NoError(t, clientgoscheme.AddToScheme(scheme))
+					objects := make([]client.Object, 0, podCount)
+					for i := 0; i < podCount; i++ {
+						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("prefill-%d", i), Namespace: rbg.Namespace,
+							Labels: map[string]string{
+								constants.GroupNameLabelKey: rbg.Name,
+								constants.RoleNameLabelKey:  role.Name,
+							},
+						}}
+						if i < scheduledPods {
+							pod.Spec.NodeName = "node-1"
+						}
+						objects = append(objects, pod)
+					}
+					r := &RoleBasedGroupReconciler{client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()}
+					targets, err := r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
+					require.NoError(t, err)
+					want := currentReplicas
+					if podCount > 0 && scheduledPods == podCount {
+						want = desiredReplicas
+					}
+					assert.Equal(t, want, targets[role.Name])
+				})
+			}
+		})
+	}
+}

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -2430,6 +2430,27 @@ func TestCalculateScalingForAllCoordination_OrderScheduled(t *testing.T) {
 			podsPerReplica: 4,
 		},
 		{
+			name: "negative component size",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{{Name: "component0", Size: ptr.To(int32(2))}, {Name: "component1", Size: ptr.To(int32(-1))}},
+			}},
+			podsPerReplica: 2,
+		},
+		{
+			name: "component sizes cancel",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{{Name: "component0", Size: ptr.To(int32(2))}, {Name: "component1", Size: ptr.To(int32(-2))}},
+			}},
+			podsPerReplica: 2,
+		},
+		{
+			name: "only negative component",
+			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{
+				Components: []workloadsv1alpha2.InstanceComponent{{Name: "component0", Size: ptr.To(int32(-1))}},
+			}},
+			podsPerReplica: 0,
+		},
+		{
 			name:    "empty custom components",
 			pattern: workloadsv1alpha2.Pattern{CustomComponentsPattern: &workloadsv1alpha2.CustomComponentsPattern{}},
 		},
@@ -2463,19 +2484,33 @@ func TestCalculateScalingForAllCoordination_OrderScheduled(t *testing.T) {
 			}
 			statuses := []workloadsv1alpha2.RoleStatus{{Name: role.Name, Replicas: currentReplicas}}
 			podCount := int(currentReplicas) * pattern.podsPerReplica
-			scheduledCounts := []int{0}
+			type schedulingCase struct {
+				name           string
+				scheduledPods  int
+				missingPod     bool
+				terminatingPod bool
+			}
+			cases := []schedulingCase{{name: "none scheduled"}}
 			if podCount > 0 {
-				scheduledCounts = append(scheduledCounts, podCount-1, podCount)
+				cases = append(cases,
+					schedulingCase{name: "one unscheduled", scheduledPods: podCount - 1},
+					schedulingCase{name: "all scheduled", scheduledPods: podCount},
+					schedulingCase{name: "one not created yet", scheduledPods: podCount - 1, missingPod: true},
+					schedulingCase{name: "terminating Pod cannot fill gap", scheduledPods: podCount - 1, terminatingPod: true},
+				)
 				if pattern.podsPerReplica > 1 {
-					scheduledCounts = append(scheduledCounts, pattern.podsPerReplica)
+					cases = append(cases, schedulingCase{name: "one replica worth scheduled", scheduledPods: pattern.podsPerReplica})
 				}
 			}
-			for _, scheduledPods := range scheduledCounts {
-				t.Run(fmt.Sprintf("%d of %d Pods scheduled", scheduledPods, podCount), func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
 					scheme := runtime.NewScheme()
 					require.NoError(t, clientgoscheme.AddToScheme(scheme))
 					objects := make([]client.Object, 0, podCount)
 					for i := 0; i < podCount; i++ {
+						if tc.missingPod && i == podCount-1 {
+							continue
+						}
 						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 							Name: fmt.Sprintf("prefill-%d", i), Namespace: rbg.Namespace,
 							Labels: map[string]string{
@@ -2483,16 +2518,24 @@ func TestCalculateScalingForAllCoordination_OrderScheduled(t *testing.T) {
 								constants.RoleNameLabelKey:  role.Name,
 							},
 						}}
-						if i < scheduledPods {
+						if i < tc.scheduledPods {
 							pod.Spec.NodeName = "node-1"
 						}
 						objects = append(objects, pod)
+					}
+					if tc.terminatingPod {
+						oldPod := objects[0].(*corev1.Pod).DeepCopy()
+						oldPod.Name = "terminating-old-pod"
+						oldPod.Spec.NodeName = "node-1"
+						oldPod.DeletionTimestamp = ptr.To(metav1.Now())
+						oldPod.Finalizers = []string{"test.rbg/hold"}
+						objects = append(objects, oldPod)
 					}
 					r := &RoleBasedGroupReconciler{client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()}
 					targets, err := r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
 					require.NoError(t, err)
 					want := currentReplicas
-					if scheduledPods == podCount {
+					if tc.scheduledPods == podCount {
 						want = desiredReplicas
 					}
 					assert.Equal(t, want, targets[role.Name])

--- a/internal/controller/workloads/rolebasedgroup_controller_test.go
+++ b/internal/controller/workloads/rolebasedgroup_controller_test.go
@@ -2492,12 +2492,79 @@ func TestCalculateScalingForAllCoordination_OrderScheduled(t *testing.T) {
 					targets, err := r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
 					require.NoError(t, err)
 					want := currentReplicas
-					if podCount > 0 && scheduledPods == podCount {
+					if scheduledPods == podCount {
 						want = desiredReplicas
 					}
 					assert.Equal(t, want, targets[role.Name])
+					if podCount != 0 {
+						return
+					}
+
+					// Skipping scheduling for zero Pods must retain batch and readiness gates.
+					const largerDesiredReplicas int32 = 10
+					const nextBatchReplicas int32 = 7 // Current 2 plus maxSkew of 50% of 10.
+					rbg.Spec.Roles[0].Replicas = ptr.To(largerDesiredReplicas)
+					targets, err = r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
+					require.NoError(t, err)
+					assert.Equal(t, nextBatchReplicas, targets[role.Name])
+
+					policy.Spec.Policies[0].Strategy.Scaling.Progression = workloadsv1alpha2.OrderReadyProgression
+					targets, err = r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
+					require.NoError(t, err)
+					assert.Equal(t, currentReplicas, targets[role.Name])
 				})
 			}
+		})
+	}
+}
+
+// A stale policy reference must not prevent the remaining roles from scaling.
+func TestCalculateScalingForAllCoordination_MissingRole(t *testing.T) {
+	const currentReplicas int32 = 2
+	const desiredReplicas int32 = 4
+	const missingRole = "removed"
+	role := workloadsv1alpha2.RoleSpec{}
+	role.Name = "prefill"
+	role.Replicas = ptr.To(desiredReplicas)
+	rbg := &workloadsv1alpha2.RoleBasedGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "stale-policy", Namespace: "default"},
+		Spec:       workloadsv1alpha2.RoleBasedGroupSpec{Roles: []workloadsv1alpha2.RoleSpec{role}},
+	}
+	policy := &workloadsv1alpha2.CoordinatedPolicy{
+		Spec: workloadsv1alpha2.CoordinatedPolicySpec{Policies: []workloadsv1alpha2.CoordinatedPolicyRule{{
+			Roles: []string{missingRole, role.Name},
+			Strategy: workloadsv1alpha2.CoordinatedPolicyStrategy{Scaling: &workloadsv1alpha2.ScalingCoordinationStrategy{
+				MaxSkew:     ptr.To(intstr.FromString("50%")),
+				Progression: workloadsv1alpha2.OrderScheduledProgression,
+			}},
+		}}},
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	objects := make([]client.Object, 0, currentReplicas)
+	for i := int32(0); i < currentReplicas; i++ {
+		objects = append(objects, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("prefill-%d", i), Namespace: rbg.Namespace,
+				Labels: map[string]string{
+					constants.GroupNameLabelKey: rbg.Name,
+					constants.RoleNameLabelKey:  role.Name,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-1"},
+		})
+	}
+	r := &RoleBasedGroupReconciler{client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()}
+	for _, staleReplicas := range []int32{0, currentReplicas} {
+		t.Run(fmt.Sprintf("removed role has %d stale replicas", staleReplicas), func(t *testing.T) {
+			statuses := []workloadsv1alpha2.RoleStatus{{Name: role.Name, Replicas: currentReplicas}}
+			if staleReplicas > 0 {
+				statuses = append(statuses, workloadsv1alpha2.RoleStatus{Name: missingRole, Replicas: staleReplicas})
+			}
+			targets, err := r.CalculateScalingForAllCoordination(context.Background(), rbg, policy, statuses)
+			require.NoError(t, err)
+			assert.Equal(t, desiredReplicas, targets[role.Name])
+			assert.Zero(t, targets[missingRole])
 		})
 	}
 }

--- a/pkg/coordination/coordinationscaling/scaler.go
+++ b/pkg/coordination/coordinationscaling/scaler.go
@@ -34,11 +34,12 @@ type CoordinationScaler struct {
 
 // RoleScalingState represents the current scaling state of a role.
 type RoleScalingState struct {
-	RoleName          string
-	DesiredReplicas   int32
-	CurrentReplicas   int32
-	ScheduledReplicas int32 // Number of replicas that have been scheduled (have nodeName)
-	ReadyReplicas     int32 // Number of replicas that are ready
+	RoleName        string
+	DesiredReplicas int32
+	CurrentReplicas int32
+	ScheduledPods   int64 // Non-terminating Pods with nodeName set.
+	ExpectedPods    int64 // Pods expected from current replicas.
+	ReadyReplicas   int32 // Number of replicas that are ready
 }
 
 // NewCoordinationScalerFromPolicy creates a new CoordinationScaler instance from v1alpha2 CoordinatedPolicyRule.
@@ -226,8 +227,8 @@ func (s *CoordinationScaler) canProceedToNextBatch(
 		// Check based on progression type
 		switch progression {
 		case workloadsv1alpha2.OrderScheduledProgression:
-			// All current replicas must be scheduled
-			if state.ScheduledReplicas < state.CurrentReplicas {
+			// Wait for the expected Pod count
+			if state.ScheduledPods < state.ExpectedPods {
 				return false
 			}
 		case workloadsv1alpha2.OrderReadyProgression:

--- a/pkg/coordination/coordinationscaling/scaler_test.go
+++ b/pkg/coordination/coordinationscaling/scaler_test.go
@@ -110,18 +110,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -135,18 +137,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15, // 5% progress
-					ScheduledReplicas: 15, // All scheduled
-					ReadyReplicas:     15, // All ready
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15, // 5% progress
+					ExpectedPods:    15,
+					ScheduledPods:   15, // All scheduled
+					ReadyReplicas:   15, // All ready
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   0, // 0% progress
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 0, // 0% progress
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -160,18 +164,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15, // 5% progress
-					ScheduledReplicas: 15,
-					ReadyReplicas:     15,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15, // 5% progress
+					ExpectedPods:    15,
+					ScheduledPods:   15,
+					ReadyReplicas:   15,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5, // 5% progress
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5, // 5% progress
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -185,18 +191,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   285, // 95% progress
-					ScheduledReplicas: 285,
-					ReadyReplicas:     285,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 285, // 95% progress
+					ExpectedPods:    285,
+					ScheduledPods:   285,
+					ReadyReplicas:   285,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   90, // 90% progress
-					ScheduledReplicas: 90,
-					ReadyReplicas:     90,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 90, // 90% progress
+					ExpectedPods:    90,
+					ScheduledPods:   90,
+					ReadyReplicas:   90,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -210,18 +218,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   300, // 100% progress
-					ScheduledReplicas: 300,
-					ReadyReplicas:     300,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 300, // 100% progress
+					ExpectedPods:    300,
+					ScheduledPods:   300,
+					ReadyReplicas:   300,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   100, // 100% progress
-					ScheduledReplicas: 100,
-					ReadyReplicas:     100,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 100, // 100% progress
+					ExpectedPods:    100,
+					ScheduledPods:   100,
+					ReadyReplicas:   100,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -235,25 +245,28 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "10%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   200,
-					CurrentReplicas:   20, // 10% progress
-					ScheduledReplicas: 20,
-					ReadyReplicas:     20,
+					RoleName:        "prefill",
+					DesiredReplicas: 200,
+					CurrentReplicas: 20, // 10% progress
+					ExpectedPods:    20,
+					ScheduledPods:   20,
+					ReadyReplicas:   20,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   0, // 0% progress
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 0, // 0% progress
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"router": {
-					RoleName:          "router",
-					DesiredReplicas:   50,
-					CurrentReplicas:   5, // 10% progress
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "router",
+					DesiredReplicas: 50,
+					CurrentReplicas: 5, // 10% progress
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -268,32 +281,36 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"router": {
-					RoleName:          "router",
-					DesiredReplicas:   10,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "router",
+					DesiredReplicas: 10,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"worker": {
-					RoleName:          "worker",
-					DesiredReplicas:   50,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "worker",
+					DesiredReplicas: 50,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -309,39 +326,44 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "8%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   500,
-					CurrentReplicas:   50, // 10% progress
-					ScheduledReplicas: 50,
-					ReadyReplicas:     50,
+					RoleName:        "prefill",
+					DesiredReplicas: 500,
+					CurrentReplicas: 50, // 10% progress
+					ExpectedPods:    50,
+					ScheduledPods:   50,
+					ReadyReplicas:   50,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   200,
-					CurrentReplicas:   20, // 10% progress
-					ScheduledReplicas: 20,
-					ReadyReplicas:     20,
+					RoleName:        "decode",
+					DesiredReplicas: 200,
+					CurrentReplicas: 20, // 10% progress
+					ExpectedPods:    20,
+					ScheduledPods:   20,
+					ReadyReplicas:   20,
 				},
 				"router": {
-					RoleName:          "router",
-					DesiredReplicas:   20,
-					CurrentReplicas:   1, // 5% progress (slowest)
-					ScheduledReplicas: 1,
-					ReadyReplicas:     1,
+					RoleName:        "router",
+					DesiredReplicas: 20,
+					CurrentReplicas: 1, // 5% progress (slowest)
+					ExpectedPods:    1,
+					ScheduledPods:   1,
+					ReadyReplicas:   1,
 				},
 				"worker": {
-					RoleName:          "worker",
-					DesiredReplicas:   100,
-					CurrentReplicas:   8, // 8% progress
-					ScheduledReplicas: 8,
-					ReadyReplicas:     8,
+					RoleName:        "worker",
+					DesiredReplicas: 100,
+					CurrentReplicas: 8, // 8% progress
+					ExpectedPods:    8,
+					ScheduledPods:   8,
+					ReadyReplicas:   8,
 				},
 				"monitor": {
-					RoleName:          "monitor",
-					DesiredReplicas:   10,
-					CurrentReplicas:   1, // 10% progress
-					ScheduledReplicas: 1,
-					ReadyReplicas:     1,
+					RoleName:        "monitor",
+					DesiredReplicas: 10,
+					CurrentReplicas: 1, // 10% progress
+					ExpectedPods:    1,
+					ScheduledPods:   1,
+					ReadyReplicas:   1,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -359,25 +381,28 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "10%",
 			roleStates: map[string]RoleScalingState{
 				"large": {
-					RoleName:          "large",
-					DesiredReplicas:   1000,
-					CurrentReplicas:   100, // 10% progress
-					ScheduledReplicas: 100,
-					ReadyReplicas:     100,
+					RoleName:        "large",
+					DesiredReplicas: 1000,
+					CurrentReplicas: 100, // 10% progress
+					ExpectedPods:    100,
+					ScheduledPods:   100,
+					ReadyReplicas:   100,
 				},
 				"medium": {
-					RoleName:          "medium",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5, // 5% progress (slowest)
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "medium",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5, // 5% progress (slowest)
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 				"small": {
-					RoleName:          "small",
-					DesiredReplicas:   10,
-					CurrentReplicas:   1, // 10% progress
-					ScheduledReplicas: 1,
-					ReadyReplicas:     1,
+					RoleName:        "small",
+					DesiredReplicas: 10,
+					CurrentReplicas: 1, // 10% progress
+					ExpectedPods:    1,
+					ScheduledPods:   1,
+					ReadyReplicas:   1,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -393,18 +418,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   0,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "prefill",
+					DesiredReplicas: 0,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   50,
-					ScheduledReplicas: 50,
-					ReadyReplicas:     50,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 50,
+					ExpectedPods:    50,
+					ScheduledPods:   50,
+					ReadyReplicas:   50,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -418,18 +445,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "10%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   0,
-					CurrentReplicas:   5,
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "prefill",
+					DesiredReplicas: 0,
+					CurrentReplicas: 5,
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   10,
-					ScheduledReplicas: 10,
-					ReadyReplicas:     10,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 10,
+					ExpectedPods:    10,
+					ScheduledPods:   10,
+					ReadyReplicas:   10,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -443,18 +472,20 @@ func TestCalculateTargetReplicas(t *testing.T) {
 			maxSkew: "5%",
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   0,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "prefill",
+					DesiredReplicas: 0,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   0,
-					CurrentReplicas:   0,
-					ScheduledReplicas: 0,
-					ReadyReplicas:     0,
+					RoleName:        "decode",
+					DesiredReplicas: 0,
+					CurrentReplicas: 0,
+					ExpectedPods:    0,
+					ScheduledPods:   0,
+					ReadyReplicas:   0,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -611,18 +642,20 @@ func TestProgressionStrategy(t *testing.T) {
 			progression: workloadsv1alpha2.OrderScheduledProgression,
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15,
-					ScheduledReplicas: 10, // Not all scheduled yet
-					ReadyReplicas:     10,
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15,
+					ExpectedPods:    15,
+					ScheduledPods:   10, // Not all scheduled yet
+					ReadyReplicas:   10,
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5,
-					ScheduledReplicas: 5, // All scheduled
-					ReadyReplicas:     5,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5,
+					ExpectedPods:    5,
+					ScheduledPods:   5, // All scheduled
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -637,18 +670,20 @@ func TestProgressionStrategy(t *testing.T) {
 			progression: workloadsv1alpha2.OrderScheduledProgression,
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15,
-					ScheduledReplicas: 15, // All scheduled
-					ReadyReplicas:     10, // Not all ready (but OK for OrderScheduled)
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15,
+					ExpectedPods:    15,
+					ScheduledPods:   15, // All scheduled
+					ReadyReplicas:   10, // Not all ready (but OK for OrderScheduled)
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5,
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5,
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -663,18 +698,20 @@ func TestProgressionStrategy(t *testing.T) {
 			progression: workloadsv1alpha2.OrderReadyProgression,
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15,
-					ScheduledReplicas: 15, // All scheduled
-					ReadyReplicas:     10, // Not all ready yet
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15,
+					ExpectedPods:    15,
+					ScheduledPods:   15, // All scheduled
+					ReadyReplicas:   10, // Not all ready yet
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5,
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5,
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{
@@ -689,18 +726,20 @@ func TestProgressionStrategy(t *testing.T) {
 			progression: workloadsv1alpha2.OrderReadyProgression,
 			roleStates: map[string]RoleScalingState{
 				"prefill": {
-					RoleName:          "prefill",
-					DesiredReplicas:   300,
-					CurrentReplicas:   15,
-					ScheduledReplicas: 15,
-					ReadyReplicas:     15, // All ready
+					RoleName:        "prefill",
+					DesiredReplicas: 300,
+					CurrentReplicas: 15,
+					ExpectedPods:    15,
+					ScheduledPods:   15,
+					ReadyReplicas:   15, // All ready
 				},
 				"decode": {
-					RoleName:          "decode",
-					DesiredReplicas:   100,
-					CurrentReplicas:   5,
-					ScheduledReplicas: 5,
-					ReadyReplicas:     5,
+					RoleName:        "decode",
+					DesiredReplicas: 100,
+					CurrentReplicas: 5,
+					ExpectedPods:    5,
+					ScheduledPods:   5,
+					ReadyReplicas:   5,
 				},
 			},
 			wantTargets: map[string]int32{


### PR DESCRIPTION
### Ⅰ. Motivation

`OrderScheduled` compares `ScheduledReplicas` against `RoleStatus.Replicas`, but the controller supplies a raw scheduled Pod count while multi-Pod role replicas are counted as RoleInstances. With two current replicas containing four Pods each, four scheduled Pods already pass the `4 >= 2` check and allow the next scaling batch, even though half the current batch is still unscheduled.

### Ⅱ. Modifications

Normalize the scheduled Pod count by the role's Pods-per-replica value using the existing `ComputeSubGroupSize` helper. The progression check therefore requires eight scheduled Pods for two four-Pod replicas. Preserve the single-Pod behavior and return zero for patterns that produce no Pods to avoid division by zero. Document the multi-Pod progression threshold.

This is a count-unit correction using the existing role-level Pod query and current role pattern; it does not add per-instance scheduling status or change the scaler's batch calculation.

### Ⅲ. Does this pull request fix one issue?

NONE.

### Ⅳ. List the added test cases

A controller regression test exercises `CalculateScalingForAllCoordination` with standalone, leader-worker, custom-component, default component-size, empty-component, and zero-sized-component patterns. It verifies that partially scheduled batches wait and fully scheduled batches advance without requiring Pod readiness.

Before the fix, the leader-worker and custom-component cases with 4/8 and 7/8 scheduled Pods failed: the target advanced to four replicas instead of remaining at two. The same cases pass after the fix.

### Ⅴ. Describe how to verify it

Passed locally with Go 1.26.1:

```sh
go test ./internal/controller/workloads ./pkg/coordination/coordinationscaling -count=1
go vet ./internal/controller/workloads ./pkg/coordination/coordinationscaling
golangci-lint run --new-from-rev=upstream/main ./internal/controller/workloads/... ./pkg/coordination/coordinationscaling/...
BASE_REF=upstream/main make copyright-check
```

The lint check used the repository-pinned golangci-lint v2.13.1. Changed Go files were formatted with gofmt; `git diff --check` passed.

### VI. Special notes for reviews

The regression test uses the controller-runtime fake client. No real-cluster E2E was run.

## Checklist

- [x] Format changed Go code.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.