### PR TITLE
fix: leave Pod Ready condition to kubelet; controller writes only readiness gates

### DIFF
--- a/pkg/inplace/pod/readiness/pod_readiness_utils.go
+++ b/pkg/inplace/pod/readiness/pod_readiness_utils.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-	util "sigs.k8s.io/rbgs/pkg/inplace/pod"
 	podadapter "sigs.k8s.io/rbgs/pkg/inplace/pod/clientadapter"
 )
 
@@ -61,8 +60,9 @@ func addNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condType v
 			condition.LastTransitionTime = metav1.Now()
 		}
 
-		// set pod ready condition to "False"
-		util.UpdatePodReadyCondition(newPod)
+		// Write only the gate condition. Ready is kubelet-owned: kubelet derives it from
+		// ContainersReady plus the readiness gates. So writing it anyway is harmful:
+		// might shortly flip the pod back to the state we just moved it away from.
 		if err = adp.UpdatePodStatus(newPod); err != nil {
 			return err
 		}
@@ -96,8 +96,7 @@ func removeNotReadyKey(adp podadapter.Adapter, pod *v1.Pod, msg Message, condTyp
 		}
 		condition.Message = messages.dump()
 		condition.LastTransitionTime = metav1.Now()
-		// Re-evaluate pod Ready condition after updating readiness gate
-		util.UpdatePodReadyCondition(newPod)
+		// Ready is left to kubelet here too; see the note in addNotReadyKey.
 		if err = adp.UpdatePodStatus(newPod); err != nil {
 			return err
 		}

--- a/pkg/inplace/pod/readiness/pod_readiness_utils_test.go
+++ b/pkg/inplace/pod/readiness/pod_readiness_utils_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package readiness
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,33 +29,62 @@ import (
 	podadapter "sigs.k8s.io/rbgs/pkg/inplace/pod/clientadapter"
 )
 
-// fakeAdapter is a minimal in-memory Adapter for unit tests.
-type fakeAdapter struct {
-	pod *v1.Pod
+var gateCondType = constants.InstancePodReadyConditionType
+
+// recordingAdapter is an in-memory Adapter that records the exact pod object
+// passed to every UpdatePodStatus call. Deliberately, it does nothing else.
+//
+// A previous version of this fake additionally recomputed the Ready condition
+// the way kubelet would, immediately after every write. That made every
+// assertion on Ready converge to the same value whether or not the controller
+// itself had written Ready, so the tests passed both with and without the
+// write they were meant to guard against. Here, any Ready value observed in a
+// recorded write is a value the controller put there itself.
+type recordingAdapter struct {
+	pod    *v1.Pod
+	writes []*v1.Pod
 }
 
-func (f *fakeAdapter) GetPod(namespace, name string) (*v1.Pod, error) {
+var _ podadapter.Adapter = &recordingAdapter{}
+
+func (f *recordingAdapter) GetPod(namespace, name string) (*v1.Pod, error) {
 	if f.pod == nil || f.pod.Namespace != namespace || f.pod.Name != name {
 		return nil, fmt.Errorf("pod %s/%s not found", namespace, name)
 	}
 	return f.pod.DeepCopy(), nil
 }
 
-func (f *fakeAdapter) UpdatePod(pod *v1.Pod) error {
+func (f *recordingAdapter) UpdatePod(pod *v1.Pod) error {
 	f.pod = pod.DeepCopy()
 	return nil
 }
 
-func (f *fakeAdapter) UpdatePodStatus(pod *v1.Pod) error {
+func (f *recordingAdapter) UpdatePodStatus(pod *v1.Pod) error {
+	f.writes = append(f.writes, pod.DeepCopy())
 	f.pod = pod.DeepCopy()
 	return nil
 }
 
-var _ podadapter.Adapter = &fakeAdapter{}
+// kubeletManagedReady returns a deliberately distinctive Ready condition.
+// Ready is kubelet-owned: kubelet derives it from ContainersReady plus the
+// readiness gates, and a controller that also writes it makes kubelet's
+// status cache diverge from the API server, so kubelet's next 10s tick
+// republishes a stale value (the observed True->False->True flap). The
+// marker Reason/Message make any controller write to Ready show up in a
+// DeepEqual even when the Status it writes happens to equal the current one.
+func kubeletManagedReady(status v1.ConditionStatus) v1.PodCondition {
+	return v1.PodCondition{
+		Type:               v1.PodReady,
+		Status:             status,
+		Reason:             "KubeletManaged",
+		Message:            "owned by kubelet; the controller must not rewrite this condition",
+		LastTransitionTime: metav1.NewTime(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)),
+	}
+}
 
-// newReadyPod creates a pod that simulates the state after KWOK's pod-ready
-// stage fires: all conditions True, both readiness gates present and True.
-func newReadyPod() *v1.Pod {
+// servingPod is a pod that has fully come up: containers ready, both gates
+// satisfied, and kubelet has published Ready=True.
+func servingPod() *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
@@ -61,147 +93,379 @@ func newReadyPod() *v1.Pod {
 		Spec: v1.PodSpec{
 			ReadinessGates: []v1.PodReadinessGate{
 				{ConditionType: constants.InstancePodReadyConditionType},
-				{ConditionType: "InPlaceUpdateReady"},
+				{ConditionType: constants.InPlaceUpdateReady},
 			},
 		},
 		Status: v1.PodStatus{
 			Conditions: []v1.PodCondition{
-				{
-					Type:               v1.PodReady,
-					Status:             v1.ConditionTrue,
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               v1.ContainersReady,
-					Status:             v1.ConditionTrue,
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               constants.InstancePodReadyConditionType,
-					Status:             v1.ConditionTrue,
-					Message:            "[]",
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               "InPlaceUpdateReady",
-					Status:             v1.ConditionTrue,
-					LastTransitionTime: metav1.Now(),
-				},
-				{
-					Type:               v1.PodScheduled,
-					Status:             v1.ConditionTrue,
-					LastTransitionTime: metav1.Now(),
-				},
+				kubeletManagedReady(v1.ConditionTrue),
+				{Type: v1.ContainersReady, Status: v1.ConditionTrue},
+				{Type: constants.InPlaceUpdateReady, Status: v1.ConditionTrue},
+				{Type: gateCondType, Status: v1.ConditionTrue, Message: "[]"},
 			},
 		},
 	}
 }
 
-func getPodConditionStatus(pod *v1.Pod, condType v1.PodConditionType) v1.ConditionStatus {
-	for _, c := range pod.Status.Conditions {
-		if c.Type == condType {
-			return c.Status
-		}
-	}
-	return ""
+// gatedOutPod is a serving pod taken out of rotation: the gate is False
+// carrying the given not-ready keys, and kubelet has already reacted to the
+// gate by publishing Ready=False.
+func gatedOutPod(msgs ...Message) *v1.Pod {
+	pod := servingPod()
+	setCondition(pod, kubeletManagedReady(v1.ConditionFalse))
+	setGateCondition(pod, v1.ConditionFalse, messageList(msgs).dump())
+	return pod
 }
 
-// TestRemoveNotReadyKey_UpdatesPodReadyCondition reproduces the bug where
-// removeNotReadyKey did not re-evaluate the pod's Ready condition after
-// setting a readiness gate back to True. This caused pods to stay
-// Ready=False permanently in KWOK environments.
-//
-// The sequence:
-//  1. KWOK sets pod Ready=True with all readiness gates True
-//  2. addNotReadyKey sets InstancePodReady=False → Ready becomes False
-//  3. removeNotReadyKey sets InstancePodReady=True → Ready must become True
-//
-// Before the fix, step 3 left Ready=False because UpdatePodReadyCondition
-// was not called.
-func TestRemoveNotReadyKey_UpdatesPodReadyCondition(t *testing.T) {
-	pod := newReadyPod()
-	adp := &fakeAdapter{pod: pod}
+func setCondition(pod *v1.Pod, condition v1.PodCondition) {
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == condition.Type {
+			pod.Status.Conditions[i] = condition
+			return
+		}
+	}
+	pod.Status.Conditions = append(pod.Status.Conditions, condition)
+}
+
+func setGateCondition(pod *v1.Pod, status v1.ConditionStatus, message string) {
+	setCondition(pod, v1.PodCondition{
+		Type:               gateCondType,
+		Status:             status,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
+}
+
+func dropConditionOfType(pod *v1.Pod, condType v1.PodConditionType) {
+	kept := pod.Status.Conditions[:0]
+	for _, c := range pod.Status.Conditions {
+		if c.Type != condType {
+			kept = append(kept, c)
+		}
+	}
+	pod.Status.Conditions = kept
+}
+
+func mustCondition(t *testing.T, pod *v1.Pod, condType v1.PodConditionType) v1.PodCondition {
+	t.Helper()
+	for _, c := range pod.Status.Conditions {
+		if c.Type == condType {
+			return c
+		}
+	}
+	t.Fatalf("condition %s not found on pod", condType)
+	return v1.PodCondition{}
+}
+
+// assertOnlyGateConditionMayChange fails if written differs from before in
+// any condition other than the readiness gate: the gate is the only condition
+// the controller owns. Ready is the one that matters — writing it is the
+// defect these tests guard against — but ContainersReady & co. are equally
+// not ours to touch.
+func assertOnlyGateConditionMayChange(t *testing.T, before, written *v1.Pod) {
+	t.Helper()
+	beforeByType := make(map[v1.PodConditionType]v1.PodCondition, len(before.Status.Conditions))
+	for _, c := range before.Status.Conditions {
+		beforeByType[c.Type] = c
+	}
+	seen := make(map[v1.PodConditionType]bool, len(written.Status.Conditions))
+	for _, c := range written.Status.Conditions {
+		seen[c.Type] = true
+		if c.Type == gateCondType {
+			continue
+		}
+		b, ok := beforeByType[c.Type]
+		if !ok {
+			t.Errorf("controller write added unexpected condition %s: %+v", c.Type, c)
+			continue
+		}
+		if !reflect.DeepEqual(b, c) {
+			t.Errorf("controller write modified condition %s, which it does not own:\n  before: %+v\n  after:  %+v", c.Type, b, c)
+		}
+	}
+	for condType := range beforeByType {
+		if !seen[condType] {
+			t.Errorf("controller write dropped condition %s", condType)
+		}
+	}
+}
+
+func assertGateMessages(t *testing.T, gate v1.PodCondition, want []Message) {
+	t.Helper()
+	var got []Message
+	if gate.Message != "" {
+		if err := json.Unmarshal([]byte(gate.Message), &got); err != nil {
+			t.Fatalf("gate message %q is not valid JSON: %v", gate.Message, err)
+		}
+	}
+	gotSet := make(map[Message]bool, len(got))
+	for _, m := range got {
+		if gotSet[m] {
+			t.Errorf("gate message %q contains duplicate %+v", gate.Message, m)
+		}
+		gotSet[m] = true
+	}
+	if len(got) != len(want) {
+		t.Errorf("gate messages = %v, want %v", got, want)
+		return
+	}
+	for _, m := range want {
+		if !gotSet[m] {
+			t.Errorf("gate messages = %v, want %v", got, want)
+			return
+		}
+	}
+}
+
+// TestAddNotReadyKey_LeavesReadyConditionToKubelet guards the ownership
+// contract on the take-out-of-rotation path: the write flips the readiness
+// gate to False and nothing else. Kubelet observes the gate and publishes
+// Ready=False itself, within tens of milliseconds on a settled pod, so
+// writing Ready here gains nothing and breaks the single-writer rule.
+func TestAddNotReadyKey_LeavesReadyConditionToKubelet(t *testing.T) {
+	pod := servingPod()
+	adp := &recordingAdapter{pod: pod}
+	before := pod.DeepCopy()
 
 	msg := Message{UserAgent: "Lifecycle", Key: "InstanceReady"}
-	condType := constants.InstancePodReadyConditionType
-
-	// Step 1: Verify initial state — pod is fully ready (simulates KWOK).
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionTrue {
-		t.Fatalf("precondition: expected Ready=True, got %s", s)
-	}
-
-	// Step 2: addNotReadyKey — sets InstancePodReady=False and Ready=False.
-	modified, err := addNotReadyKey(adp, adp.pod, msg, condType)
+	modified, err := addNotReadyKey(adp, pod, msg, gateCondType)
 	if err != nil {
 		t.Fatalf("addNotReadyKey failed: %v", err)
 	}
 	if !modified {
 		t.Fatal("addNotReadyKey should have modified the pod")
 	}
-	if s := getPodConditionStatus(adp.pod, condType); s != v1.ConditionFalse {
-		t.Fatalf("after addNotReadyKey: expected InstancePodReady=False, got %s", s)
+	if len(adp.writes) != 1 {
+		t.Fatalf("expected exactly 1 status write, got %d", len(adp.writes))
 	}
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionFalse {
-		t.Fatalf("after addNotReadyKey: expected Ready=False, got %s", s)
-	}
+	written := adp.writes[0]
 
-	// Step 3: removeNotReadyKey — sets InstancePodReady=True.
-	// This is the critical assertion: Ready must also become True.
-	modified, err = removeNotReadyKey(adp, adp.pod, msg, condType)
+	gate := mustCondition(t, written, gateCondType)
+	if gate.Status != v1.ConditionFalse {
+		t.Errorf("gate status = %s, want False", gate.Status)
+	}
+	assertGateMessages(t, gate, []Message{msg})
+
+	assertOnlyGateConditionMayChange(t, before, written)
+	if got := mustCondition(t, written, v1.PodReady); got.Status != v1.ConditionTrue {
+		t.Errorf("Ready must be left untouched at True; controller wrote %s", got.Status)
+	}
+}
+
+// TestRemoveNotReadyKey_LeavesReadyConditionToKubelet guards the ownership
+// contract on the return-to-rotation path: the write flips the readiness
+// gate back to True and nothing else. Ready stays False in the write on
+// purpose — flipping it is kubelet's job. The old behavior of writing
+// Ready=True here is what made kubelet's next 10s sync republish its stale
+// Ready=False over ours.
+func TestRemoveNotReadyKey_LeavesReadyConditionToKubelet(t *testing.T) {
+	msg := Message{UserAgent: "Lifecycle", Key: "InstanceReady"}
+	pod := gatedOutPod(msg)
+	adp := &recordingAdapter{pod: pod}
+	before := pod.DeepCopy()
+
+	modified, err := removeNotReadyKey(adp, pod, msg, gateCondType)
 	if err != nil {
 		t.Fatalf("removeNotReadyKey failed: %v", err)
 	}
 	if !modified {
 		t.Fatal("removeNotReadyKey should have modified the pod")
 	}
-	if s := getPodConditionStatus(adp.pod, condType); s != v1.ConditionTrue {
-		t.Fatalf("after removeNotReadyKey: expected InstancePodReady=True, got %s", s)
+	if len(adp.writes) != 1 {
+		t.Fatalf("expected exactly 1 status write, got %d", len(adp.writes))
 	}
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionTrue {
-		t.Fatalf("after removeNotReadyKey: expected Ready=True, got %s (bug: UpdatePodReadyCondition not called)", s)
+	written := adp.writes[0]
+
+	gate := mustCondition(t, written, gateCondType)
+	if gate.Status != v1.ConditionTrue {
+		t.Errorf("gate status = %s, want True", gate.Status)
+	}
+	assertGateMessages(t, gate, nil)
+
+	assertOnlyGateConditionMayChange(t, before, written)
+	if got := mustCondition(t, written, v1.PodReady); got.Status != v1.ConditionFalse {
+		t.Errorf("Ready must be left untouched at False for kubelet to flip; controller wrote %s", got.Status)
 	}
 }
 
-// TestAddRemoveNotReadyKey_MultipleKeys verifies that Ready only becomes True
-// once all not-ready keys are removed, not just one.
-func TestAddRemoveNotReadyKey_MultipleKeys(t *testing.T) {
-	pod := newReadyPod()
-	adp := &fakeAdapter{pod: pod}
+// TestAddNotReadyKey_GateCondition pins the gate-condition behavior the fix
+// must preserve: when the gate is written, which keys it carries, and when
+// no write happens at all. Redundant writes are worth pinning because every
+// status write is what wakes kubelet's pod-readiness reconciliation.
+func TestAddNotReadyKey_GateCondition(t *testing.T) {
+	msg := Message{UserAgent: "Lifecycle", Key: "InstanceReady"}
 
+	cases := []struct {
+		name         string
+		prepare      func(pod *v1.Pod)
+		wantModified bool
+		wantWrites   int
+		wantStatus   v1.ConditionStatus
+		wantMessages []Message
+	}{
+		{
+			name: "gate condition absent is created as False with the key",
+			prepare: func(pod *v1.Pod) {
+				dropConditionOfType(pod, gateCondType)
+			},
+			wantModified: true,
+			wantWrites:   1,
+			wantStatus:   v1.ConditionFalse,
+			wantMessages: []Message{msg},
+		},
+		{
+			name:         "gate condition True gains the key and flips to False",
+			prepare:      func(pod *v1.Pod) {},
+			wantModified: true,
+			wantWrites:   1,
+			wantStatus:   v1.ConditionFalse,
+			wantMessages: []Message{msg},
+		},
+		{
+			name: "key already present is a no-op with no status write",
+			prepare: func(pod *v1.Pod) {
+				setGateCondition(pod, v1.ConditionFalse, messageList{msg}.dump())
+			},
+			wantModified: false,
+			wantWrites:   0,
+		},
+		{
+			name: "pod without the readiness gate is left alone",
+			prepare: func(pod *v1.Pod) {
+				pod.Spec.ReadinessGates = nil
+			},
+			wantModified: false,
+			wantWrites:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := servingPod()
+			tc.prepare(pod)
+			adp := &recordingAdapter{pod: pod}
+			before := pod.DeepCopy()
+
+			modified, err := addNotReadyKey(adp, pod, msg, gateCondType)
+			if err != nil {
+				t.Fatalf("addNotReadyKey failed: %v", err)
+			}
+			if modified != tc.wantModified {
+				t.Errorf("modified = %v, want %v", modified, tc.wantModified)
+			}
+			if len(adp.writes) != tc.wantWrites {
+				t.Fatalf("expected %d status writes, got %d", tc.wantWrites, len(adp.writes))
+			}
+			if tc.wantWrites == 0 {
+				return
+			}
+
+			written := adp.writes[0]
+			gate := mustCondition(t, written, gateCondType)
+			if gate.Status != tc.wantStatus {
+				t.Errorf("gate status = %s, want %s", gate.Status, tc.wantStatus)
+			}
+			assertGateMessages(t, gate, tc.wantMessages)
+			assertOnlyGateConditionMayChange(t, before, written)
+		})
+	}
+}
+
+// TestRemoveNotReadyKey_GateCondition pins the gate-condition behavior the
+// fix must preserve: the gate goes back to True only once the last not-ready
+// key is removed, and keys the caller does not own are left untouched.
+func TestRemoveNotReadyKey_GateCondition(t *testing.T) {
 	msg1 := Message{UserAgent: "Lifecycle", Key: "InstanceReady"}
 	msg2 := Message{UserAgent: "InPlaceUpdate", Key: "Updating"}
-	condType := constants.InstancePodReadyConditionType
 
-	// Add two not-ready keys.
-	if _, err := addNotReadyKey(adp, adp.pod, msg1, condType); err != nil {
-		t.Fatalf("addNotReadyKey(msg1) failed: %v", err)
-	}
-	if _, err := addNotReadyKey(adp, adp.pod, msg2, condType); err != nil {
-		t.Fatalf("addNotReadyKey(msg2) failed: %v", err)
-	}
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionFalse {
-		t.Fatalf("after adding two keys: expected Ready=False, got %s", s)
+	cases := []struct {
+		name         string
+		prepare      func(pod *v1.Pod)
+		remove       Message
+		wantModified bool
+		wantWrites   int
+		wantStatus   v1.ConditionStatus
+		wantMessages []Message
+	}{
+		{
+			name: "removing the last key flips the gate back to True",
+			prepare: func(pod *v1.Pod) {
+				setGateCondition(pod, v1.ConditionFalse, messageList{msg1}.dump())
+			},
+			remove:       msg1,
+			wantModified: true,
+			wantWrites:   1,
+			wantStatus:   v1.ConditionTrue,
+			wantMessages: nil,
+		},
+		{
+			name: "removing one of two keys keeps the gate False",
+			prepare: func(pod *v1.Pod) {
+				setGateCondition(pod, v1.ConditionFalse, messageList{msg1, msg2}.dump())
+			},
+			remove:       msg1,
+			wantModified: true,
+			wantWrites:   1,
+			wantStatus:   v1.ConditionFalse,
+			wantMessages: []Message{msg2},
+		},
+		{
+			name: "unknown key is a no-op with no status write",
+			prepare: func(pod *v1.Pod) {
+				setGateCondition(pod, v1.ConditionFalse, messageList{msg2}.dump())
+			},
+			remove:       msg1,
+			wantModified: false,
+			wantWrites:   0,
+		},
+		{
+			name: "gate condition absent is a no-op with no status write",
+			prepare: func(pod *v1.Pod) {
+				dropConditionOfType(pod, gateCondType)
+			},
+			remove:       msg1,
+			wantModified: false,
+			wantWrites:   0,
+		},
+		{
+			name: "pod without the readiness gate is left alone",
+			prepare: func(pod *v1.Pod) {
+				pod.Spec.ReadinessGates = nil
+			},
+			remove:       msg1,
+			wantModified: false,
+			wantWrites:   0,
+		},
 	}
 
-	// Remove first key — Ready should remain False (one key still present).
-	if _, err := removeNotReadyKey(adp, adp.pod, msg1, condType); err != nil {
-		t.Fatalf("removeNotReadyKey(msg1) failed: %v", err)
-	}
-	if s := getPodConditionStatus(adp.pod, condType); s != v1.ConditionFalse {
-		t.Fatalf("after removing one key: expected InstancePodReady=False, got %s", s)
-	}
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionFalse {
-		t.Fatalf("after removing one key: expected Ready=False, got %s", s)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := gatedOutPod(msg1)
+			tc.prepare(pod)
+			adp := &recordingAdapter{pod: pod}
+			before := pod.DeepCopy()
 
-	// Remove second key — now Ready should become True.
-	if _, err := removeNotReadyKey(adp, adp.pod, msg2, condType); err != nil {
-		t.Fatalf("removeNotReadyKey(msg2) failed: %v", err)
-	}
-	if s := getPodConditionStatus(adp.pod, condType); s != v1.ConditionTrue {
-		t.Fatalf("after removing all keys: expected InstancePodReady=True, got %s", s)
-	}
-	if s := getPodConditionStatus(adp.pod, v1.PodReady); s != v1.ConditionTrue {
-		t.Fatalf("after removing all keys: expected Ready=True, got %s", s)
+			modified, err := removeNotReadyKey(adp, pod, tc.remove, gateCondType)
+			if err != nil {
+				t.Fatalf("removeNotReadyKey failed: %v", err)
+			}
+			if modified != tc.wantModified {
+				t.Errorf("modified = %v, want %v", modified, tc.wantModified)
+			}
+			if len(adp.writes) != tc.wantWrites {
+				t.Fatalf("expected %d status writes, got %d", tc.wantWrites, len(adp.writes))
+			}
+			if tc.wantWrites == 0 {
+				return
+			}
+
+			written := adp.writes[0]
+			gate := mustCondition(t, written, gateCondType)
+			if gate.Status != tc.wantStatus {
+				t.Errorf("gate status = %s, want %s", gate.Status, tc.wantStatus)
+			}
+			assertGateMessages(t, gate, tc.wantMessages)
+			assertOnlyGateConditionMayChange(t, before, written)
+		})
 	}
 }

--- a/test/e2e/testcase/v1alpha2/shared_service_selection.go
+++ b/test/e2e/testcase/v1alpha2/shared_service_selection.go
@@ -260,8 +260,9 @@ func expectLeaderWorkerPodsMatching(
 				return false
 			}
 			component := pod.Labels[constants.ComponentNameLabelKey]
-			if component == "" || pod.Status.PodIP == "" {
-				logger.V(1).Info("waiting for labeled leader-worker pods", "pod", pod.Name, "component", component, "podIP", pod.Status.PodIP)
+			ready := podReady(&pod)
+			if component == "" || pod.Status.PodIP == "" || !ready {
+				logger.V(1).Info("waiting for labeled ready leader-worker pods", "pod", pod.Name, "component", component, "podIP", pod.Status.PodIP, "ready", ready)
 				return false
 			}
 			if matches != nil && !matches(&pod) {
@@ -360,6 +361,17 @@ func podIPsByName(podsByComponent map[string]corev1.Pod) map[string]string {
 		podIPs[pod.Name] = pod.Status.PodIP
 	}
 	return podIPs
+}
+
+// podReady reports whether the kubelet has published Ready=True for the pod.
+func podReady(pod *corev1.Pod) bool {
+	for i := range pod.Status.Conditions {
+		c := &pod.Status.Conditions[i]
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func dumpSharedServiceSelectionDebugInfo(

--- a/test/stress/scripts/teardown-kwok.sh
+++ b/test/stress/scripts/teardown-kwok.sh
@@ -29,6 +29,7 @@ if [ "${UNINSTALL_KWOK}" = "true" ]; then
     kubectl delete stage pod-initialize --ignore-not-found=true 2>/dev/null || true
     kubectl delete stage pod-running --ignore-not-found=true 2>/dev/null || true
     kubectl delete stage pod-ready --ignore-not-found=true 2>/dev/null || true
+    kubectl delete stage pod-ready-blocked --ignore-not-found=true 2>/dev/null || true
     kubectl delete stage pod-delete --ignore-not-found=true 2>/dev/null || true
 else
     echo "[3/3] Keeping kwok installed (set UNINSTALL_KWOK=true to remove)"

--- a/test/stress/templates/kwok-stage.yaml
+++ b/test/stress/templates/kwok-stage.yaml
@@ -1,5 +1,16 @@
 # KWOK Stage resources to simulate Pod lifecycle for stress testing.
 # These stages automatically transition Pods to Ready state and handle deletion.
+#
+# Readiness-gate fidelity: the controller only writes readiness gates (InPlaceUpdateReady,
+# InstancePodReady) and leaves the kubelet-owned Ready condition to the kubelet. KWOK has no
+# kubelet, so the Ready promotion is emulated exclusively by the gate-aware pod-ready stage:
+#   - pod-running        runs containers (ContainersReady=True) but never promotes Ready;
+#   - pod-ready          flips Ready=True only while no gate is False;
+#   - pod-ready-blocked  flips Ready=False as soon as any gate is False (take-out-of-rotation).
+# Gate types must be kept in sync with api/workloads/constants (PodReadinessGate types the
+# controller injects). Known fidelity gap (accepted): a missing gate condition is treated as
+# satisfied, unlike kubelet which treats it as not-ready; the controller fills both gate
+# conditions right after Pod creation, so the window is transient.
 ---
 apiVersion: kwok.x-k8s.io/v1alpha1
 kind: Stage
@@ -70,8 +81,11 @@ spec:
         - type: Initialized
           status: "True"
           lastTransitionTime: {{ $now | Quote }}
+        # Ready must stay False here: only the gate-aware pod-ready stage may promote a pod
+        # to Ready=True. Writing Ready=True unconditionally would briefly expose a pod the
+        # controller has already gated out, before pod-ready-blocked flips it back.
         - type: Ready
-          status: "True"
+          status: "False"
           lastTransitionTime: {{ $now | Quote }}
         - type: ContainersReady
           status: "True"
@@ -111,6 +125,12 @@ spec:
         operator: 'NotIn'
         values:
           - "True"
+      # Only promote to Ready while the controller has not gated the pod out of rotation.
+      # Emulates kubelet deriving Ready from the readiness gates (see file header).
+      - key: '[.status.conditions.[]? | select((.type == "InPlaceUpdateReady" or .type == "InstancePodReady") and .status == "False")] | if length > 0 then "False" else "True" end'
+        operator: 'NotIn'
+        values:
+          - "False"
   delay:
     durationMilliseconds: 1000
   next:
@@ -142,6 +162,42 @@ spec:
             running:
               startedAt: {{ $now | Quote }}
         {{ end }}
+---
+# Gate-aware counterpart of pod-ready: when the controller has written any readiness gate to
+# False (markPodNotReady / take-out-of-rotation), flip Ready to False exactly like a kubelet
+# would. Only the Ready condition is patched; Pod statuses are merged with a strategic merge
+# patch for Pods, so the controller-owned gate conditions are preserved.
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-ready-blocked
+spec:
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+      - key: '.metadata.deletionTimestamp'
+        operator: 'DoesNotExist'
+      - key: '.status.podIP'
+        operator: 'Exists'
+      - key: '.status.conditions.[] | select( .type == "Ready" ) | .status'
+        operator: 'NotIn'
+        values:
+          - "False"
+      - key: '[.status.conditions.[]? | select((.type == "InPlaceUpdateReady" or .type == "InstancePodReady") and .status == "False")] | if length > 0 then "False" else "True" end'
+        operator: 'In'
+        values:
+          - "False"
+  delay:
+    durationMilliseconds: 1000
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      conditions:
+        - type: Ready
+          status: "False"
+          lastTransitionTime: {{ $now | Quote }}
 ---
 apiVersion: kwok.x-k8s.io/v1alpha1
 kind: Stage


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/sgl-project/rbg/blob/main/CONTRIBUTING.md -->

### Ⅰ. Motivation
<!-- Describe the purpose and goals of this pull request. -->

### Ⅱ. Modifications
<!-- Detail the changes made in this pull request. -->

### Ⅲ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #460 

### Ⅳ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅴ. Describe how to verify it

### VI. Special notes for reviews

The two cases differ by an order of magnitude, so quote the right one:

| Situation | Kubelet picks up the gate change in | Measured |
|-----------|-------------------------------------|----------|
| Gate transition on an already-settled Pod (Repro 2) | tens of milliseconds | 17 ms, 36 ms |
| A newly created Pod reaching `Ready` for the first time (Repro 1) | about one second | 992 ms, 981 ms |

The ~1 s case is worth knowing about: it is what a rolling update or a scale-up pays per Pod. It
looks like kubelet's regular sync cadence rather than the RECONCILE path, because a Pod that is
still starting up has a busy pod worker. Pods come up in parallel, so the wall-clock cost of a
scale-up is roughly one second total; a strictly serial recreate rollout pays it once per group.

| | before | after |
|---|---|---|
| Controller writes | gate + `Ready` | gate only |
| Kubelet's first reaction | none (it agrees with us) | writes the correct `Ready` |
| At the next 10s tick | stale value republished for 25-35 ms | nothing |
| Cost of the fix | — | 17-36 ms on a settled Pod, ~1 s on a new one |

#### Two remaining callers that are *not* bugs

`UpdatePodReadyCondition` is still called from the in-place update paths:

- `pkg/inplace/pod/inplaceupdate/inplace_update.go`, in `updateCondition` when a gate is set False
  at the start of an update
- `pkg/reconciler/roleinstance/inplaceupdate/inplaceupdate.go`, in `updateInstanceReadyCondition`

Both are safe because each is immediately followed, in the same reconcile, by a write that
`podsDifferSemantically` **does** compare:

| Caller | Followed by | Effect on kubelet |
|--------|-------------|-------------------|
| `inplace_update.go` `Update()` | `updatePodInPlace` patches the Pod **spec** (container image) | spec change → `needUpdate` → `HandlePodUpdates` → full pod sync → cache refreshed |
| `inplaceupdate.go` `onlyUpdateRevision` | sets `controller-revision-hash` **label** + `UpdatePod` | label change → same |

The rule is therefore: **writing `Ready` is only harmful when it is the sole effect of the
reconcile.** A pure status write leaves kubelet's cache stale; a status write accompanied by a
spec or label change forces kubelet to re-sync and refresh it.

## Checklist

- [x] Format your code `make fmt`.
- [x] Add unit tests or integration tests.
- [x] Update the documentation related to the change.
